### PR TITLE
chore: tighten parity-test header and error-handler comments

### DIFF
--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -134,15 +134,11 @@ static void ConfigureMeosSridCsvOnce() {
 // =====================================================================
 
 // MEOS's default handler calls exit(EXIT_FAILURE) on errlevel == ERROR,
-// which tears down the whole DuckDB process on any invalid input. We
-// install a handler that throws duckdb::InvalidInputException instead,
-// so MEOS errors surface as ordinary query failures and `statement
-// error` tests behave as expected.
-//
-// `ERROR` is the numeric value of PostgreSQL's elog ERROR level (21),
-// carried through MEOS via <postgres.h>. Anything at or above that
-// level (ERROR, FATAL, PANIC) is fatal in MEOS's model; lower levels
-// are informational and we ignore them silently.
+// which would tear down the whole DuckDB process on any invalid input.
+// Throw a DuckDB exception instead. Numeric levels follow PostgreSQL's
+// elog values carried through via <postgres.h>: ERROR / FATAL / PANIC
+// are fatal (>= 21); lower levels (WARNING / NOTICE / INFO) are
+// informational and ignored.
 static constexpr int MEOS_ERRLEVEL_ERROR = 21;
 
 extern "C" void MobilityduckMeosErrorHandler(int errlevel, int errcode, const char *errmsg) {


### PR DESCRIPTION
## Summary

Comment-only cleanup in two files. No logic, no test behavior change.

**`test/sql/parity/001_set.test`** — the file's preamble explained the parity-harness methodology at length. Replaced with a short header pointing at the upstream regression file and noting the date/timestamp display-format divergence. Same pass over the remaining gap-note blocks (geomset, spans, splitN, set_hash, empty-array): keep the technical content (which symbol is missing, where in the source), drop the surrounding explanatory padding.

**`src/mobilityduck_extension.cpp`** — `MobilityduckMeosErrorHandler` had a multi-paragraph comment narrating why the handler exists. Trimmed to the load-bearing facts: MEOS's default handler exits the process; we throw instead; level numbering follows PostgreSQL's elog with `>= 21` (ERROR/FATAL/PANIC) treated as fatal.

## Test plan

- Comment / header text only; no rebuild needed for behavior verification. CI exercises the full suite.