### PR TITLE
feat(bindings): span_hash / span_hash_extended for all span types

### DIFF
--- a/src/include/temporal/span_functions.hpp
+++ b/src/include/temporal/span_functions.hpp
@@ -45,6 +45,8 @@ struct SpanFunctions {
         // accessors
     static void Span_lower(DataChunk &args, ExpressionState &state, Vector &result);
     static void Span_upper(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Span_hash(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Span_hash_extended(DataChunk &args, ExpressionState &state, Vector &result);
     static void Span_lower_inc(DataChunk &args, ExpressionState &state, Vector &result);
     static void Span_upper_inc(DataChunk &args, ExpressionState &state, Vector &result);
     static void Numspan_width(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/span.cpp
+++ b/src/temporal/span.cpp
@@ -272,6 +272,9 @@ void SpanTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
 
         loader.RegisterFunction( ScalarFunction("lowerInc",{span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_lower_inc));
         loader.RegisterFunction( ScalarFunction("upperInc",{span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_upper_inc));
+
+        loader.RegisterFunction( ScalarFunction("span_hash", {span_type}, LogicalType::UINTEGER, SpanFunctions::Span_hash));
+        loader.RegisterFunction( ScalarFunction("span_hash_extended", {span_type, LogicalType::BIGINT}, LogicalType::UBIGINT, SpanFunctions::Span_hash_extended));
         }
     
     loader.RegisterFunction( 

--- a/src/temporal/span_functions.cpp
+++ b/src/temporal/span_functions.cpp
@@ -798,6 +798,37 @@ void SpanFunctions::Span_upper(DataChunk &args, ExpressionState &state, Vector &
     }
 }
 
+void SpanFunctions::Span_hash(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto &input = args.data[0];
+    UnaryExecutor::Execute<string_t, uint32_t>(
+        input, result, args.size(),
+        [&](string_t input_blob) -> uint32_t {
+            const uint8_t *data = (const uint8_t *)input_blob.GetData();
+            size_t size = input_blob.GetSize();
+            Span *s = (Span*)malloc(size);
+            memcpy(s, data, size);
+            uint32_t h = span_hash(s);
+            free(s);
+            return h;
+        });
+}
+
+void SpanFunctions::Span_hash_extended(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto &input = args.data[0];
+    auto &seed_vec = args.data[1];
+    BinaryExecutor::Execute<string_t, int64_t, uint64_t>(
+        input, seed_vec, result, args.size(),
+        [&](string_t input_blob, int64_t seed) -> uint64_t {
+            const uint8_t *data = (const uint8_t *)input_blob.GetData();
+            size_t size = input_blob.GetSize();
+            Span *s = (Span*)malloc(size);
+            memcpy(s, data, size);
+            uint64_t h = span_hash_extended(s, (uint64_t)seed);
+            free(s);
+            return h;
+        });
+}
+
 void SpanFunctions::Span_lower_inc(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &input = args.data[0];
     auto span_type = SpanTypeMapping::GetMeosTypeFromAlias(input.GetType().ToString());


### PR DESCRIPTION
## Summary

Adds the two MEOS hash scalars for all five span types (intspan/bigintspan/floatspan/datespan/tstzspan):

- `span_hash(<span>) -> UINTEGER` (MEOS `uint32 span_hash`)
- `span_hash_extended(<span>, BIGINT seed) -> UBIGINT` (MEOS `uint64 span_hash_extended`; seed cast to `uint64`)

Mirrors `set_hash` / `set_hash_extended` from the corresponding set PR. Implementation copies the blob into a malloc'd `Span`, calls MEOS, frees. Registered in the per-span-type loop in `src/temporal/span.cpp` next to `lower` / `upper` / `lowerInc` / `upperInc`.

## Smoke test

```sql
SELECT span_hash(intspan '[1,2]');                                 -- 2065175488 (UINTEGER)
SELECT span_hash_extended(tstzspan '[2000-01-01,2000-01-02]', 1);  -- 13017976434127639577 (UBIGINT)
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.

Activates the `span_hash` skip block in `test/sql/parity/003_span.test` (open in PR #13) once both land.