### PR TITLE
test(parity): first parity harness — port MobilityDB 001_set.test.sql

### DIFF
--- a/test/sql/parity/001_set.test
+++ b/test/sql/parity/001_set.test
@@ -28,6 +28,20 @@
 # this file reflects MobilityDuck's output — the parity is in the query
 # *surface*, not the display layer. Display-layer alignment, if desired,
 # is a separate follow-up.
+#
+# ----------------------------------------------------------------------------
+# Error-handler gap (affects every `statement error` block in this file)
+# ----------------------------------------------------------------------------
+# `src/mobilityduck_extension.cpp` calls `meos_initialize()` but not
+# `meos_initialize_error_handler(...)`. MEOS's default error handler
+# terminates the process on MEOS_ERROR instead of surfacing as a
+# DuckDB::InvalidInputException, which kills the whole test runner the
+# moment a parity query triggers a MEOS parse / validation error. As a
+# result, *every* `statement error` block in this file is wrapped in
+# `mode skip` with a cross-reference to this note. Follow-up PR:
+# install a MEOS error handler in LoadInternal() that maps MEOS_ERROR
+# to a thrown DuckDB exception — all the skip wrappers can be deleted
+# in one stroke once that lands.
 
 require mobilityduck
 
@@ -61,7 +75,15 @@ SELECT tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
 {"2000-01-01 00:00:00+00", "2000-01-02 00:00:00+00", "2000-01-03 00:00:00+00"}
 
 # --- parse errors ---
-
+mode skip
+# gap: MEOS error handler is not wired to DuckDB exceptions.
+# `mobilityduck_extension.cpp:143` calls `meos_initialize()` but not
+# `meos_initialize_error_handler(...)`, so MEOS errors hit the default
+# handler and terminate the process instead of surfacing as a
+# DuckDB::InvalidInputException. Every `statement error` in this file
+# currently kills the test runner before Catch2 can check it, so all
+# error-path assertions are skipped until a follow-up PR installs a
+# MEOS error handler that throws on MEOS_ERROR.
 statement error
 SELECT tstzset '2000-01-01, 2000-01-02';
 ----
@@ -71,6 +93,7 @@ statement error
 SELECT tstzset '{2000-01-01, 2000-01-02';
 ----
 Could not parse
+mode unskip
 
 # =============================================================================
 # Output in WKT format
@@ -82,10 +105,14 @@ SELECT asText(floatset '{1.12345678, 2.123456789}', 6);
 {1.123457, 2.123457}
 
 # --- negative digits should error ---
+mode skip
+# gap: MEOS error handler not wired — see top-of-file note. Skipping
+# until the follow-up PR that installs a MEOS error handler.
 statement error
 SELECT asText(floatset '{1.12345678, 2.123456789}', -6);
 ----
 cannot be negative
+mode unskip
 
 # =============================================================================
 # Constructors
@@ -112,10 +139,13 @@ SELECT set(ARRAY [timestamptz '2000-01-01', '2000-01-01', '2000-01-03']);
 {"2000-01-01 00:00:00+00", "2000-01-03 00:00:00+00"}
 
 # --- empty array should error ---
+mode skip
+# gap: MEOS error handler not wired — see top-of-file note.
 statement error
 SELECT set('{}'::timestamptz[]);
 ----
 cannot be empty
+mode unskip
 
 mode skip
 # gap: set(ARRAY[GEOMETRY ...]) geomset constructor is not registered in

--- a/test/sql/parity/001_set.test
+++ b/test/sql/parity/001_set.test
@@ -64,9 +64,13 @@ SELECT tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
 
 statement error
 SELECT tstzset '2000-01-01, 2000-01-02';
+----
+Could not parse
 
 statement error
 SELECT tstzset '{2000-01-01, 2000-01-02';
+----
+Could not parse
 
 # =============================================================================
 # Output in WKT format
@@ -80,6 +84,8 @@ SELECT asText(floatset '{1.12345678, 2.123456789}', 6);
 # --- negative digits should error ---
 statement error
 SELECT asText(floatset '{1.12345678, 2.123456789}', -6);
+----
+cannot be negative
 
 # =============================================================================
 # Constructors
@@ -108,6 +114,8 @@ SELECT set(ARRAY [timestamptz '2000-01-01', '2000-01-01', '2000-01-03']);
 # --- empty array should error ---
 statement error
 SELECT set('{}'::timestamptz[]);
+----
+cannot be empty
 
 mode skip
 # gap: set(ARRAY[GEOMETRY ...]) geomset constructor is not registered in
@@ -126,12 +134,18 @@ SELECT asText(set(ARRAY[geometry 'Point(1 1)', 'Linestring(1 1,2 2)']));
 
 statement error
 SELECT set(ARRAY[geometry 'Point(1 1)', 'Point(1 1 1)']);
+----
+mixed 2D/3D
 
 statement error
 SELECT set(ARRAY[geometry 'Point(1 1)', 'Point empty']);
+----
+non-empty
 
 statement error
 SELECT set(ARRAY[geometry 'Point(1 1)', 'SRID=5676;Point(1 1)']);
+----
+mixed SRID
 mode unskip
 
 # =============================================================================
@@ -255,6 +269,8 @@ SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 10);
 
 statement error
 SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', -1);
+----
+strictly positive
 
 query I
 SELECT splitEachNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
@@ -288,6 +304,8 @@ SELECT splitEachNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 6);
 
 statement error
 SELECT splitEachNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', -1);
+----
+strictly positive
 mode unskip
 
 query I

--- a/test/sql/parity/001_set.test
+++ b/test/sql/parity/001_set.test
@@ -1,0 +1,669 @@
+# name: test/sql/parity/001_set.test
+# description: Parity harness — MobilityDB regression file 001_set.test.sql mirrored for MobilityDuck
+# group: [sql]
+#
+# ----------------------------------------------------------------------------
+# Goal
+# ----------------------------------------------------------------------------
+# The long-term objective is that the same SQL query can be run against
+# MobilityDB (PostgreSQL extension, historical store) and MobilityDuck
+# (DuckDB extension, pipeline side) and produce comparable results. This
+# file is the first parity harness that makes the gap measurable.
+#
+# Queries are ported verbatim from the upstream regression file
+# `mobilitydb/test/temporal/queries/001_set.test.sql`. Each query that runs
+# on MobilityDuck today is an active assertion; each that hits an unbound
+# MEOS symbol, a naming divergence, or an output-format divergence is
+# wrapped in `mode skip` with a `# gap:` annotation that names the
+# specific missing binding or divergence. Every skip is a tracked backlog
+# item for a follow-up PR.
+#
+# ----------------------------------------------------------------------------
+# Output-format note
+# ----------------------------------------------------------------------------
+# MobilityDB emits PG-locale output (e.g. `01-01-2000` dates, `Sat Jan 01
+# 00:00:00 2000 PST` timestamps). MobilityDuck emits DuckDB-shaped output
+# (ISO dates, UTC timestamps under TZ=UTC, which the Makefile sets
+# explicitly). Where a query passes on both sides, the expected block in
+# this file reflects MobilityDuck's output — the parity is in the query
+# *surface*, not the display layer. Display-layer alignment, if desired,
+# is a separate follow-up.
+
+require mobilityduck
+
+# =============================================================================
+# I/O
+# =============================================================================
+
+query I
+SELECT intset '{1,2,3}';
+----
+{1, 2, 3}
+
+query I
+SELECT bigintset '{1,2,3}';
+----
+{1, 2, 3}
+
+query I
+SELECT floatset '{1.5,2.5,3.5}';
+----
+{1.5, 2.5, 3.5}
+
+query I
+SELECT dateset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+{2000-01-01, 2000-01-02, 2000-01-03}
+
+query I
+SELECT tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+{"2000-01-01 00:00:00+00", "2000-01-02 00:00:00+00", "2000-01-03 00:00:00+00"}
+
+# --- parse errors ---
+
+statement error
+SELECT tstzset '2000-01-01, 2000-01-02';
+
+statement error
+SELECT tstzset '{2000-01-01, 2000-01-02';
+
+# =============================================================================
+# Output in WKT format
+# =============================================================================
+
+query I
+SELECT asText(floatset '{1.12345678, 2.123456789}', 6);
+----
+{1.123457, 2.123457}
+
+# --- negative digits should error ---
+statement error
+SELECT asText(floatset '{1.12345678, 2.123456789}', -6);
+
+# =============================================================================
+# Constructors
+# =============================================================================
+
+query I
+SELECT set(ARRAY [date '2000-01-01', '2000-01-02', '2000-01-03']);
+----
+{2000-01-01, 2000-01-02, 2000-01-03}
+
+query I
+SELECT set(ARRAY [date '2000-01-01', '2000-01-01', '2000-01-03']);
+----
+{2000-01-01, 2000-01-03}
+
+query I
+SELECT set(ARRAY [timestamptz '2000-01-01', '2000-01-02', '2000-01-03']);
+----
+{"2000-01-01 00:00:00+00", "2000-01-02 00:00:00+00", "2000-01-03 00:00:00+00"}
+
+query I
+SELECT set(ARRAY [timestamptz '2000-01-01', '2000-01-01', '2000-01-03']);
+----
+{"2000-01-01 00:00:00+00", "2000-01-03 00:00:00+00"}
+
+# --- empty array should error ---
+statement error
+SELECT set('{}'::timestamptz[]);
+
+mode skip
+# gap: set(ARRAY[GEOMETRY ...]) geomset constructor is not registered in
+# src/geo/geoset.cpp (only I/O / asText / memSize / SRID / transform /
+# accessors are). MEOS symbol: geomset_make. Track: follow-up PR to
+# register ScalarFunction("set", {LIST(GEOMETRY)}, geomset(), ...).
+query I
+SELECT asText(set(ARRAY[geometry 'Point(1 1)', 'Point(2 2)', 'Point(3 3)']));
+----
+{"POINT(1 1)", "POINT(2 2)", "POINT(3 3)"}
+
+query I
+SELECT asText(set(ARRAY[geometry 'Point(1 1)', 'Linestring(1 1,2 2)']));
+----
+{"POINT(1 1)", "LINESTRING(1 1,2 2)"}
+
+statement error
+SELECT set(ARRAY[geometry 'Point(1 1)', 'Point(1 1 1)']);
+
+statement error
+SELECT set(ARRAY[geometry 'Point(1 1)', 'Point empty']);
+
+statement error
+SELECT set(ARRAY[geometry 'Point(1 1)', 'SRID=5676;Point(1 1)']);
+mode unskip
+
+# =============================================================================
+# Conversion functions
+# =============================================================================
+
+query I
+SELECT set(date '2000-01-01');
+----
+{2000-01-01}
+
+query I
+SELECT date '2000-01-01'::dateset;
+----
+{2000-01-01}
+
+query I
+SELECT set(timestamptz '2000-01-01');
+----
+{"2000-01-01 00:00:00+00"}
+
+query I
+SELECT timestamptz '2000-01-01'::tstzset;
+----
+{"2000-01-01 00:00:00+00"}
+
+# =============================================================================
+# Accessors
+# =============================================================================
+
+query I
+SELECT memSize(dateset '{2000-01-01}');
+----
+32
+
+query I
+SELECT memSize(dateset '{2000-01-01, 2000-01-02, 2000-01-03}');
+----
+48
+
+query I
+SELECT memSize(tstzset '{2000-01-01}');
+----
+32
+
+query I
+SELECT memSize(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}');
+----
+48
+
+query I
+SELECT span(dateset '{2000-01-01}');
+----
+[2000-01-01, 2000-01-02)
+
+query I
+SELECT span(dateset '{2000-01-01, 2000-01-02, 2000-01-03}');
+----
+[2000-01-01, 2000-01-04)
+
+query I
+SELECT span(tstzset '{2000-01-01}');
+----
+[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00]
+
+query I
+SELECT span(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}');
+----
+[2000-01-01 00:00:00+00, 2000-01-03 00:00:00+00]
+
+mode skip
+# gap: `spans(<set_type>)` — returns a list of unit spans. MobilityDuck
+# only registers `spans(<spanset_type>)` (src/temporal/spanset.cpp:330);
+# the set-level version is not bound. MEOS symbol: set_spans.
+query I
+SELECT spans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}');
+----
+{"[1, 2)","[2, 3)","[3, 4)","[4, 5)","[5, 6)","[6, 7)","[7, 8)","[8, 9)","[9, 10)","[10, 11)"}
+mode unskip
+
+mode skip
+# gap: naming divergence — MobilityDB SQL uses `splitNspans` /
+# `splitEachNspans` (lowercase "spans"), MobilityDuck registers
+# `splitNSpans` / `splitEachNSpans` (camelCase, capital S) in
+# src/temporal/span.cpp:313-340. Follow-up: add lowercase aliases in
+# span.cpp registration for parity.
+query I
+SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
+----
+{"[1, 11)"}
+
+query I
+SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 2);
+----
+{"[1, 6)","[6, 11)"}
+
+query I
+SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 3);
+----
+{"[1, 5)","[5, 8)","[8, 11)"}
+
+query I
+SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 4);
+----
+{"[1, 4)","[4, 7)","[7, 9)","[9, 11)"}
+
+query I
+SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 5);
+----
+{"[1, 3)","[3, 5)","[5, 7)","[7, 9)","[9, 11)"}
+
+query I
+SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 6);
+----
+{"[1, 3)","[3, 5)","[5, 7)","[7, 9)","[9, 10)","[10, 11)"}
+
+query I
+SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 10);
+----
+{"[1, 2)","[2, 3)","[3, 4)","[4, 5)","[5, 6)","[6, 7)","[7, 8)","[8, 9)","[9, 10)","[10, 11)"}
+
+statement error
+SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', -1);
+
+query I
+SELECT splitEachNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
+----
+{"[1, 2)","[2, 3)","[3, 4)","[4, 5)","[5, 6)","[6, 7)","[7, 8)","[8, 9)","[9, 10)","[10, 11)"}
+
+query I
+SELECT splitEachNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 2);
+----
+{"[1, 3)","[3, 5)","[5, 7)","[7, 9)","[9, 11)"}
+
+query I
+SELECT splitEachNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 3);
+----
+{"[1, 4)","[4, 7)","[7, 10)","[10, 11)"}
+
+query I
+SELECT splitEachNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 4);
+----
+{"[1, 5)","[5, 9)","[9, 11)"}
+
+query I
+SELECT splitEachNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 5);
+----
+{"[1, 6)","[6, 11)"}
+
+query I
+SELECT splitEachNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 6);
+----
+{"[1, 7)","[7, 11)"}
+
+statement error
+SELECT splitEachNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', -1);
+mode unskip
+
+query I
+SELECT numValues(dateset '{2000-01-01}');
+----
+1
+
+query I
+SELECT numValues(dateset '{2000-01-01, 2000-01-02, 2000-01-03}');
+----
+3
+
+query I
+SELECT numValues(tstzset '{2000-01-01}');
+----
+1
+
+query I
+SELECT numValues(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}');
+----
+3
+
+query I
+SELECT startValue(dateset '{2000-01-01}');
+----
+2000-01-01
+
+query I
+SELECT startValue(dateset '{2000-01-01, 2000-01-02, 2000-01-03}');
+----
+2000-01-01
+
+query I
+SELECT startValue(tstzset '{2000-01-01}');
+----
+2000-01-01 00:00:00+00
+
+query I
+SELECT startValue(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}');
+----
+2000-01-01 00:00:00+00
+
+query I
+SELECT endValue(dateset '{2000-01-01}');
+----
+2000-01-01
+
+query I
+SELECT endValue(dateset '{2000-01-01, 2000-01-02, 2000-01-03}');
+----
+2000-01-03
+
+query I
+SELECT endValue(tstzset '{2000-01-01}');
+----
+2000-01-01 00:00:00+00
+
+query I
+SELECT endValue(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}');
+----
+2000-01-03 00:00:00+00
+
+query I
+SELECT valueN(dateset '{2000-01-01}', 1);
+----
+2000-01-01
+
+query I
+SELECT valueN(dateset '{2000-01-01, 2000-01-02, 2000-01-03}', 1);
+----
+2000-01-01
+
+query I
+SELECT valueN(dateset '{2000-01-01}', 2);
+----
+NULL
+
+query I
+SELECT valueN(dateset '{2000-01-01, 2000-01-02, 2000-01-03}', 4);
+----
+NULL
+
+query I
+SELECT valueN(tstzset '{2000-01-01}', 1);
+----
+2000-01-01 00:00:00+00
+
+query I
+SELECT valueN(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}', 1);
+----
+2000-01-01 00:00:00+00
+
+query I
+SELECT valueN(tstzset '{2000-01-01}', 2);
+----
+NULL
+
+query I
+SELECT valueN(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}', 4);
+----
+NULL
+
+query I
+SELECT getValues(dateset '{2000-01-01}');
+----
+[2000-01-01]
+
+query I
+SELECT getValues(dateset '{2000-01-01, 2000-01-02, 2000-01-03}');
+----
+[2000-01-01, 2000-01-02, 2000-01-03]
+
+query I
+SELECT getValues(tstzset '{2000-01-01}');
+----
+['2000-01-01 00:00:00+00']
+
+query I
+SELECT getValues(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}');
+----
+['2000-01-01 00:00:00+00', '2000-01-02 00:00:00+00', '2000-01-03 00:00:00+00']
+
+# =============================================================================
+# Comparison
+# =============================================================================
+
+query I
+SELECT set_cmp(dateset '{2000-01-01}', dateset '{2000-01-01, 2000-01-02, 2000-01-03}') = -1;
+----
+true
+
+query I
+SELECT dateset '{2000-01-01}' = dateset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+false
+
+query I
+SELECT dateset '{2000-01-01}' <> dateset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+true
+
+query I
+SELECT dateset '{2000-01-01}' < dateset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+true
+
+query I
+SELECT dateset '{2000-01-01, 2000-01-02, 2000-01-03}' < dateset '{2000-01-01}';
+----
+false
+
+query I
+SELECT dateset '{2000-01-01}' <= dateset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+true
+
+query I
+SELECT dateset '{2000-01-01}' > dateset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+false
+
+query I
+SELECT dateset '{2000-01-01}' >= dateset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+false
+
+query I
+SELECT set_cmp(tstzset '{2000-01-01}', tstzset '{2000-01-01, 2000-01-02, 2000-01-03}') = -1;
+----
+true
+
+query I
+SELECT tstzset '{2000-01-01}' = tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+false
+
+query I
+SELECT tstzset '{2000-01-01}' <> tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+true
+
+query I
+SELECT tstzset '{2000-01-01}' < tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+true
+
+query I
+SELECT tstzset '{2000-01-01, 2000-01-02, 2000-01-03}' < tstzset '{2000-01-01}';
+----
+false
+
+query I
+SELECT tstzset '{2000-01-01}' <= tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+true
+
+query I
+SELECT tstzset '{2000-01-01}' > tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+false
+
+query I
+SELECT tstzset '{2000-01-01}' >= tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
+----
+false
+
+mode skip
+# gap: `set_hash` / `set_hash_extended` are not registered in
+# src/temporal/set.cpp. MEOS symbols: set_hash, set_hash_extended.
+# Follow-up: add ScalarFunction bindings returning BIGINT/UBIGINT.
+query I
+SELECT set_hash(dateset '{2000-01-01,2000-01-02}') = set_hash(dateset '{2000-01-01,2000-01-02}');
+----
+true
+
+query I
+SELECT set_hash(dateset '{2000-01-01,2000-01-02}') <> set_hash(dateset '{2000-01-01,2000-01-02}');
+----
+false
+
+query I
+SELECT set_hash(tstzset '{2000-01-01,2000-01-02}') = set_hash(tstzset '{2000-01-01,2000-01-02}');
+----
+true
+
+query I
+SELECT set_hash(tstzset '{2000-01-01,2000-01-02}') <> set_hash(tstzset '{2000-01-01,2000-01-02}');
+----
+false
+
+query I
+SELECT set_hash_extended(dateset '{2000-01-01,2000-01-02}', 1) = set_hash_extended(dateset '{2000-01-01,2000-01-02}', 1);
+----
+true
+
+query I
+SELECT set_hash_extended(dateset '{2000-01-01,2000-01-02}', 1) <> set_hash_extended(dateset '{2000-01-01,2000-01-02}', 1);
+----
+false
+
+query I
+SELECT set_hash_extended(tstzset '{2000-01-01,2000-01-02}', 1) = set_hash_extended(tstzset '{2000-01-01,2000-01-02}', 1);
+----
+true
+
+query I
+SELECT set_hash_extended(tstzset '{2000-01-01,2000-01-02}', 1) <> set_hash_extended(tstzset '{2000-01-01,2000-01-02}', 1);
+----
+false
+mode unskip
+
+# =============================================================================
+# Transformations
+# =============================================================================
+
+query I
+SELECT shift(intset '{1}', 4);
+----
+{5}
+
+query I
+SELECT shift(dateset '{2000-01-01, 2000-01-02, 2000-01-03}', 4);
+----
+{2000-01-05, 2000-01-06, 2000-01-07}
+
+query I
+SELECT shift(tstzset '{2000-01-01}', '5 min');
+----
+{"2000-01-01 00:05:00+00"}
+
+query I
+SELECT shift(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}', '5 min');
+----
+{"2000-01-01 00:05:00+00", "2000-01-02 00:05:00+00", "2000-01-03 00:05:00+00"}
+
+query I
+SELECT scale(intset '{1}', 4);
+----
+{1}
+
+query I
+SELECT scale(dateset '{2000-01-01, 2000-01-02, 2000-01-03}', 4);
+----
+{2000-01-01, 2000-01-03, 2000-01-06}
+
+query I
+SELECT scale(tstzset '{2000-01-01}', '1 hour');
+----
+{"2000-01-01 00:00:00+00"}
+
+query I
+SELECT scale(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}', '1 hour');
+----
+{"2000-01-01 00:00:00+00", "2000-01-01 00:30:00+00", "2000-01-01 01:00:00+00"}
+
+query I
+SELECT shiftScale(intset '{1}', 4, 4);
+----
+{5}
+
+query I
+SELECT shiftScale(dateset '{2000-01-01, 2000-01-02, 2000-01-03}', 4, 4);
+----
+{2000-01-05, 2000-01-07, 2000-01-10}
+
+query I
+SELECT shiftScale(tstzset '{2000-01-01}', '1 day', '1 hour');
+----
+{"2000-01-02 00:00:00+00"}
+
+query I
+SELECT shiftScale(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}', '1 day', '1 hour');
+----
+{"2000-01-02 00:00:00+00", "2000-01-02 00:30:00+00", "2000-01-02 01:00:00+00"}
+
+query I
+SELECT floor(floatset '{0.5, 1.5, 2.5}');
+----
+{0, 1, 2}
+
+query I
+SELECT floor(floatset '{0.5, 1.5, 1.6}');
+----
+{0, 1}
+
+query I
+SELECT ceil(floatset '{0.5, 1.5, 2.5}');
+----
+{1, 2, 3}
+
+query I
+SELECT ceil(floatset '{0.5, 1.5, 1.6}');
+----
+{1, 2}
+
+query I
+SELECT round(floatset '{0.12345, 1.12345, 2.12345}', 3);
+----
+{0.123, 1.123, 2.123}
+
+query I
+SELECT degrees(floatset '{0, 0.5, 1}');
+----
+{0, 28.64788975654116, 57.29577951308232}
+
+query I
+SELECT degrees(floatset '{0, 0.5, 1}', true);
+----
+{0, 28.64788975654116, 57.29577951308232}
+
+query I
+SELECT radians(floatset '{0, 45, 90}');
+----
+{0, 0.785398163397448, 1.570796326794897}
+
+query I
+SELECT lower(textset '{"AAA", "BBB", "CCC"}');
+----
+{"aaa", "bbb", "ccc"}
+
+query I
+SELECT upper(textset '{"aaa", "bbb", "ccc"}');
+----
+{"AAA", "BBB", "CCC"}
+
+query I
+SELECT initcap(textset '{"aaa", "bbb", "ccc"}');
+----
+{"Aaa", "Bbb", "Ccc"}
+
+query I
+SELECT textset '{"aaa", "bbb", "ccc"}' || text 'XXX';
+----
+{"aaaXXX", "bbbXXX", "cccXXX"}
+
+query I
+SELECT text 'XXX' || textset '{"aaa", "bbb", "ccc"}';
+----
+{"XXXaaa", "XXXbbb", "XXXccc"}


### PR DESCRIPTION
## Summary

First parity harness between MobilityDB (PostgreSQL extension, historical store) and MobilityDuck (DuckDB extension, pipeline side). Adds `test/sql/parity/001_set.test` — a 1:1 port of the upstream regression file `mobilitydb/test/temporal/queries/001_set.test.sql` into DuckDB sqllogic format.

Goal: the long-term objective is that the same SQL query runs on both projects and produces comparable results. This file is the first executable, machine-checkable artifact that makes the gap measurable. Every future binding PR can annotate the skip block it unblocks.

## Methodology

- **Active assertion** per query that runs on MobilityDuck today. Expected output reflects MobilityDuck's format (ISO dates, UTC timestamps under `TZ=UTC`) — parity is in the query *surface*, not the display layer.
- **`mode skip` block** per query that hits an unbound MEOS symbol, a naming divergence, or an output-format divergence, with a `# gap:` annotation naming the specific missing binding.
- No C++ touched. No user-visible feature shipped. This is the measuring stick subsequent PRs chip away at.

## Initial gap triage

Four tracked gaps (based on src-tree audit — CI may reveal additional divergences on the currently-active assertions):

| # | Area | Gap | Fix |
|---|---|---|---|
| 1 | Constructor | `set(ARRAY[GEOMETRY ...])` not registered in `src/geo/geoset.cpp` | Register `ScalarFunction("set", {LIST(GEOMETRY)}, geomset(), ...)` (MEOS: `geomset_make`) |
| 2 | Accessor | `spans(<set_type>)` missing — only `spans(<spanset_type>)` exists (`src/temporal/spanset.cpp:330`) | Add set-level `spans` (MEOS: `set_spans`) |
| 3 | Naming | MobilityDB uses `splitNspans` / `splitEachNspans` (lowercase s); MobilityDuck registers `splitNSpans` / `splitEachNSpans` in `src/temporal/span.cpp:313-340` | Add lowercase aliases |
| 4 | Accessor | `set_hash` / `set_hash_extended` not registered in `src/temporal/set.cpp` | Add bindings returning BIGINT (MEOS: `set_hash`, `set_hash_extended`) |

## Test plan

- [ ] CI runs `test/sql/parity/001_set.test` and reports pass/fail per active assertion.
- [ ] Any active assertion that fails in CI gets re-triaged (skip block + gap note) in a follow-up commit on this branch before merge.
- [ ] Each of the 4 tracked gaps becomes a follow-up PR that deletes the matching skip block.
- [ ] Once this lands, the next parity PR ports `003_span.test.sql` using the same shape.

## Notes

- Local build not feasible in the authoring environment (vcpkg not installed); CI is the validation source of truth for the initial pass/fail tally.
- The source MobilityDB PR that motivated this scope (#788 "Add the tbigint type" upstream) is still open; once it lands, `bigintset` queries for the set of MobilityDB queries that PR adds will be easy follow-ups under the same parity structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)