### PR TITLE
fix: install MEOS error handler so errors throw instead of exit()

### DIFF
--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -130,17 +130,42 @@ static void ConfigureMeosSridCsvOnce() {
 }
 
 // =====================================================================
-// 4. Extension load logic
+// 4. MEOS error handler: translate MEOS_ERROR to a DuckDB exception
+// =====================================================================
+
+// MEOS's default handler calls exit(EXIT_FAILURE) on errlevel == ERROR,
+// which tears down the whole DuckDB process on any invalid input. We
+// install a handler that throws duckdb::InvalidInputException instead,
+// so MEOS errors surface as ordinary query failures and `statement
+// error` tests behave as expected.
+//
+// `ERROR` is the numeric value of PostgreSQL's elog ERROR level (21),
+// carried through MEOS via <postgres.h>. Anything at or above that
+// level (ERROR, FATAL, PANIC) is fatal in MEOS's model; lower levels
+// are informational and we ignore them silently.
+static constexpr int MEOS_ERRLEVEL_ERROR = 21;
+
+extern "C" void MobilityduckMeosErrorHandler(int errlevel, int errcode, const char *errmsg) {
+    (void) errcode;
+    if (errlevel >= MEOS_ERRLEVEL_ERROR) {
+        throw duckdb::InvalidInputException(errmsg ? errmsg : "MEOS error");
+    }
+}
+
+// =====================================================================
+// 5. Extension load logic
 // =====================================================================
 
 static void LoadInternal(ExtensionLoader &loader) {
 	// Configure MEOS SRID CSV once (env / embedded)
 	ConfigureMeosSridCsvOnce();
 
-	// Initialize MEOS once
+	// Initialize MEOS once and install our error handler so MEOS errors
+	// become DuckDB exceptions instead of exit()ing the process.
 	static std::once_flag meos_init_flag;
     std::call_once(meos_init_flag, []() {
         meos_initialize();
+        meos_initialize_error_handler(&MobilityduckMeosErrorHandler);
     });
 
 

--- a/test/sql/parity/001_set.test
+++ b/test/sql/parity/001_set.test
@@ -28,20 +28,6 @@
 # this file reflects MobilityDuck's output — the parity is in the query
 # *surface*, not the display layer. Display-layer alignment, if desired,
 # is a separate follow-up.
-#
-# ----------------------------------------------------------------------------
-# Error-handler gap (affects every `statement error` block in this file)
-# ----------------------------------------------------------------------------
-# `src/mobilityduck_extension.cpp` calls `meos_initialize()` but not
-# `meos_initialize_error_handler(...)`. MEOS's default error handler
-# terminates the process on MEOS_ERROR instead of surfacing as a
-# DuckDB::InvalidInputException, which kills the whole test runner the
-# moment a parity query triggers a MEOS parse / validation error. As a
-# result, *every* `statement error` block in this file is wrapped in
-# `mode skip` with a cross-reference to this note. Follow-up PR:
-# install a MEOS error handler in LoadInternal() that maps MEOS_ERROR
-# to a thrown DuckDB exception — all the skip wrappers can be deleted
-# in one stroke once that lands.
 
 require mobilityduck
 
@@ -75,15 +61,7 @@ SELECT tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
 {"2000-01-01 00:00:00+00", "2000-01-02 00:00:00+00", "2000-01-03 00:00:00+00"}
 
 # --- parse errors ---
-mode skip
-# gap: MEOS error handler is not wired to DuckDB exceptions.
-# `mobilityduck_extension.cpp:143` calls `meos_initialize()` but not
-# `meos_initialize_error_handler(...)`, so MEOS errors hit the default
-# handler and terminate the process instead of surfacing as a
-# DuckDB::InvalidInputException. Every `statement error` in this file
-# currently kills the test runner before Catch2 can check it, so all
-# error-path assertions are skipped until a follow-up PR installs a
-# MEOS error handler that throws on MEOS_ERROR.
+
 statement error
 SELECT tstzset '2000-01-01, 2000-01-02';
 ----
@@ -93,7 +71,6 @@ statement error
 SELECT tstzset '{2000-01-01, 2000-01-02';
 ----
 Could not parse
-mode unskip
 
 # =============================================================================
 # Output in WKT format
@@ -105,14 +82,10 @@ SELECT asText(floatset '{1.12345678, 2.123456789}', 6);
 {1.123457, 2.123457}
 
 # --- negative digits should error ---
-mode skip
-# gap: MEOS error handler not wired — see top-of-file note. Skipping
-# until the follow-up PR that installs a MEOS error handler.
 statement error
 SELECT asText(floatset '{1.12345678, 2.123456789}', -6);
 ----
 cannot be negative
-mode unskip
 
 # =============================================================================
 # Constructors
@@ -140,7 +113,18 @@ SELECT set(ARRAY [timestamptz '2000-01-01', '2000-01-01', '2000-01-03']);
 
 # --- empty array should error ---
 mode skip
-# gap: MEOS error handler not wired — see top-of-file note.
+# gap: array-literal syntax divergence, not a MEOS-error-handler test.
+# DuckDB parses `'{}'` as a string literal (PG's array-literal form) and
+# rejects the cast at the DuckDB layer before MEOS sees it, with
+# "Conversion Error: Type VARCHAR with value '{}' can't be cast...".
+# The parity intent is "an empty array should error" — both sides
+# reject, but by different mechanisms. An equivalent DuckDB-syntax
+# form `set(ARRAY[]::TIMESTAMPTZ[])` reaches MEOS but the constructor
+# wrapper in src/temporal/set_functions.cpp returns a null pointer
+# instead of calling `meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+# "The input array cannot be empty")`. Follow-up: port the empty-array
+# check into the wrapper so `set(ARRAY[]::TIMESTAMPTZ[])` raises a
+# proper InvalidInputException via the MEOS path.
 statement error
 SELECT set('{}'::timestamptz[]);
 ----


### PR DESCRIPTION
## Summary

MEOS's default error handler writes the message to stderr and calls `exit(EXIT_FAILURE)` on `errlevel == ERROR` (PG elog level 21, carried through via `postgres.h`). That tears down the entire DuckDB process on any invalid user input — a malformed tstzset literal, a negative precision on `asText`, etc. — which is both user-hostile in production and made every `statement error` test in PR #6's parity harness kill the test runner before Catch2 could check it.

This PR installs `MobilityduckMeosErrorHandler` via `meos_initialize_error_handler(...)` in `LoadInternal`, right after `meos_initialize()`. The handler throws `DuckDB::InvalidInputException` on `errlevel >= 21` (ERROR/FATAL/PANIC), so MEOS errors surface as ordinary query failures with the MEOS message attached. Lower levels (WARNING/NOTICE/INFO) are silently ignored for now — can be wired to DuckDB's logger in a follow-up if useful.

## Parity file consequences

- Deletes the top-of-file error-handler gap note (now obsolete).
- Unwraps the 3 MEOS-error-specific `mode skip` blocks covering `tstzset` parse errors and `asText` negative-digits — they now run as real `statement error` assertions.
- Re-wraps **one** of those (`set('{}'::timestamptz[])`) in a fresh skip block with a new gap note: that query fails at the DuckDB cast layer with a `Conversion Error` before MEOS sees it, because `'{}'` is PG array-literal syntax that DuckDB rejects as a string literal. The equivalent DuckDB form `set(ARRAY[]::TIMESTAMPTZ[])` reaches MEOS but the constructor wrapper in `src/temporal/set_functions.cpp` returns null instead of calling `meos_error(...)` on empty input — a separate gap, documented for a later follow-up.

## Test plan

- [x] `TZ=UTC ./build/release/test/unittest \"<proj>/test/*\"` locally: **747 assertions pass across 13 test cases** (up from 739 pre-handler), no regressions.
- [ ] CI validates on linux_amd64, linux_arm64, macos, wasm.
- [ ] After merge: the empty-array constructor follow-up (documented in the new skip block) unblocks that one remaining `statement error`.

## Notes

- Throwing a C++ exception through a C callback is technically UB by the standard, but is well-defined in GCC/Clang with `-fexceptions` enabled (which DuckDB and its extensions use). This is the same mechanism DuckDB-spatial uses for GDAL error handlers — precedent in the surrounding ecosystem.
- `errcode` is currently unused in the handler. Could be mapped to more specific DuckDB exception types in a follow-up (e.g. `MEOS_ERR_WKB_INPUT` → `InvalidTypeException`), but one-size-fits-all `InvalidInputException` is fine as a baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)