### PR TITLE
feat(bindings): scalar value -> span casts (date, timestamptz, int, bigint, double)

### DIFF
--- a/src/temporal/span.cpp
+++ b/src/temporal/span.cpp
@@ -143,6 +143,13 @@ void SpanTypes::RegisterCastFunctions(ExtensionLoader &loader) {
             SpanTypes::TSTZSPAN(),
             SpanFunctions::Set_to_span_cast // tstzset -> tstzspan
          );
+
+        // Scalar value -> span casts
+        loader.RegisterCastFunction(LogicalType::INTEGER,      SpanTypes::INTSPAN(),    SpanFunctions::Value_to_span_cast);
+        loader.RegisterCastFunction(LogicalType::BIGINT,       SpanTypes::BIGINTSPAN(), SpanFunctions::Value_to_span_cast);
+        loader.RegisterCastFunction(LogicalType::DOUBLE,       SpanTypes::FLOATSPAN(),  SpanFunctions::Value_to_span_cast);
+        loader.RegisterCastFunction(LogicalType::DATE,         SpanTypes::DATESPAN(),   SpanFunctions::Value_to_span_cast);
+        loader.RegisterCastFunction(LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN(),   SpanFunctions::Value_to_span_cast);
     }
 }
 

--- a/src/temporal/span_functions.cpp
+++ b/src/temporal/span_functions.cpp
@@ -315,7 +315,7 @@ static void Value_to_span_core(Vector &source, Vector &result, idx_t count, meos
                 Span *s = value_span(d, T_INT4);
                 Write_span(result,i,s);
             }
-
+            break;
         }
         case T_INT8: {
             auto in = FlatVector::GetData<int64_t>(source);
@@ -372,6 +372,13 @@ void SpanFunctions::Value_to_span(DataChunk &args, ExpressionState &state, Vecto
 
     Value_to_span_core(source, result, args.size(), base_type);
 
+}
+
+bool SpanFunctions::Value_to_span_cast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(result.GetType().GetAlias());
+    meosType base_type = spantype_basetype(span_type);
+    Value_to_span_core(source, result, count, base_type);
+    return true;
 }
 
 static void Set_to_span_common(Vector &source, Vector &result, idx_t count) {


### PR DESCRIPTION
## Summary

Registers cast functions so DuckDB recognises:

| From | To |
|---|---|
| `INTEGER` | `INTSPAN` |
| `BIGINT` | `BIGINTSPAN` |
| `DOUBLE` | `FLOATSPAN` |
| `DATE` | `DATESPAN` |
| `TIMESTAMP_TZ` | `TSTZSPAN` |

The cast entry point `Value_to_span_cast` was previously declared in `src/include/temporal/span_functions.hpp` but never defined; defines it to delegate to `Value_to_span_core` (same path the existing `span(value)` scalar function uses).

Also fixes a pre-existing fall-through bug in `Value_to_span_core`: the `T_INT4` case was missing `break;` and silently fell through to the `T_INT8` branch, which would read the INT32 source vector as INT64 and trip DuckDB's internal `Expected vector of type INT64, but found vector of type INT32` assertion. The bug only surfaced once anything actually exercised the INT4 branch via this entry point, which the new `INTEGER -> INTSPAN` cast does.

## Smoke test

```sql
SELECT 5::intspan;                          -- [5, 6)
SELECT 5::BIGINT::bigintspan;               -- [5, 6)
SELECT 1.5::DOUBLE::floatspan;              -- [1.5, 1.5]
SELECT date '2000-01-01'::datespan;         -- [2000-01-01, 2000-01-02)
SELECT timestamptz '2000-01-01'::tstzspan;  -- [2000-01-01 00:00:00+00, ...]
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.

Activates the date / timestamptz cast skip block in `test/sql/parity/003_span.test` (open in PR #13) once both land.