### PR TITLE
feat(bindings): spans(<set_type>) — list of unit spans from a set

### DIFF
--- a/src/temporal/span.cpp
+++ b/src/temporal/span.cpp
@@ -309,6 +309,23 @@ void SpanTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
 
 
 
+    // spans(<set_type>) — list of unit spans, one per set element
+    loader.RegisterFunction(
+        ScalarFunction("spans", {SetTypes::intset()},
+                       LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_spans));
+    loader.RegisterFunction(
+        ScalarFunction("spans", {SetTypes::bigintset()},
+                       LogicalType::LIST(SpanTypes::BIGINTSPAN()), SpanFunctions::Set_spans));
+    loader.RegisterFunction(
+        ScalarFunction("spans", {SetTypes::floatset()},
+                       LogicalType::LIST(SpanTypes::FLOATSPAN()), SpanFunctions::Set_spans));
+    loader.RegisterFunction(
+        ScalarFunction("spans", {SetTypes::dateset()},
+                       LogicalType::LIST(SpanTypes::DATESPAN()), SpanFunctions::Set_spans));
+    loader.RegisterFunction(
+        ScalarFunction("spans", {SetTypes::tstzset()},
+                       LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_spans));
+
     loader.RegisterFunction(
         ScalarFunction("splitNSpans", {SetTypes::intset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_split_n_spans));

--- a/src/temporal/span_functions.cpp
+++ b/src/temporal/span_functions.cpp
@@ -408,23 +408,56 @@ bool SpanFunctions::Set_to_span_cast(Vector &source, Vector &result, idx_t count
     return true;
 }
 
+// spans(<set_type>) — returns a LIST(<span_type>) of unit spans, one per
+// element of the input set. Mirrors SpansetFunctions::Spanset_spans but
+// reads a Set and uses set_spans() / set_num_values() from MEOS.
 void SpanFunctions::Set_spans(DataChunk &args, ExpressionState &state, Vector &result) {
-    BinaryExecutor::Execute<string_t, string_t, string_t>(
-        args.data[0], args.data[1], result, args.size(),
-        [&](string_t set_blob, string_t span_blob) -> string_t {
-            const uint8_t *set_data = reinterpret_cast<const uint8_t*>(set_blob.GetData());
-            size_t set_size = set_blob.GetSize();
-            const Set *s = reinterpret_cast<const Set*>(set_data);
-            Span *span = set_to_span(s);
-            if (span == NULL) {
-                throw InvalidInputException("Failed to convert set to span");
-            }
-            size_t span_size = sizeof(*span);
-            string_t out = StringVector::AddStringOrBlob(result, (const char *)span, span_size);
-            free(span);
-            return out;
+    auto &set_vec = args.data[0];
+    idx_t row_count = args.size();
+    set_vec.Flatten(row_count);
+
+    auto &result_validity = FlatVector::Validity(result);
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &child_vector = ListVector::GetEntry(result);
+    child_vector.SetVectorType(VectorType::FLAT_VECTOR);
+    ListVector::Reserve(result, row_count);
+
+    idx_t total_offset = 0;
+    const size_t span_bytes = sizeof(Span);
+
+    for (idx_t i = 0; i < row_count; ++i) {
+        if (FlatVector::IsNull(set_vec, i)) {
+            result_validity.SetInvalid(i);
+            continue;
         }
-    );
+
+        string_t blob = FlatVector::GetData<string_t>(set_vec)[i];
+        Set *s = (Set *)malloc(blob.GetSize());
+        memcpy(s, blob.GetData(), blob.GetSize());
+
+        int num = set_num_values(s);
+        Span *spans = set_spans(s);
+        free(s);
+
+        if (!spans || num <= 0) {
+            if (spans) free(spans);
+            result_validity.SetInvalid(i);
+            continue;
+        }
+
+        ListVector::SetListSize(result, total_offset + num);
+        list_entries[i] = list_entry_t{total_offset, static_cast<uint64_t>(num)};
+
+        auto *child_data = FlatVector::GetData<string_t>(child_vector);
+        for (int j = 0; j < num; ++j) {
+            child_data[total_offset + j] =
+                StringVector::AddStringOrBlob(child_vector, reinterpret_cast<const char *>(&spans[j]), span_bytes);
+        }
+
+        free(spans);
+        total_offset += num;
+        result_validity.SetValid(i);
+    }
 }
 
 // --- Conversion: intspan <-> floatspan ---

--- a/test/sql/parity/001_set.test
+++ b/test/sql/parity/001_set.test
@@ -230,15 +230,10 @@ SELECT span(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}');
 ----
 [2000-01-01 00:00:00+00, 2000-01-03 00:00:00+00]
 
-mode skip
-# gap: `spans(<set_type>)` — returns a list of unit spans. MobilityDuck
-# only registers `spans(<spanset_type>)` (src/temporal/spanset.cpp:330);
-# the set-level version is not bound. MEOS symbol: set_spans.
 query I
 SELECT spans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}');
 ----
 {"[1, 2)","[2, 3)","[3, 4)","[4, 5)","[5, 6)","[6, 7)","[7, 8)","[8, 9)","[9, 10)","[10, 11)"}
-mode unskip
 
 mode skip
 # gap: naming divergence — MobilityDB SQL uses `splitNspans` /


### PR DESCRIPTION
## Summary

Adds the set-level `spans` scalar for all five set types (intset/bigintset/floatset/dateset/tstzset), mirroring `SpansetFunctions::Spanset_spans` but reading a `Set` and calling the MEOS-side `set_spans(s)` + `set_num_values(s)` pair.

`SpanFunctions::Set_spans` already existed as a stub in `src/temporal/span_functions.cpp` but was never registered and had the wrong semantics — it was a `BinaryExecutor` calling `set_to_span` that returned a single `Span`, not a list. Replaced with a proper list-building implementation and registered `spans(<set_type>)` as a `LIST(<span_type>)` returner for each of the five set types.

## Parity file

Unwraps the `spans(intset ...)` skip block — 1 query now active.

## Test plan

- [x] `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` locally: **747 assertions pass across 13 test cases**, no regressions.
- [ ] CI validates on linux_amd64, linux_arm64, macos, wasm.

## Dependencies

**Stacked** on top of the MEOS error handler / lowercase aliases chain. Merge order: #7 → #8 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)