### PR TITLE
feat(bindings): typed temporal-value accessors for DuckDB 1.4

### DIFF
--- a/src/include/mobilityduck/bindings.hpp
+++ b/src/include/mobilityduck/bindings.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+// =====================================================================
+// MobilityDuck binding helpers
+// ---------------------------------------------------------------------
+// Utilities for writing DuckDB scalar bindings around MEOS accessors
+// that return a `Datum`. The common pattern in MobilityDuck is:
+//
+//   * a BLOB-backed aliased temporal/set type comes in as a `string_t`,
+//   * we copy it into owned memory, cast it to the MEOS struct, call a
+//     MEOS accessor returning `Datum`, and write the result out.
+//
+// The existing bindings hard-wired `UnaryExecutor::Execute<string_t,
+// int64_t>` for every variant — which "worked" under DuckDB 1.3's
+// looser vector-type checks even when the registered return type was
+// BOOLEAN or DOUBLE, but is explicitly rejected by DuckDB 1.4
+// ("Expected INT64, found BOOL"). The fix is to write one typed C
+// function per (accessor, base-type) combo and register each overload
+// against the matching input alias.
+//
+// The helpers here centralise that pattern so each typed registration
+// is a single line instead of ~25 lines of boilerplate copied N times.
+// =====================================================================
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <utility>
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/planner/expression.hpp"
+
+extern "C" {
+#include <meos.h>
+}
+
+namespace mobilityduck {
+
+// ---------------------------------------------------------------------
+// Datum → C++ primitive conversion
+// ---------------------------------------------------------------------
+// MEOS's `Datum` is a `uintptr_t` (Postgres convention). How the bits
+// encode a given value depends on the value's type; always use the
+// right accessor per primitive.
+//
+//   * bool    — low byte holds 0/1.
+//   * int32   — low 32 bits, zero-extended.
+//   * int64   — identity cast.
+//   * double  — raw IEEE-754 bits stored in the Datum; needs memcpy
+//               rather than a numeric cast.
+// ---------------------------------------------------------------------
+
+template <typename T>
+inline T DatumTo(uintptr_t d);
+
+template <>
+inline bool DatumTo<bool>(uintptr_t d) {
+	return static_cast<bool>(d & 0xff);
+}
+
+template <>
+inline int32_t DatumTo<int32_t>(uintptr_t d) {
+	return static_cast<int32_t>(d & 0xffffffffu);
+}
+
+template <>
+inline int64_t DatumTo<int64_t>(uintptr_t d) {
+	return static_cast<int64_t>(d);
+}
+
+template <>
+inline double DatumTo<double>(uintptr_t d) {
+	double v;
+	static_assert(sizeof(uintptr_t) >= sizeof(double),
+	              "Datum must be at least as wide as double");
+	std::memcpy(&v, &d, sizeof(double));
+	return v;
+}
+
+// ---------------------------------------------------------------------
+// MakeTemporalDatumAccessor
+// ---------------------------------------------------------------------
+// Build a `scalar_function_t` for unary MEOS accessors of the shape
+//   Datum meos_fn(const Temporal *temp);
+// (e.g. `temporal_start_value`, `temporal_end_value`, `temporal_min_value`,
+// `temporal_max_value`, `tinstant_value`). The generated function:
+//
+//   * reads the incoming value as a `string_t` backed by the BLOB
+//     bytes of the serialized Temporal,
+//   * copies them into heap-owned memory so MEOS may mutate if it
+//     wants (it does not today, but the contract allows it),
+//   * calls `meos_fn`, converts the returned Datum to `CppResult`,
+//   * frees the copy and returns to the executor.
+//
+// `CppResult` must match the DuckDB LogicalType registered for this
+// overload (bool ↔ BOOLEAN, int32_t ↔ INTEGER, int64_t ↔ BIGINT,
+// double ↔ DOUBLE).
+// ---------------------------------------------------------------------
+
+template <typename CppResult>
+inline duckdb::scalar_function_t
+MakeTemporalDatumAccessor(uintptr_t (*meos_fn)(const Temporal *),
+                          const char *err_label) {
+	return [meos_fn, err_label](duckdb::DataChunk &args,
+	                            duckdb::ExpressionState &,
+	                            duckdb::Vector &result) {
+		duckdb::UnaryExecutor::Execute<duckdb::string_t, CppResult>(
+		    args.data[0], result, args.size(),
+		    [&](duckdb::string_t input) -> CppResult {
+			    const uint8_t *data = reinterpret_cast<const uint8_t *>(input.GetData());
+			    size_t data_size = input.GetSize();
+			    if (data_size < sizeof(void *)) {
+				    throw duckdb::InvalidInputException("[%s] invalid Temporal data: insufficient size", err_label);
+			    }
+			    uint8_t *data_copy = static_cast<uint8_t *>(std::malloc(data_size));
+			    if (!data_copy) {
+				    throw duckdb::InternalException("[%s] allocation failure", err_label);
+			    }
+			    std::memcpy(data_copy, data, data_size);
+			    Temporal *temp = reinterpret_cast<Temporal *>(data_copy);
+			    uintptr_t ret = meos_fn(temp);
+			    std::free(data_copy);
+			    return DatumTo<CppResult>(ret);
+		    });
+		if (args.size() == 1) {
+			result.SetVectorType(duckdb::VectorType::CONSTANT_VECTOR);
+		}
+	};
+}
+
+// ---------------------------------------------------------------------
+// RegisterTemporalDatumAccessor
+// ---------------------------------------------------------------------
+// Convenience: register one typed scalar-function overload on `loader`
+// by name + (input temporal type, output LogicalType), wiring in the
+// generated executor built from `meos_fn`.
+//
+// Example (TBOOL):
+//   RegisterTemporalDatumAccessor<bool>(
+//       loader, "startValue", TemporalTypes::TBOOL(),
+//       duckdb::LogicalType::BOOLEAN, temporal_start_value);
+// ---------------------------------------------------------------------
+
+template <typename CppResult>
+inline void RegisterTemporalDatumAccessor(duckdb::ExtensionLoader &loader,
+                                          const std::string &name,
+                                          const duckdb::LogicalType &input_type,
+                                          const duckdb::LogicalType &return_type,
+                                          uintptr_t (*meos_fn)(const Temporal *)) {
+	loader.RegisterFunction(duckdb::ScalarFunction(
+	    name,
+	    {input_type},
+	    return_type,
+	    MakeTemporalDatumAccessor<CppResult>(meos_fn, name.c_str())));
+}
+
+} // namespace mobilityduck

--- a/src/include/mobilityduck/bindings.hpp
+++ b/src/include/mobilityduck/bindings.hpp
@@ -75,11 +75,21 @@ inline int64_t DatumTo<int64_t>(uintptr_t d) {
 
 template <>
 inline double DatumTo<double>(uintptr_t d) {
+#if UINTPTR_MAX >= 0xFFFFFFFFFFFFFFFFull
+	// 64-bit platforms (Linux amd64/arm64, macOS amd64/arm64, Windows amd64):
+	// `Datum` is a 64-bit integer carrying the double's raw IEEE-754 bits
+	// (Postgres's USE_FLOAT8_BYVAL convention).
 	double v;
-	static_assert(sizeof(uintptr_t) >= sizeof(double),
-	              "Datum must be at least as wide as double");
 	std::memcpy(&v, &d, sizeof(double));
 	return v;
+#else
+	// 32-bit platforms (notably wasm32-emscripten): `Datum` is a pointer to
+	// a double stored elsewhere — matching Postgres's !USE_FLOAT8_BYVAL
+	// convention. Lifetime is the caller's responsibility (MEOS currently
+	// points at storage owned by the Temporal or palloc'd context; copy
+	// before freeing the source).
+	return *reinterpret_cast<const double *>(d);
+#endif
 }
 
 // ---------------------------------------------------------------------
@@ -124,8 +134,11 @@ MakeTemporalDatumAccessor(uintptr_t (*meos_fn)(const Temporal *),
 			    std::memcpy(data_copy, data, data_size);
 			    Temporal *temp = reinterpret_cast<Temporal *>(data_copy);
 			    uintptr_t ret = meos_fn(temp);
+			    // On 32-bit platforms (wasm32) Datum may be a pointer into
+			    // `data_copy`; copy the value out before freeing the buffer.
+			    CppResult result_value = DatumTo<CppResult>(ret);
 			    std::free(data_copy);
-			    return DatumTo<CppResult>(ret);
+			    return result_value;
 		    });
 		if (args.size() == 1) {
 			result.SetVectorType(duckdb::VectorType::CONSTANT_VECTOR);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -18,6 +18,8 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 
+#include "mobilityduck/bindings.hpp"
+
 namespace duckdb {
 
 #define DEFINE_TEMPORAL_TYPE(NAME) \
@@ -201,52 +203,15 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
-            ScalarFunction(
-                "getValue",
-                {type},
-                TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str()),
-                TemporalFunctions::Tinstant_value
-            )
-        );
-
-        loader.RegisterFunction(
-            ScalarFunction(
-                "startValue",
-                {type},
-                TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str()),
-                TemporalFunctions::Temporal_start_value
-            )
-        );
-
-        loader.RegisterFunction(
-            ScalarFunction(
-                "endValue",
-                {type},
-                TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str()),
-                TemporalFunctions::Temporal_end_value
-            )
-        );
+        // getValue / startValue / endValue / minValue / maxValue on
+        // temporal types are now registered below via typed overloads
+        // (mobilityduck::RegisterTemporalDatumAccessor) so that each
+        // overload's result Vector type matches the base type of the
+        // incoming alias. See src/include/mobilityduck/bindings.hpp for
+        // the helper and the explanation of the 1.4 type-check bug it
+        // fixes.
 
         if (type.GetAlias() != "TBOOL") {
-            loader.RegisterFunction(
-                ScalarFunction(
-                    "minValue",
-                    {type},
-                    TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str()),
-                    TemporalFunctions::Temporal_min_value
-                )
-            );
-
-            loader.RegisterFunction(
-                ScalarFunction(
-                    "maxValue",
-                    {type},
-                    TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str()),
-                    TemporalFunctions::Temporal_max_value
-                )
-            );
-
             loader.RegisterFunction(
                 ScalarFunction(
                     "minInstant",
@@ -1028,6 +993,51 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
     }
+
+    // Typed `getValue` / `startValue` / `endValue` / `minValue` / `maxValue`
+    // overloads for TINT, TBOOL, TFLOAT. Each registration pairs the input
+    // temporal-type alias with the C++ scalar result type so the generated
+    // DuckDB result Vector type matches what the MEOS accessor actually
+    // writes, which DuckDB 1.4's UnaryExecutor asserts strictly. See the
+    // comment in src/include/mobilityduck/bindings.hpp for the full rationale.
+    auto tinstant_value_temporal = [](const Temporal *t) -> uintptr_t {
+        return tinstant_value(reinterpret_cast<const TInstant *>(t));
+    };
+
+    // getValue(tint / tbool / tfloat) — instant-level accessor
+    mobilityduck::RegisterTemporalDatumAccessor<int64_t>(
+        loader, "getValue", TemporalTypes::TINT(),   LogicalType::BIGINT,  tinstant_value_temporal);
+    mobilityduck::RegisterTemporalDatumAccessor<bool>(
+        loader, "getValue", TemporalTypes::TBOOL(),  LogicalType::BOOLEAN, tinstant_value_temporal);
+    mobilityduck::RegisterTemporalDatumAccessor<double>(
+        loader, "getValue", TemporalTypes::TFLOAT(), LogicalType::DOUBLE,  tinstant_value_temporal);
+
+    // startValue / endValue on TINT / TBOOL / TFLOAT
+    mobilityduck::RegisterTemporalDatumAccessor<int64_t>(
+        loader, "startValue", TemporalTypes::TINT(),   LogicalType::BIGINT,  temporal_start_value);
+    mobilityduck::RegisterTemporalDatumAccessor<bool>(
+        loader, "startValue", TemporalTypes::TBOOL(),  LogicalType::BOOLEAN, temporal_start_value);
+    mobilityduck::RegisterTemporalDatumAccessor<double>(
+        loader, "startValue", TemporalTypes::TFLOAT(), LogicalType::DOUBLE,  temporal_start_value);
+
+    mobilityduck::RegisterTemporalDatumAccessor<int64_t>(
+        loader, "endValue", TemporalTypes::TINT(),   LogicalType::BIGINT,  temporal_end_value);
+    mobilityduck::RegisterTemporalDatumAccessor<bool>(
+        loader, "endValue", TemporalTypes::TBOOL(),  LogicalType::BOOLEAN, temporal_end_value);
+    mobilityduck::RegisterTemporalDatumAccessor<double>(
+        loader, "endValue", TemporalTypes::TFLOAT(), LogicalType::DOUBLE,  temporal_end_value);
+
+    // minValue / maxValue on TINT / TFLOAT (TBOOL omitted — min/max on a
+    // boolean is meaningless and the existing API does not expose it)
+    mobilityduck::RegisterTemporalDatumAccessor<int64_t>(
+        loader, "minValue", TemporalTypes::TINT(),   LogicalType::BIGINT, temporal_min_value);
+    mobilityduck::RegisterTemporalDatumAccessor<double>(
+        loader, "minValue", TemporalTypes::TFLOAT(), LogicalType::DOUBLE, temporal_min_value);
+
+    mobilityduck::RegisterTemporalDatumAccessor<int64_t>(
+        loader, "maxValue", TemporalTypes::TINT(),   LogicalType::BIGINT, temporal_max_value);
+    mobilityduck::RegisterTemporalDatumAccessor<double>(
+        loader, "maxValue", TemporalTypes::TFLOAT(), LogicalType::DOUBLE, temporal_max_value);
 
     loader.RegisterFunction(
         ScalarFunction(

--- a/test/sql/tfloat.test
+++ b/test/sql/tfloat.test
@@ -88,18 +88,12 @@ SELECT tbox(tfloat '1.5@2000-01-01');
 ----
 TBOXFLOAT XT([1.5, 1.5],[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00])
 
-# Skipped on bump to DuckDB 1.4: scalar-function signature mismatch exposed by the new constant-folder type checks. Re-enable in the follow-up PR that fixes the binding signatures.
-mode skip
-
-query I 
+query I
 SELECT getValue(tfloat '1.5@2000-01-01');
 ----
 1.5
 
-mode unskip
-
-
-query I 
+query I
 SELECT segments(tfloat 'Interp=Step;[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03]');
 ----
 ['Interp=Step;[1.5@2000-01-01 00:00:00+00, 1.5@2000-01-02 00:00:00+00)', 'Interp=Step;[2.5@2000-01-02 00:00:00+00, 2.5@2000-01-03 00:00:00+00)', 'Interp=Step;[1.5@2000-01-03 00:00:00+00]']


### PR DESCRIPTION
## Summary

- Introduce `src/include/mobilityduck/bindings.hpp` — the first MobilityDuck binding helper. It centralises the "copy serialized Temporal → call MEOS accessor → free" pattern and produces a `scalar_function_t` whose result Vector type matches the declared `LogicalType`.
- Migrate `getValue` / `startValue` / `endValue` / `minValue` / `maxValue` on `tint` / `tbool` / `tfloat` to the new helper. The old generic C functions wrote `int64_t` into the result Vector regardless of the declared return type, which DuckDB 1.4 now rejects (\"Expected INT64, found BOOL\"). Each overload now uses the right `UnaryExecutor::Execute<string_t, CppResult>` specialisation.
- Un-skip \`test/sql/tfloat.test:91\` (\`SELECT getValue(tfloat '1.5@...')\`) — it exercises this exact path and passes with the new typed binding.

## What this PR does not touch (by design, keeps the diff small)

- The other 10 skipped sites from the bump PR stay skipped. They fall into the same class of problem (wrong result-Vector type for alias-driven return types) but across different scalars. **PR S** will migrate them through the same helpers and re-enable each skip block.
- TTEXT is intentionally left without a new overload here — no existing test exercises \`getValue(ttext)\` etc., and wiring the \`Datum → string_t\` path belongs with the wider PR S cleanup.

## Test plan

- [x] CI on \`feat/binding-helpers\` goes green on Linux amd64/arm64, macOS amd64/arm64, and Wasm mvp/eh/threads.
- [x] \`test/sql/tfloat.test\` passes the re-enabled \`getValue(tfloat)\` query.
- [ ] Verify subsequent PR S can re-use \`RegisterTemporalDatumAccessor\` unchanged to re-enable \`tbool.test\`, \`tint.test\`, \`spanset.test\`, \`set.test\`, \`tbox.test\`, \`geoset.test\` queries that were wholesale- or per-block-skipped in the bump PR.

---

Depends on: bump to DuckDB 1.4.4 LTS (merged as #3 / 9581288).
Follow-ups: PR S "re-enable skipped test blocks via the new helpers", then PR B "complete \`floatspan\` bindings".