### PR TITLE
feat(bindings): splitNspans / splitEachNspans lowercase aliases

### DIFF
--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -130,17 +130,42 @@ static void ConfigureMeosSridCsvOnce() {
 }
 
 // =====================================================================
-// 4. Extension load logic
+// 4. MEOS error handler: translate MEOS_ERROR to a DuckDB exception
+// =====================================================================
+
+// MEOS's default handler calls exit(EXIT_FAILURE) on errlevel == ERROR,
+// which tears down the whole DuckDB process on any invalid input. We
+// install a handler that throws duckdb::InvalidInputException instead,
+// so MEOS errors surface as ordinary query failures and `statement
+// error` tests behave as expected.
+//
+// `ERROR` is the numeric value of PostgreSQL's elog ERROR level (21),
+// carried through MEOS via <postgres.h>. Anything at or above that
+// level (ERROR, FATAL, PANIC) is fatal in MEOS's model; lower levels
+// are informational and we ignore them silently.
+static constexpr int MEOS_ERRLEVEL_ERROR = 21;
+
+extern "C" void MobilityduckMeosErrorHandler(int errlevel, int errcode, const char *errmsg) {
+    (void) errcode;
+    if (errlevel >= MEOS_ERRLEVEL_ERROR) {
+        throw duckdb::InvalidInputException(errmsg ? errmsg : "MEOS error");
+    }
+}
+
+// =====================================================================
+// 5. Extension load logic
 // =====================================================================
 
 static void LoadInternal(ExtensionLoader &loader) {
 	// Configure MEOS SRID CSV once (env / embedded)
 	ConfigureMeosSridCsvOnce();
 
-	// Initialize MEOS once
+	// Initialize MEOS once and install our error handler so MEOS errors
+	// become DuckDB exceptions instead of exit()ing the process.
 	static std::once_flag meos_init_flag;
     std::call_once(meos_init_flag, []() {
         meos_initialize();
+        meos_initialize_error_handler(&MobilityduckMeosErrorHandler);
     });
 
 

--- a/src/temporal/span.cpp
+++ b/src/temporal/span.cpp
@@ -339,7 +339,41 @@ void SpanTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(
         ScalarFunction("splitEachNSpans", {SetTypes::tstzset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_split_each_n_spans));
-                
+
+    // Lowercase-"spans" aliases matching MobilityDB's SQL surface
+    // (`splitNspans` / `splitEachNspans`). The camelCase forms above
+    // stay registered for back-compat with existing MobilityDuck callers.
+    loader.RegisterFunction(
+        ScalarFunction("splitNspans", {SetTypes::intset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_split_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitNspans", {SetTypes::bigintset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::BIGINTSPAN()), SpanFunctions::Set_split_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitNspans", {SetTypes::floatset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::FLOATSPAN()), SpanFunctions::Set_split_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitNspans", {SetTypes::dateset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::DATESPAN()), SpanFunctions::Set_split_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitNspans", {SetTypes::tstzset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_split_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitEachNspans", {SetTypes::intset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_split_each_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitEachNspans", {SetTypes::bigintset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::BIGINTSPAN()), SpanFunctions::Set_split_each_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitEachNspans", {SetTypes::floatset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::FLOATSPAN()), SpanFunctions::Set_split_each_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitEachNspans", {SetTypes::dateset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::DATESPAN()), SpanFunctions::Set_split_each_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitEachNspans", {SetTypes::tstzset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_split_each_n_spans));
+
     loader.RegisterFunction(
         ScalarFunction("floor", {SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Floatspan_floor)
     );

--- a/test/sql/parity/001_set.test
+++ b/test/sql/parity/001_set.test
@@ -28,20 +28,6 @@
 # this file reflects MobilityDuck's output — the parity is in the query
 # *surface*, not the display layer. Display-layer alignment, if desired,
 # is a separate follow-up.
-#
-# ----------------------------------------------------------------------------
-# Error-handler gap (affects every `statement error` block in this file)
-# ----------------------------------------------------------------------------
-# `src/mobilityduck_extension.cpp` calls `meos_initialize()` but not
-# `meos_initialize_error_handler(...)`. MEOS's default error handler
-# terminates the process on MEOS_ERROR instead of surfacing as a
-# DuckDB::InvalidInputException, which kills the whole test runner the
-# moment a parity query triggers a MEOS parse / validation error. As a
-# result, *every* `statement error` block in this file is wrapped in
-# `mode skip` with a cross-reference to this note. Follow-up PR:
-# install a MEOS error handler in LoadInternal() that maps MEOS_ERROR
-# to a thrown DuckDB exception — all the skip wrappers can be deleted
-# in one stroke once that lands.
 
 require mobilityduck
 
@@ -75,15 +61,7 @@ SELECT tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
 {"2000-01-01 00:00:00+00", "2000-01-02 00:00:00+00", "2000-01-03 00:00:00+00"}
 
 # --- parse errors ---
-mode skip
-# gap: MEOS error handler is not wired to DuckDB exceptions.
-# `mobilityduck_extension.cpp:143` calls `meos_initialize()` but not
-# `meos_initialize_error_handler(...)`, so MEOS errors hit the default
-# handler and terminate the process instead of surfacing as a
-# DuckDB::InvalidInputException. Every `statement error` in this file
-# currently kills the test runner before Catch2 can check it, so all
-# error-path assertions are skipped until a follow-up PR installs a
-# MEOS error handler that throws on MEOS_ERROR.
+
 statement error
 SELECT tstzset '2000-01-01, 2000-01-02';
 ----
@@ -93,7 +71,6 @@ statement error
 SELECT tstzset '{2000-01-01, 2000-01-02';
 ----
 Could not parse
-mode unskip
 
 # =============================================================================
 # Output in WKT format
@@ -105,14 +82,10 @@ SELECT asText(floatset '{1.12345678, 2.123456789}', 6);
 {1.123457, 2.123457}
 
 # --- negative digits should error ---
-mode skip
-# gap: MEOS error handler not wired — see top-of-file note. Skipping
-# until the follow-up PR that installs a MEOS error handler.
 statement error
 SELECT asText(floatset '{1.12345678, 2.123456789}', -6);
 ----
 cannot be negative
-mode unskip
 
 # =============================================================================
 # Constructors
@@ -140,7 +113,18 @@ SELECT set(ARRAY [timestamptz '2000-01-01', '2000-01-01', '2000-01-03']);
 
 # --- empty array should error ---
 mode skip
-# gap: MEOS error handler not wired — see top-of-file note.
+# gap: array-literal syntax divergence, not a MEOS-error-handler test.
+# DuckDB parses `'{}'` as a string literal (PG's array-literal form) and
+# rejects the cast at the DuckDB layer before MEOS sees it, with
+# "Conversion Error: Type VARCHAR with value '{}' can't be cast...".
+# The parity intent is "an empty array should error" — both sides
+# reject, but by different mechanisms. An equivalent DuckDB-syntax
+# form `set(ARRAY[]::TIMESTAMPTZ[])` reaches MEOS but the constructor
+# wrapper in src/temporal/set_functions.cpp returns a null pointer
+# instead of calling `meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+# "The input array cannot be empty")`. Follow-up: port the empty-array
+# check into the wrapper so `set(ARRAY[]::TIMESTAMPTZ[])` raises a
+# proper InvalidInputException via the MEOS path.
 statement error
 SELECT set('{}'::timestamptz[]);
 ----

--- a/test/sql/parity/001_set.test
+++ b/test/sql/parity/001_set.test
@@ -240,12 +240,6 @@ SELECT spans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}');
 {"[1, 2)","[2, 3)","[3, 4)","[4, 5)","[5, 6)","[6, 7)","[7, 8)","[8, 9)","[9, 10)","[10, 11)"}
 mode unskip
 
-mode skip
-# gap: naming divergence — MobilityDB SQL uses `splitNspans` /
-# `splitEachNspans` (lowercase "spans"), MobilityDuck registers
-# `splitNSpans` / `splitEachNSpans` (camelCase, capital S) in
-# src/temporal/span.cpp:313-340. Follow-up: add lowercase aliases in
-# span.cpp registration for parity.
 query I
 SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
 ----
@@ -320,7 +314,6 @@ statement error
 SELECT splitEachNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', -1);
 ----
 strictly positive
-mode unskip
 
 query I
 SELECT numValues(dateset '{2000-01-01}');


### PR DESCRIPTION
## Summary

MobilityDB's SQL surface exposes `splitNspans` and `splitEachNspans` (lowercase "spans"). MobilityDuck registered only the camelCase forms `splitNSpans` / `splitEachNSpans` in `src/temporal/span.cpp`, so every parity query using the MobilityDB-native name errored out with "function not found". This PR adds the lowercase aliases for all five set types (intset/bigintset/floatset/dateset/tstzset), pointing at the same underlying `SpanFunctions::Set_split_n_spans` / `SpanFunctions::Set_split_each_n_spans` dispatchers. The camelCase forms stay registered for back-compat with existing MobilityDuck callers.

## Parity file

Unwraps the splitN/splitEach skip block — **15 queries** now active, including the 2 `statement error` `-1` cases that work thanks to the MEOS error handler installed in the parent PR this branch stacks on.

## Test plan

- [x] `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` locally: **747 assertions pass across 13 test cases**, no regressions.
- [ ] CI validates on linux_amd64, linux_arm64, macos, wasm.

## Dependencies

**Stacked on #7** (`fix: install MEOS error handler`). This PR's base branch is `fix/meos-error-handler`, not `main` — the 2 `statement error` cases inside the unwrapped block need the error handler from #7 to not kill the test runner. Merge order: #7 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)