### PR TITLE
fix(bindings): re-enable tests skipped on the DuckDB 1.4 bump (PR S)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -4,8 +4,14 @@
 name: Main Extension Distribution Pipeline
 on:
   pull_request:
+    # `main` for release-bound PRs, plus `feat/**` and `fix/**` so stacked
+    # PRs (each targeting the previous branch rather than `main`) trigger
+    # CI automatically — instead of needing a manual `workflow_dispatch`
+    # call from a reviewer or from a maintainer's local machine.
     branches:
       - main
+      - 'feat/**'
+      - 'fix/**'
     paths-ignore:
       - '**/README.md'
       - 'doc/**'

--- a/src/geo/geoset.cpp
+++ b/src/geo/geoset.cpp
@@ -425,7 +425,8 @@ void SpatialSetFunctions::Set_value_n(DataChunk &args, ExpressionState &state, V
     n.Flatten(args.size());
 
     auto input_data = FlatVector::GetData<string_t>(input);
-    auto n_data = FlatVector::GetData<int64_t>(n);
+    // `valueN` is registered with second argument LogicalType::INTEGER.
+    auto n_data = FlatVector::GetData<int32_t>(n);
     auto result_data = FlatVector::GetData<string_t>(result);
 
     for (idx_t i = 0; i < args.size(); i++) {

--- a/src/geo/geoset.cpp
+++ b/src/geo/geoset.cpp
@@ -393,7 +393,9 @@ void SpatialSetFunctions::Set_num_values(DataChunk &args, ExpressionState &state
     auto &input = args.data[0];
     input.Flatten(args.size());
     auto input_data = FlatVector::GetData<string_t>(input);
-    auto result_data = FlatVector::GetData<int64_t>(result);
+    // numValues is registered as returning INTEGER (INT32); DuckDB 1.4 asserts
+    // the result Vector's template type matches the declared type.
+    auto result_data = FlatVector::GetData<int32_t>(result);
 
     for (idx_t i = 0; i < args.size(); i++) {
         if (FlatVector::IsNull(input, i)) {

--- a/src/geo/tgeompoint.cpp
+++ b/src/geo/tgeompoint.cpp
@@ -398,7 +398,12 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(
         ScalarFunction(
             "valueN",
-            {TGEOMPOINT(), LogicalType::INTEGER},
+            // BIGINT to match the sibling `valueN(<other temporal>, BIGINT)`
+            // overload in temporal.cpp and the C function's int64_t template
+            // arg (BinaryExecutor<string_t,int64_t,string_t>). Registering
+            // INTEGER here made DuckDB 1.4 reject the bind with
+            // "Expected INT64, found INT32" (tgeompoint.test:482).
+            {TGEOMPOINT(), LogicalType::BIGINT},
             GeoTypes::GEOMETRY(),
             TemporalFunctions::Temporal_value_n
         )

--- a/src/temporal/set_functions.cpp
+++ b/src/temporal/set_functions.cpp
@@ -1201,7 +1201,10 @@ void SetFunctions::Floatset_degrees(DataChunk &args, ExpressionState &state, Vec
         }
 
         auto blob = FlatVector::GetData<string_t>(input_vec)[i];
-        int bools = has_bools ? FlatVector::GetData<int32_t>(*bools_vec_ptr)[i] : false;
+        // Registered in set.cpp as a BOOLEAN argument; DuckDB 1.4 asserts the
+        // Vector's template type matches the declared type, so reading this as
+        // `int32_t` triggered `Expected INT32, found BOOL` (set.test:227).
+        bool bools = has_bools ? FlatVector::GetData<bool>(*bools_vec_ptr)[i] : false;
 
         const uint8_t *data = (const uint8_t *)blob.GetData();
         size_t size = blob.GetSize();

--- a/src/temporal/spanset_functions.cpp
+++ b/src/temporal/spanset_functions.cpp
@@ -714,7 +714,9 @@ void SpansetFunctions::Numspanset_width(DataChunk &args, ExpressionState &state,
         }
 
         auto blob = FlatVector::GetData<string_t>(input_vec)[i];
-        int bools = has_bools ? FlatVector::GetData<int32_t>(*bools_vec_ptr)[i] : false;
+        // Second argument registered as BOOLEAN; read as bool, not int32_t
+        // (see set_functions.cpp:Floatset_degrees for the same pattern).
+        bool bools = has_bools ? FlatVector::GetData<bool>(*bools_vec_ptr)[i] : false;
 
         const uint8_t *data = (const uint8_t *)blob.GetData();
         size_t size = blob.GetSize();
@@ -753,7 +755,7 @@ void SpansetFunctions::Datespanset_duration(DataChunk &args, ExpressionState &st
         }
 
         auto blob = FlatVector::GetData<string_t>(input_vec)[i];
-        int bools = has_bools ? FlatVector::GetData<int32_t>(*bools_vec_ptr)[i] : false;
+        bool bools = has_bools ? FlatVector::GetData<bool>(*bools_vec_ptr)[i] : false;
 
         const uint8_t *data = (const uint8_t *)blob.GetData();
         size_t size = blob.GetSize();
@@ -782,7 +784,7 @@ void SpansetFunctions::Tstzspanset_duration(DataChunk &args, ExpressionState &st
         }
 
         auto blob = FlatVector::GetData<string_t>(input_vec)[i];
-        int bools = has_bools ? FlatVector::GetData<int32_t>(*bools_vec_ptr)[i] : false;
+        bool bools = has_bools ? FlatVector::GetData<bool>(*bools_vec_ptr)[i] : false;
 
         const uint8_t *data = (const uint8_t *)blob.GetData();
         size_t size = blob.GetSize();

--- a/src/temporal/spanset_functions.cpp
+++ b/src/temporal/spanset_functions.cpp
@@ -856,13 +856,15 @@ void SpansetFunctions::Spanset_span_n(DataChunk &args, ExpressionState &state, V
     auto &n = args.data[1];
     BinaryExecutor::Execute<string_t, int32_t, string_t>(
             input, n, result, args.size(),
-            [&](string_t blob, int32_t pos) -> string_t {                             
+            [&](string_t blob, int32_t pos) -> string_t {
             const uint8_t *data = (const uint8_t *)blob.GetData();
             size_t size = blob.GetSize();
             SpanSet *s = (SpanSet*)malloc(size);
-            memcpy(s, data, size);            
-            int64_t n_value = FlatVector::GetData<int64_t>(n)[0];
-            Span *span_n = spanset_span_n(s, n_value);  
+            memcpy(s, data, size);
+            // Use the int32_t `pos` the executor passes us; the previous
+            // `FlatVector::GetData<int64_t>(n)[0]` mis-typed the arg Vector
+            // and tripped DuckDB 1.4's "Expected INT64, found INT32" check.
+            Span *span_n = spanset_span_n(s, pos);
             free(s);
             string_t out = StringVector::AddStringOrBlob(result, (const char *)span_n, sizeof(Span));
             free(span_n);

--- a/src/temporal/spanset_functions.cpp
+++ b/src/temporal/spanset_functions.cpp
@@ -800,14 +800,15 @@ void SpansetFunctions::Tstzspanset_duration(DataChunk &args, ExpressionState &st
 // --- numSpans ---
 void SpansetFunctions::Spanset_num_spans(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &input = args.data[0];
-    UnaryExecutor::Execute<string_t, int64_t>(
+    // numSpans is registered as returning LogicalType::INTEGER.
+    UnaryExecutor::Execute<string_t, int32_t>(
         input, result, args.size(),
-        [&](string_t input_blob) -> int64_t {                                 
+        [&](string_t input_blob) -> int32_t {
             const uint8_t *data = (const uint8_t *)input_blob.GetData();
             size_t size = input_blob.GetSize();
             SpanSet *s = (SpanSet*)malloc(size);
-            memcpy(s, data, size);            
-            int64_t num_spans = spanset_num_spans(s);  
+            memcpy(s, data, size);
+            int32_t num_spans = spanset_num_spans(s);
             free(s);
             return num_spans;
         });
@@ -872,14 +873,15 @@ void SpansetFunctions::Spanset_span_n(DataChunk &args, ExpressionState &state, V
 // --- numDates ---
 void SpansetFunctions::Datespanset_num_dates(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &input = args.data[0];
-    UnaryExecutor::Execute<string_t, int64_t>(
+    // Registered as returning LogicalType::INTEGER.
+    UnaryExecutor::Execute<string_t, int32_t>(
         input, result, args.size(),
-        [&](string_t input_blob) -> int64_t {                                 
+        [&](string_t input_blob) -> int32_t {
             const uint8_t *data = (const uint8_t *)input_blob.GetData();
             size_t size = input_blob.GetSize();
             SpanSet *s = (SpanSet*)malloc(size);
-            memcpy(s, data, size);            
-            int64_t num_dates = datespanset_num_dates(s);  
+            memcpy(s, data, size);
+            int32_t num_dates = datespanset_num_dates(s);
             free(s);
             return num_dates;
         });
@@ -960,14 +962,15 @@ void SpansetFunctions::Datespanset_dates(DataChunk &args, ExpressionState &state
 // --- numTimestamps ---
 void SpansetFunctions::Tstzspanset_num_timestamps(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &input = args.data[0];
-    UnaryExecutor::Execute<string_t, int64_t>(
+    // Registered as returning LogicalType::INTEGER.
+    UnaryExecutor::Execute<string_t, int32_t>(
         input, result, args.size(),
-        [&](string_t input_blob) -> int64_t {                                 
+        [&](string_t input_blob) -> int32_t {
             const uint8_t *data = (const uint8_t *)input_blob.GetData();
             size_t size = input_blob.GetSize();
             SpanSet *s = (SpanSet*)malloc(size);
-            memcpy(s, data, size);            
-            int64_t num_timestamps = tstzspanset_num_timestamps(s);  
+            memcpy(s, data, size);
+            int32_t num_timestamps = tstzspanset_num_timestamps(s);
             free(s);
             return num_timestamps;
         });

--- a/test/sql/geoset.test
+++ b/test/sql/geoset.test
@@ -1,15 +1,3 @@
-# =====================================================================
-# Entire test file skipped on bump to DuckDB 1.4.
-# Reason: scalar-function signature mismatches exposed by the new
-# constant-folder type checks surface in many queries throughout this
-# file (not just a handful). Rather than wrap every affected query
-# individually in `mode skip`, the whole file is disabled until the
-# follow-up PR "fix scalar-function signatures for DuckDB 1.4 type
-# checking" re-registers the bindings with correct argument / return
-# types, at which point the `mode skip`/`mode unskip` wrapper below is
-# removed and the file runs as before.
-# =====================================================================
-mode skip
 
 require mobilityduck
 
@@ -64,5 +52,3 @@ query I
 SELECT asEWKT(transform(geomset 'SRID=4326;{Point(2.340088 49.400250), Point(6.575317 51.553167)}', 3812), 6);
 ----
 SRID=3812;{"POINT(502773.429981 511805.120402)", "POINT(803028.908265 751590.742629)"}
-
-mode unskip

--- a/test/sql/set.test
+++ b/test/sql/set.test
@@ -224,16 +224,10 @@ SELECT round(floatset '{0.12345, 1.12345, 2.12345}', 3);
 ----
 {0.123, 1.123, 2.123}
 
-# Skipped on bump to DuckDB 1.4: scalar-function signature mismatch exposed by the new constant-folder type checks. Re-enable in the follow-up PR that fixes the binding signatures.
-mode skip
-
-query I 
+query I
 SELECT degrees(floatset '{0, 0.5, 1}', true);
 ----
 {0, 28.64788975654116, 57.29577951308232}
-
-mode unskip
-
 
 query I
 SELECT radians(floatset '{0, 45, 90}');

--- a/test/sql/spanset.test
+++ b/test/sql/spanset.test
@@ -1,15 +1,3 @@
-# =====================================================================
-# Entire test file skipped on bump to DuckDB 1.4.
-# Reason: scalar-function signature mismatches exposed by the new
-# constant-folder type checks surface in many queries throughout this
-# file (not just a handful). Rather than wrap every affected query
-# individually in `mode skip`, the whole file is disabled until the
-# follow-up PR "fix scalar-function signatures for DuckDB 1.4 type
-# checking" re-registers the bindings with correct argument / return
-# types, at which point the `mode skip`/`mode unskip` wrapper below is
-# removed and the file runs as before.
-# =====================================================================
-mode skip
 
 require mobilityduck
 
@@ -525,5 +513,3 @@ query I
 SELECT floatspanset '{[1,1]}' >= floatspanset '{[1,2),[2,3),[3,4)}';
 ----
 false
-
-mode unskip

--- a/test/sql/tbool.test
+++ b/test/sql/tbool.test
@@ -1,15 +1,3 @@
-# =====================================================================
-# Entire test file skipped on bump to DuckDB 1.4.
-# Reason: scalar-function signature mismatches exposed by the new
-# constant-folder type checks surface in many queries throughout this
-# file (not just a handful). Rather than wrap every affected query
-# individually in `mode skip`, the whole file is disabled until the
-# follow-up PR "fix scalar-function signatures for DuckDB 1.4 type
-# checking" re-registers the bindings with correct argument / return
-# types, at which point the `mode skip`/`mode unskip` wrapper below is
-# removed and the file runs as before.
-# =====================================================================
-mode skip
 
 # name: test/sql/tbool.test
 # description: test tbool type of mobilityduck extension
@@ -186,5 +174,3 @@ query I
 SELECT tbool 't@2000-01-01' = tbool '{[t@2000-01-01, f@2000-01-02, t@2000-01-03],[t@2000-01-04, t@2000-01-05]}';
 ----
 false
-
-mode unskip

--- a/test/sql/tgeompoint.test
+++ b/test/sql/tgeompoint.test
@@ -479,15 +479,10 @@ SELECT numTimestamps(tgeompoint 'Point(1 1)@2000-01-01');
 ----
 1
 
-# Skipped on bump to DuckDB 1.4: scalar-function signature mismatch exposed by the new constant-folder type checks. Re-enable in the follow-up PR that fixes the binding signatures.
-mode skip
-
-query I 
+query I
 SELECT ST_AsText(valueN(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]', 1));
 ----
 POINT (1 1)
-
-mode unskip
 
 
 query I 


### PR DESCRIPTION
## Summary

Follow-up to **#4 (feat/binding-helpers)** — progressively re-enables the test blocks and files that were wrapped in \`mode skip\` during the bump PR. Each re-enable is paired with the signature fix that makes the query pass under DuckDB 1.4's strict vector-type checking. Starts small (tbool.test, which PR A's typed overloads already cover) and grows incrementally as CI reveals each next failure class.

**Stacked on \`feat/binding-helpers\` — please merge #4 first, then this.**

## First commit

\`test(tbool): remove wholesale skip after PR A fixes\` — PR A registered typed \`getValue\`/\`startValue\`/\`endValue\` overloads for TBOOL, which was the cause of every tbool.test failure on the bump. Un-wrapping the file.

## Planned follow-up commits (pushed incrementally as CI drives them)

- \`set.test:227\` — \`degrees(floatset, bool)\`: C function uses wrong BinaryExecutor template.
- \`tgeompoint.test:482\` — \`valueN(tgeompoint, 1)\`: second-arg INT32/INT64 drift.
- \`spanset.test\` (wholesale): \`width(..., bool)\` and similar.
- \`geoset.test\` (wholesale): \`numValues\` return-type drift.
- \`tbox.test\` (wholesale): several tbox constructor signatures.

Each CI round will narrow the remaining failures; I push one signature fix per visible failure class.

## Test plan

- [x] CI on \`fix/scalar-signatures-for-1.4\` (stacked on #4) green on Linux / macOS / Wasm.
- [ ] All 11 bump-PR skip wrappers removed.

---

Depends on: #4 (\`feat/binding-helpers\`). Blocks PR B (\`floatspan\` bindings) from re-using the helpers cleanly.