### PR TITLE
feat(bindings): spanset follow-ups — lowercase aliases, hash, empty-array fix

### DIFF
--- a/src/include/temporal/spanset_functions.hpp
+++ b/src/include/temporal/spanset_functions.hpp
@@ -45,6 +45,8 @@ struct SpansetFunctions{
     static void Spanset_mem_size(DataChunk &args, ExpressionState &state, Vector &result);
     static void Spanset_lower(DataChunk &args, ExpressionState &state, Vector &result);
     static void Spanset_upper(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Spanset_hash(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Spanset_hash_extended(DataChunk &args, ExpressionState &state, Vector &result);
     static void Spanset_lower_inc(DataChunk &args, ExpressionState &state, Vector &result);
     static void Spanset_upper_inc(DataChunk &args, ExpressionState &state, Vector &result);
     static void Numspanset_width(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/spanset.cpp
+++ b/src/temporal/spanset.cpp
@@ -336,6 +336,22 @@ void SpansetTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             ScalarFunction("splitEachNSpans", {spanset_type, LogicalType::INTEGER}, LogicalType::LIST(child_type), SpansetFunctions::Spanset_split_each_n_spans)
         );
 
+        // Lowercase aliases matching MobilityDB's SQL surface
+        loader.RegisterFunction(
+            ScalarFunction("splitNspans", {spanset_type, LogicalType::INTEGER}, LogicalType::LIST(child_type), SpansetFunctions::Spanset_split_n_spans)
+        );
+        loader.RegisterFunction(
+            ScalarFunction("splitEachNspans", {spanset_type, LogicalType::INTEGER}, LogicalType::LIST(child_type), SpansetFunctions::Spanset_split_each_n_spans)
+        );
+
+        // Hash
+        loader.RegisterFunction(
+            ScalarFunction("spanset_hash", {spanset_type}, LogicalType::UINTEGER, SpansetFunctions::Spanset_hash)
+        );
+        loader.RegisterFunction(
+            ScalarFunction("spanset_hash_extended", {spanset_type, LogicalType::BIGINT}, LogicalType::UBIGINT, SpansetFunctions::Spanset_hash_extended)
+        );
+
         // comparison operators
         loader.RegisterFunction(
             ScalarFunction("spanset_eq", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_eq)

--- a/src/temporal/spanset_functions.cpp
+++ b/src/temporal/spanset_functions.cpp
@@ -109,7 +109,7 @@ bool SpansetFunctions::Text_to_spanset(Vector &source, Vector &result, idx_t cou
 // --- Constructor ---
 void SpansetFunctions::Spanset_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &list_input = args.data[0];
-    auto meos_type = SpansetTypeMapping::GetMeosTypeFromAlias(result.GetType().ToString());    
+    auto meos_type = SpansetTypeMapping::GetMeosTypeFromAlias(result.GetType().ToString());
     UnaryExecutor::Execute<list_entry_t, string_t>(
         list_input, result, args.size(),
         [&](list_entry_t list_entry) -> string_t {
@@ -118,6 +118,10 @@ void SpansetFunctions::Spanset_constructor(DataChunk &args, ExpressionState &sta
 
             idx_t offset = list_entry.offset;
             idx_t length = list_entry.length;
+
+            if (length == 0) {
+                throw InvalidInputException("The input array cannot be empty");
+            }
 
             Span *spans = (Span *)malloc(sizeof(Span) * length);
             if (!spans) throw std::bad_alloc();
@@ -664,6 +668,39 @@ void SpansetFunctions::Spanset_upper(DataChunk &args, ExpressionState &state, Ve
         }
     }
 }    
+
+// --- spanset_hash / spanset_hash_extended ---
+
+void SpansetFunctions::Spanset_hash(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto &input = args.data[0];
+    UnaryExecutor::Execute<string_t, uint32_t>(
+        input, result, args.size(),
+        [&](string_t input_blob) -> uint32_t {
+            const uint8_t *data = (const uint8_t *)input_blob.GetData();
+            size_t size = input_blob.GetSize();
+            SpanSet *s = (SpanSet*)malloc(size);
+            memcpy(s, data, size);
+            uint32_t h = spanset_hash(s);
+            free(s);
+            return h;
+        });
+}
+
+void SpansetFunctions::Spanset_hash_extended(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto &input = args.data[0];
+    auto &seed_vec = args.data[1];
+    BinaryExecutor::Execute<string_t, int64_t, uint64_t>(
+        input, seed_vec, result, args.size(),
+        [&](string_t input_blob, int64_t seed) -> uint64_t {
+            const uint8_t *data = (const uint8_t *)input_blob.GetData();
+            size_t size = input_blob.GetSize();
+            SpanSet *s = (SpanSet*)malloc(size);
+            memcpy(s, data, size);
+            uint64_t h = spanset_hash_extended(s, (uint64_t)seed);
+            free(s);
+            return h;
+        });
+}
 
 // --- lower_inc ---
 


### PR DESCRIPTION
## Summary

Three independent fixes for spanset, mirroring the corresponding set-level work in PRs #8, #10, and #11:

### 1. Lowercase `splitNspans` / `splitEachNspans` aliases

Adds the lowercase forms for all five spanset types (intspanset/bigintspanset/floatspanset/datespanset/tstzspanset) pointing at the same `Spanset_split_n_spans` / `Spanset_split_each_n_spans` dispatchers as the existing camelCase registrations. The camelCase forms stay registered for back-compat.

### 2. `spanset_hash` / `spanset_hash_extended`

- `spanset_hash(<spanset>) -> UINTEGER` (MEOS `uint32 spanset_hash`)
- `spanset_hash_extended(<spanset>, BIGINT seed) -> UBIGINT` (MEOS `uint64 spanset_hash_extended`; seed cast to `uint64`)

Implementation mirrors `set_hash` / `span_hash`: copies the blob into a malloc'd `SpanSet`, calls MEOS, frees. Registered in the per-spanset-type loop in `src/temporal/spanset.cpp`.

### 3. Empty-array `spanset()` constructor

`Spanset_constructor` in `src/temporal/spanset_functions.cpp` built a `Span` array from a DuckDB list and called the MEOS constructor without checking length. On an empty input list MEOS returned NULL, surfacing later as `Invalid Input Error: Null pointer not allowed`. Adds a `length == 0` check that raises `InvalidInputException("The input array cannot be empty")`, matching the message MEOS itself uses.

## Smoke test

```sql
SELECT splitNspans(intspanset '{[1,2),[3,4),[5,6)}', 2);          -- ['[1, 4)', '[5, 6)']
SELECT spanset_hash(intspanset '{[1,2]}');                         -- 2065175519 (UINTEGER)
SELECT spanset_hash_extended(tstzspanset '{[2000-01-01,2000-01-02]}', 1);
                                                                   -- 13017976434127639608 (UBIGINT)
SELECT spanset(ARRAY[]::TSTZSPAN[]);
  -- Invalid Input Error: The input array cannot be empty
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.

Activates the corresponding skip blocks in `test/sql/parity/007_spanset.test` (open in PR #18) once both land.