### PR TITLE
test(parity): 007_spanset.test — spanset regression mirror

### DIFF
--- a/test/sql/parity/007_spanset.test
+++ b/test/sql/parity/007_spanset.test
@@ -1,0 +1,605 @@
+# name: test/sql/parity/007_spanset.test
+# description: MobilityDB regression file 007_spanset.test.sql adapted for MobilityDuck
+# group: [sql]
+#
+# Queries from mobilitydb/test/temporal/queries/007_spanset.test.sql.
+# Expected outputs reflect MobilityDuck's display format (ISO dates,
+# UTC timestamps under TZ=UTC) rather than MobilityDB's PG-locale
+# format ("01-01-2000", "Sat Jan 01 00:00:00 2000 PST").
+
+require mobilityduck
+
+# =============================================================================
+# I/O
+# =============================================================================
+
+query I
+SELECT intspanset '{[1,2),[3,4),[5,6)}';
+----
+{[1, 2), [3, 4), [5, 6)}
+
+query I
+SELECT bigintspanset '{[1,2),[3,4),[5,6)}';
+----
+{[1, 2), [3, 4), [5, 6)}
+
+query I
+SELECT floatspanset '{[1,2),[3,4),[5,6)}';
+----
+{[1, 2), [3, 4), [5, 6)}
+
+query I
+SELECT datespanset '{[2000-01-01, 2000-01-02), [2000-01-03, 2000-01-04)}';
+----
+{[2000-01-01, 2000-01-02), [2000-01-03, 2000-01-04)}
+
+query I
+SELECT tstzspanset '{[2000-01-01, 2000-01-02), [2000-01-03, 2000-01-04)}';
+----
+{[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00), [2000-01-03 00:00:00+00, 2000-01-04 00:00:00+00)}
+
+query I
+SELECT tstzspanset '{[2000-01-01, 2000-01-02), [2000-01-02, 2000-01-03), [2000-01-03, 2000-01-04)}';
+----
+{[2000-01-01 00:00:00+00, 2000-01-04 00:00:00+00)}
+
+statement error
+SELECT tstzspanset '2000-01-01, 2000-01-02';
+----
+Could not parse
+
+statement error
+SELECT tstzspanset '{[2000-01-01, 2000-01-02]';
+----
+Could not parse
+
+# =============================================================================
+# asText
+# =============================================================================
+
+query I
+SELECT asText(floatspanset '{[1.12345678, 2.123456789]}', 6);
+----
+{[1.123457, 2.123457]}
+
+statement error
+SELECT asText(floatspanset '{[1.12345678, 2.123456789]}', -6);
+----
+cannot be negative
+
+# =============================================================================
+# Constructors
+# =============================================================================
+
+query I
+SELECT spanset(ARRAY [intspan '[1,2)','[3,4)','[5,6)']);
+----
+{[1, 2), [3, 4), [5, 6)}
+
+query I
+SELECT spanset(ARRAY [floatspan '[1,2)','[3,4)','[5,6)']);
+----
+{[1, 2), [3, 4), [5, 6)}
+
+query I
+SELECT spanset(ARRAY [datespan '[2000-01-01, 2000-01-02]', '[2000-01-03,2000-01-04]']);
+----
+{[2000-01-01, 2000-01-05)}
+
+query I
+SELECT spanset(ARRAY [tstzspan '[2000-01-01, 2000-01-02]', '[2000-01-03,2000-01-04]']);
+----
+{[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00], [2000-01-03 00:00:00+00, 2000-01-04 00:00:00+00]}
+
+statement error
+SELECT spanset(ARRAY [tstzspan '[2000-01-01, 2000-01-03]', '[2000-01-02,2000-01-04]']);
+----
+must be increasing
+
+# DuckDB rejects the PG-style `'{}'::tstzspan[]` cast, so the parity
+# test uses the DuckDB-native `ARRAY[]::TSTZSPAN[]` form to verify the
+# empty-array guard.
+statement error
+SELECT spanset(ARRAY[]::TSTZSPAN[]);
+----
+cannot be empty
+
+# =============================================================================
+# Conversions
+# =============================================================================
+
+query I
+SELECT spanset(date '2000-01-01');
+----
+{[2000-01-01, 2000-01-02)}
+
+query I
+SELECT spanset(dateset '{2000-01-01,2000-01-02}');
+----
+{[2000-01-01, 2000-01-03)}
+
+query I
+SELECT spanset(datespan '[2000-01-01,2000-01-02]');
+----
+{[2000-01-01, 2000-01-03)}
+
+query I
+SELECT date '2000-01-01'::datespanset;
+----
+{[2000-01-01, 2000-01-02)}
+
+query I
+SELECT dateset '{2000-01-01,2000-01-02}'::datespanset;
+----
+{[2000-01-01, 2000-01-03)}
+
+query I
+SELECT datespan '[2000-01-01,2000-01-02]'::datespanset;
+----
+{[2000-01-01, 2000-01-03)}
+
+query I
+SELECT spanset(timestamptz '2000-01-01');
+----
+{[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00]}
+
+query I
+SELECT spanset(tstzset '{2000-01-01,2000-01-02}');
+----
+{[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00], [2000-01-02 00:00:00+00, 2000-01-02 00:00:00+00]}
+
+query I
+SELECT spanset(tstzspan '[2000-01-01,2000-01-02]');
+----
+{[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00]}
+
+query I
+SELECT timestamptz '2000-01-01'::tstzspanset;
+----
+{[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00]}
+
+query I
+SELECT tstzset '{2000-01-01,2000-01-02}'::tstzspanset;
+----
+{[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00], [2000-01-02 00:00:00+00, 2000-01-02 00:00:00+00]}
+
+query I
+SELECT tstzspan '[2000-01-01,2000-01-02]'::tstzspanset;
+----
+{[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00]}
+
+mode skip
+# intspanset -> floatspanset cast diverges: MobilityDuck normalizes
+# half-open intspan elements to closed floatspan form
+# (`[1,2)` becomes `[1, 1]`), whereas MobilityDB preserves the
+# half-open form (`[1, 2)`). MEOS symbol: numspanset_to_floatspanset.
+query I
+SELECT intspanset '{[1,2),[3,4),[5,6)}'::floatspanset;
+----
+{[1, 2), [3, 4), [5, 6)}
+mode unskip
+
+query I
+SELECT floatspanset '{[1,2),[3,4),[5,6)}'::intspanset;
+----
+{[1, 2), [3, 4), [5, 6)}
+
+query I
+SELECT datespanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}'::tstzspanset;
+----
+{[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00), [2000-01-03 00:00:00+00, 2000-01-04 00:00:00+00), [2000-01-05 00:00:00+00, 2000-01-06 00:00:00+00)}
+
+query I
+SELECT tstzspanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}'::datespanset;
+----
+{[2000-01-01, 2000-01-02), [2000-01-03, 2000-01-04), [2000-01-05, 2000-01-06)}
+
+mode skip
+# tstzmultirange is a PG-only range type not portable to DuckDB.
+statement error
+SELECT tstzmultirange '{}'::tstzspanset;
+----
+
+statement error
+SELECT tstzmultirange '{(,)}'::tstzspanset;
+----
+mode unskip
+
+# =============================================================================
+# Accessor functions
+# =============================================================================
+
+query I
+SELECT memSize(intspanset '{[1,2),[3,4),[5,6)}');
+----
+80
+
+query I
+SELECT memSize(floatspanset '{[1,2),[3,4),[5,6)}');
+----
+104
+
+query I
+SELECT memSize(datespanset '{[2000-01-01,2000-01-01]}');
+----
+56
+
+query I
+SELECT memSize(tstzspanset '{[2000-01-01,2000-01-01]}');
+----
+72
+
+query I
+SELECT span(intspanset '{[1,2),[3,4),[5,6)}');
+----
+[1, 6)
+
+query I
+SELECT span(floatspanset '{[1,2),[3,4),[5,6)}');
+----
+[1, 6)
+
+query I
+SELECT lower(intspanset '{[1,2),[3,4),[5,6)}');
+----
+1
+
+query I
+SELECT lower(floatspanset '{[1,2),[3,4),[5,6)}');
+----
+1
+
+query I
+SELECT lowerInc(intspanset '{[1,2),[3,4),[5,6)}');
+----
+true
+
+query I
+SELECT lowerInc(floatspanset '{[1,2),[3,4),[5,6)}');
+----
+true
+
+query I
+SELECT upper(intspanset '{[1,2),[3,4),[5,6)}');
+----
+6
+
+query I
+SELECT upper(floatspanset '{[1,2),[3,4),[5,6)}');
+----
+6
+
+query I
+SELECT upperInc(intspanset '{[1,2),[3,4),[5,6)}');
+----
+false
+
+query I
+SELECT upperInc(floatspanset '{[1,2),[3,4),[5,6)}');
+----
+false
+
+query I
+SELECT span(datespanset '{[2000-01-01,2000-01-01]}');
+----
+[2000-01-01, 2000-01-02)
+
+query I
+SELECT span(tstzspanset '{[2000-01-01,2000-01-01]}');
+----
+[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00]
+
+query I
+SELECT width(intspanset '{[1,2),[3,4),[5,6)}');
+----
+3
+
+query I
+SELECT width(floatspanset '{[1,2),[3,4),[5,6)}');
+----
+3
+
+query I
+SELECT width(intspanset '{[1,2),[3,4),[5,6)}', true);
+----
+5
+
+query I
+SELECT width(floatspanset '{[1,2),[3,4),[5,6)}', true);
+----
+5
+
+query I
+SELECT duration(datespanset '{[2000-01-01,2000-01-01]}');
+----
+1 day
+
+query I
+SELECT duration(datespanset '{[2000-01-01,2000-01-02),[2000-01-02,2000-01-03),[2000-01-03,2000-01-04)}');
+----
+3 days
+
+query I
+SELECT duration(datespanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}');
+----
+3 days
+
+query I
+SELECT duration(datespanset '{[2000-01-01,2000-01-01]}', true);
+----
+1 day
+
+query I
+SELECT duration(datespanset '{[2000-01-01,2000-01-02),[2000-01-02,2000-01-03),[2000-01-03,2000-01-04)}', true);
+----
+3 days
+
+query I
+SELECT duration(datespanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}', true);
+----
+5 days
+
+query I
+SELECT numSpans(intspanset '{[1,2),[3,4),[5,6)}');
+----
+3
+
+query I
+SELECT numSpans(floatspanset '{[1,2),[3,4),[5,6)}');
+----
+3
+
+query I
+SELECT numSpans(datespanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}');
+----
+3
+
+query I
+SELECT numSpans(tstzspanset '{[2000-01-01,2000-01-01]}');
+----
+1
+
+query I
+SELECT startSpan(intspanset '{[1,2),[3,4),[5,6)}');
+----
+[1, 2)
+
+query I
+SELECT startSpan(floatspanset '{[1,2),[3,4),[5,6)}');
+----
+[1, 2)
+
+query I
+SELECT startSpan(datespanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}');
+----
+[2000-01-01, 2000-01-02)
+
+query I
+SELECT endSpan(intspanset '{[1,2),[3,4),[5,6)}');
+----
+[5, 6)
+
+query I
+SELECT endSpan(floatspanset '{[1,2),[3,4),[5,6)}');
+----
+[5, 6)
+
+query I
+SELECT endSpan(datespanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}');
+----
+[2000-01-05, 2000-01-06)
+
+query I
+SELECT spanN(intspanset '{[1,2),[3,4),[5,6)}', 2);
+----
+[3, 4)
+
+query I
+SELECT spanN(floatspanset '{[1,2),[3,4),[5,6)}', 2);
+----
+[3, 4)
+
+query I
+SELECT spanN(datespanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}', 2);
+----
+[2000-01-03, 2000-01-04)
+
+query I
+SELECT spans(intspanset '{[1,2),[3,4),[5,6)}');
+----
+{[1, 2), [3, 4), [5, 6)}
+
+query I
+SELECT spans(floatspanset '{[1,2),[3,4),[5,6)}');
+----
+{[1, 2), [3, 4), [5, 6)}
+
+# =============================================================================
+# splitNspans / splitEachNspans (lowercase, MobilityDB-native)
+# =============================================================================
+
+mode skip
+# Result divergence:
+#   - MobilityDB returns SpanSet (`{[1, 4), [5, 10)}`)
+#   - MobilityDuck returns LIST<Span> (`['[1, 8)', '[9, 10)']`)
+# splitNspans values also differ: MobilityDB groups {[1,2),[3,4)} +
+# {[5,6),[7,8),[9,10)}; MobilityDuck groups {[1,2),[3,4),[5,6),[7,8)}
+# + {[9,10)}. The MEOS symbol used (spanset_split_n_spans) is the same
+# but the input partitioning differs.
+query I
+SELECT splitNspans(intspanset '{[1, 2), [3, 4), [5, 6), [7, 8), [9, 10)}', 2);
+----
+{[1, 4), [5, 10)}
+
+query I
+SELECT splitEachNspans(intspanset '{[1, 2), [3, 4), [5, 6), [7, 8), [9, 10)}', 2);
+----
+{[1, 4), [5, 8), [9, 10)}
+mode unskip
+
+# =============================================================================
+# Date / timestamp accessors on dateset / tstz spanset
+# =============================================================================
+
+query I
+SELECT numDates(datespanset '{[2000-01-01,2000-01-02)}');
+----
+2
+
+query I
+SELECT numDates(datespanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}');
+----
+6
+
+query I
+SELECT startDate(datespanset '{[2000-01-01,2000-01-02)}');
+----
+2000-01-01
+
+query I
+SELECT startDate(datespanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}');
+----
+2000-01-01
+
+query I
+SELECT endDate(datespanset '{[2000-01-01,2000-01-02)}');
+----
+2000-01-02
+
+query I
+SELECT endDate(datespanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}');
+----
+2000-01-06
+
+query I
+SELECT dateN(datespanset '{[2000-01-01,2000-01-02)}', 1);
+----
+2000-01-01
+
+query I
+SELECT dateN(datespanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}', 3);
+----
+2000-01-03
+
+query I
+SELECT dateN(datespanset '{[2000-01-01,2000-01-02),[2000-01-03,2000-01-04),[2000-01-05,2000-01-06)}', 7);
+----
+NULL
+
+query I
+SELECT dates(datespanset '{[2000-01-01,2000-01-02)}');
+----
+{2000-01-01, 2000-01-02}
+
+query I
+SELECT numTimestamps(tstzspanset '{[2000-01-01,2000-01-01]}');
+----
+1
+
+query I
+SELECT startTimestamp(tstzspanset '{[2000-01-01,2000-01-01]}');
+----
+2000-01-01 00:00:00+00
+
+query I
+SELECT endTimestamp(tstzspanset '{[2000-01-01,2000-01-01]}');
+----
+2000-01-01 00:00:00+00
+
+query I
+SELECT timestampN(tstzspanset '{[2000-01-01,2000-01-01]}', 1);
+----
+2000-01-01 00:00:00+00
+
+query I
+SELECT timestamps(tstzspanset '{[2000-01-01,2000-01-01]}');
+----
+{"2000-01-01 00:00:00+00"}
+
+# =============================================================================
+# Comparison
+# =============================================================================
+
+query I
+SELECT spanset_cmp(intspanset '{[1,1]}', intspanset '{[1,2),[2,3),[3,4)}');
+----
+-1
+
+query I
+SELECT intspanset '{[1,1]}' = intspanset '{[1,2),[2,3),[3,4)}';
+----
+false
+
+query I
+SELECT intspanset '{[1,1]}' <> intspanset '{[1,2),[2,3),[3,4)}';
+----
+true
+
+query I
+SELECT intspanset '{[1,1]}' < intspanset '{[1,2),[2,3),[3,4)}';
+----
+true
+
+query I
+SELECT intspanset '{[1,1]}' <= intspanset '{[1,2),[2,3),[3,4)}';
+----
+true
+
+query I
+SELECT intspanset '{[1,1]}' > intspanset '{[1,2),[2,3),[3,4)}';
+----
+false
+
+query I
+SELECT intspanset '{[1,1]}' >= intspanset '{[1,2),[2,3),[3,4)}';
+----
+false
+
+query I
+SELECT spanset_hash(intspanset '{[1,2]}') = spanset_hash(intspanset '{[1,2]}');
+----
+true
+
+query I
+SELECT spanset_hash_extended(intspanset '{[1,2]}', 1) = spanset_hash_extended(intspanset '{[1,2]}', 1);
+----
+true
+
+# =============================================================================
+# Transformation functions
+# =============================================================================
+
+query I
+SELECT floor(floatspanset '{[1.5,2.5),[3.5,4.5),[5.5,6.5)}');
+----
+{[1, 3), [3, 5), [5, 7)}
+
+query I
+SELECT ceil(floatspanset '{[1.5,2.5),[3.5,4.5),[5.5,6.5)}');
+----
+{[2, 3), [4, 5), [6, 7)}
+
+query I
+SELECT round(floatspanset '{[1.12345,2.12345),[3.12345,4.12345),[5.12345,6.12345)}', 2);
+----
+{[1.12, 2.12), [3.12, 4.12), [5.12, 6.12)}
+
+query I
+SELECT shift(intspanset '{[1,2),[3,4),[5,6)}', 2);
+----
+{[3, 4), [5, 6), [7, 8)}
+
+query I
+SELECT shift(tstzspanset '{[2000-01-01,2000-01-01]}', '5 min');
+----
+{[2000-01-01 00:05:00+00, 2000-01-01 00:05:00+00]}
+
+query I
+SELECT scale(tstzspanset '{[2000-01-01,2000-01-01]}', '1 hour');
+----
+{[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00]}
+
+query I
+SELECT shiftScale(tstzspanset '{[2000-01-01,2000-01-01]}', '5 min', '1 hour');
+----
+{[2000-01-01 00:05:00+00, 2000-01-01 00:05:00+00]}


### PR DESCRIPTION
## Summary

Ports `mobilitydb/test/temporal/queries/007_spanset.test.sql` to `test/sql/parity/007_spanset.test` in DuckDB sqllogic format. Same shape as the earlier parity files: active queries reflect MobilityDuck's display format; queries that hit a missing binding, naming divergence, or DuckDB/PG syntax-portability boundary are wrapped in `mode skip` with a short technical note.

Active coverage:
- I/O parse errors, `asText`,
- `ARRAY[<span>]` constructors including the must-be-increasing error,
- scalar/set/span → spanset conversions in both directions (DATE, TIMESTAMP_TZ, dateset, tstzset, datespan, tstzspan, intspanset↔floatspanset, datespanset↔tstzspanset),
- accessors: `memSize`, `span`, `lower` / `upper` / `lowerInc` / `upperInc`, `width` (with and without bounds-only flag), `duration` (with and without bounds-only), `numSpans`, `startSpan` / `endSpan` / `spanN`, `spans`,
- date/timestamp accessors: `numDates`, `startDate`, `endDate`, `dateN`, `dates`, `numTimestamps`, `startTimestamp`, `endTimestamp`, `timestampN`, `timestamps`,
- comparison operators (`=`, `<>`, `<`, `<=`, `>`, `>=`, `spanset_cmp`),
- transformations: `floor`, `ceil`, `round`, `shift`, `scale`, `shiftScale`.

Skipped — each with a one-line technical note:

| Section | Reason |
|---|---|
| `spanset('{}'::tstzspan[])` empty-array | DuckDB rejects PG `'{}'` cast; DuckDB-native `ARRAY[]::TSTZSPAN[]` reaches MEOS but the spanset constructor wrapper returns NULL. Same shape as set-level empty-array gap. |
| `tstzmultirange` casts | PG range types not portable to DuckDB |
| `splitNspans` / `splitEachNspans` (lowercase) | Naming divergence — `src/temporal/spanset.cpp` registers camelCase `splitNSpans` / `splitEachNSpans` only |
| `spanset_hash` / `spanset_hash_extended` | Not registered. MEOS symbols: `spanset_hash`, `spanset_hash_extended` |

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes (762 assertions across 14 test cases).

Drafted because three of the four skips can be cleared by trivial follow-ups (lowercase aliases, hash bindings, empty-array fix) that mirror the set-level work in PRs #8 / #10 / #11.