### PR TITLE
test(parity): 022_temporal.test — representative sample of upstream temporal regression

### DIFF
--- a/test/sql/parity/022_temporal.test
+++ b/test/sql/parity/022_temporal.test
@@ -1,0 +1,280 @@
+# name: test/sql/parity/022_temporal.test
+# description: MobilityDB regression file 022_temporal.test.sql adapted for MobilityDuck
+# group: [sql]
+#
+# The upstream 022_temporal.test.sql is 3296 lines and walks every
+# scalar/accessor/restriction surface for tbool / tint / tfloat /
+# ttext. This port is REPRESENTATIVE rather than 1:1: each upstream
+# section gets 1-3 queries that exercise the surface; full per-type
+# coverage is left for follow-up files. Every query is either an
+# active assertion in MobilityDuck's display format or a `mode skip`
+# block with a one-line technical note about the missing symbol.
+
+require mobilityduck
+
+# =============================================================================
+# Utility functions
+# =============================================================================
+
+# MobilityDuck exposes `mobilityduck_version()` /
+# `mobilityduck_full_version()` instead of the MobilityDB names — the
+# brand divergence is intentional. PR #28.
+query I
+SELECT mobilityduck_version() LIKE 'MobilityDuck%';
+----
+true
+
+# =============================================================================
+# I/O — temporal instant
+# =============================================================================
+
+query I
+SELECT tbool 'TRUE@2012-01-01 08:00:00';
+----
+t@2012-01-01 08:00:00+00
+
+query I
+SELECT tint '1@2012-01-01 08:00:00';
+----
+1@2012-01-01 08:00:00+00
+
+query I
+SELECT tfloat '1@2012-01-01 08:00:00';
+----
+1@2012-01-01 08:00:00+00
+
+query I
+SELECT ttext 'AAA@2012-01-01 08:00:00';
+----
+"AAA"@2012-01-01 08:00:00+00
+
+statement error
+SELECT tbool '2@2012-01-01 08:00:00';
+----
+invalid input
+
+statement error
+SELECT tfloat 'ABC@2012-01-01 08:00:00';
+----
+invalid
+
+# =============================================================================
+# I/O — temporal discrete sequence
+# =============================================================================
+
+query I
+SELECT tint '{1@2001-01-01 08:00:00,2@2001-01-01 08:05:00,3@2001-01-01 08:06:00}';
+----
+{1@2001-01-01 08:00:00+00, 2@2001-01-01 08:05:00+00, 3@2001-01-01 08:06:00+00}
+
+query I
+SELECT tfloat '{1@2001-01-01 08:00:00,2@2001-01-01 08:05:00,3@2001-01-01 08:06:00}';
+----
+{1@2001-01-01 08:00:00+00, 2@2001-01-01 08:05:00+00, 3@2001-01-01 08:06:00+00}
+
+# =============================================================================
+# I/O — temporal continuous sequence
+# =============================================================================
+
+query I
+SELECT tint '[1@2001-01-01 08:00:00,2@2001-01-01 08:05:00,3@2001-01-01 08:06:00]';
+----
+[1@2001-01-01 08:00:00+00, 2@2001-01-01 08:05:00+00, 3@2001-01-01 08:06:00+00]
+
+query I
+SELECT tfloat '[1@2001-01-01 08:00:00,2@2001-01-01 08:05:00,3@2001-01-01 08:06:00]';
+----
+[1@2001-01-01 08:00:00+00, 2@2001-01-01 08:05:00+00, 3@2001-01-01 08:06:00+00]
+
+mode skip
+
+# Step interpolation prefix `Interp=Step;` parsing — verify against
+# MobilityDuck's parser; output likely includes the interp marker.
+query I
+SELECT tfloat 'Interp=Step;[1@2001-01-01 08:00:00,2@2001-01-01 08:05:00,3@2001-01-01 08:06:00]';
+----
+Interp=Step;[1@2001-01-01 00:00:00+00, ...]
+
+mode unskip
+
+# =============================================================================
+# Constructors (TINT / TFLOAT / TBOOL / TTEXT scalar+timestamptz)
+# =============================================================================
+
+query I
+SELECT TINT(42, '2023-01-01'::TIMESTAMPTZ);
+----
+42@2023-01-01 00:00:00+00
+
+query I
+SELECT TFLOAT(1.5, '2023-01-01'::TIMESTAMPTZ);
+----
+1.5@2023-01-01 00:00:00+00
+
+query I
+SELECT TBOOL(true, '2023-01-01'::TIMESTAMPTZ);
+----
+t@2023-01-01 00:00:00+00
+
+query I
+SELECT TTEXT('hello', '2023-01-01'::TIMESTAMPTZ);
+----
+"hello"@2023-01-01 00:00:00+00
+
+# =============================================================================
+# Conversion functions (tboolSeq, tintSeq, tfloatSeq, ttextSeq with interp)
+# =============================================================================
+
+mode skip
+
+# `tboolSeq(<temporal>, <interpolation_text>)` 2-arg form parsing;
+# verify discrete/step/linear interpolation arg handling in
+# src/temporal/temporal.cpp.
+query I
+SELECT tboolSeq(tbool '{true@2000-01-01, false@2000-01-02}', 'discrete');
+----
+{t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00}
+
+mode unskip
+
+# =============================================================================
+# Accessor functions
+# =============================================================================
+
+query I
+SELECT tempSubtype(tint '1@2012-01-01');
+----
+Instant
+
+query I
+SELECT interp(tfloat '[1@2001-01-01, 2@2001-01-02]');
+----
+Linear
+
+query I
+SELECT startValue(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]');
+----
+1
+
+query I
+SELECT endValue(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]');
+----
+3
+
+query I
+SELECT minValue(tint '[3@2001-01-01, 1@2001-01-02, 2@2001-01-03]');
+----
+1
+
+query I
+SELECT maxValue(tint '[3@2001-01-01, 1@2001-01-02, 2@2001-01-03]');
+----
+3
+
+query I
+SELECT valueN(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]', 2);
+----
+2
+
+query I
+SELECT duration(tint '[1@2001-01-01, 2@2001-01-02]');
+----
+1 day
+
+query I
+SELECT timeSpan(tint '[1@2001-01-01, 2@2001-01-02]');
+----
+[2001-01-01 00:00:00+00, 2001-01-02 00:00:00+00]
+
+# =============================================================================
+# Comparison
+# =============================================================================
+
+query I
+SELECT tint '1@2001-01-01' = tint '1@2001-01-01';
+----
+true
+
+query I
+SELECT tint '1@2001-01-01' <> tint '2@2001-01-01';
+----
+true
+
+query I
+SELECT temporal_cmp(tint '1@2001-01-01', tint '2@2001-01-01') < 0;
+----
+true
+
+# =============================================================================
+# Transformations
+# =============================================================================
+
+query I
+SELECT shiftValue(tint '[1@2001-01-01, 2@2001-01-02]', 10);
+----
+[11@2001-01-01 00:00:00+00, 12@2001-01-02 00:00:00+00]
+
+mode skip
+
+# scaleValue currently returns the input temporal unchanged for tint
+# inputs (verified: the 2-scaled tint is identical to the 1-scaled
+# version). MEOS symbol: tnumber_scale_value. Likely a MobilityDuck
+# wrapper bug rather than a missing binding.
+query I
+SELECT scaleValue(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]', 2);
+----
+[1@2001-01-01 00:00:00+00, 3@2001-01-02 00:00:00+00, 5@2001-01-03 00:00:00+00]
+
+mode unskip
+
+# =============================================================================
+# Restriction functions (atValues / minusValues / atTime / minusTime / atMin /
+# atMax / minusMin / minusMax / atTbox / minusTbox)
+# =============================================================================
+
+query I
+SELECT atValues(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]', 2);
+----
+{[2@2001-01-02 00:00:00+00, 2@2001-01-03 00:00:00+00)}
+
+query I
+SELECT atMin(tint '[3@2001-01-01, 1@2001-01-02, 2@2001-01-03]');
+----
+{[1@2001-01-02 00:00:00+00, 1@2001-01-03 00:00:00+00)}
+
+query I
+SELECT atMax(tint '[3@2001-01-01, 1@2001-01-02, 2@2001-01-03]');
+----
+{[3@2001-01-01 00:00:00+00, 3@2001-01-02 00:00:00+00)}
+
+# =============================================================================
+# Modification functions (insert / update / delete / append)
+# =============================================================================
+
+query I
+SELECT appendInstant(tint '[1@2001-01-01, 2@2001-01-02]', tint '3@2001-01-03');
+----
+[1@2001-01-01 00:00:00+00, 2@2001-01-02 00:00:00+00, 3@2001-01-03 00:00:00+00]
+
+mode skip
+
+# tsample / tprecision sampling functions — not yet checked for
+# binding presence. MEOS symbols: temporal_tsample, temporal_tprecision.
+query I
+SELECT tsample(tfloat '[1@2001-01-01, 2@2001-01-02]', '6 hours');
+----
+{1@2001-01-01 00:00:00+00, 1.25@2001-01-01 06:00:00+00, 1.5@2001-01-01 12:00:00+00, ...}
+
+mode unskip
+
+mode skip
+
+# Aggregate functions (tand, tor, tmin, tmax, tsum, tcount, twAvg agg
+# variant) — same architectural gap as 015_span_aggfuncs: MobilityDuck
+# registers no AggregateFunction infrastructure for temporal types.
+query I
+SELECT tcount(temp) FROM (VALUES (tint '1@2001-01-01'), (tint '2@2001-01-02')) t(temp);
+----
+{[2@2001-01-01 00:00:00+00, 2@2001-01-02 00:00:00+00]}
+
+mode unskip


### PR DESCRIPTION
## Summary

Ports a section-by-section representative sample of `mobilitydb/test/temporal/queries/022_temporal.test.sql` (3296 lines) to `test/sql/parity/022_temporal.test`. Each upstream section gets 1-3 queries that exercise the surface; full per-type coverage is left for follow-up files.

## Active coverage (31 assertions)

| Section | Surface |
|---|---|
| I/O instants | `tbool` / `tint` / `tfloat` / `ttext` literal parsing |
| I/O parse errors | `tbool '2@...'`, `tfloat 'ABC@...'` |
| I/O discrete sequence | `tint '{...}'`, `tfloat '{...}'` |
| I/O continuous sequence | `tint '[...]'`, `tfloat '[...]'` |
| Constructors | `TINT` / `TFLOAT` / `TBOOL` / `TTEXT` (value, timestamptz) |
| Accessors | `tempSubtype`, `interp`, `startValue`, `endValue`, `minValue`, `maxValue`, `valueN`, `duration`, `timeSpan` |
| Comparison | `=`, `<>`, `temporal_cmp` |
| Transformations | `shiftValue` |
| Restrictions | `atValues`, `atMin`, `atMax` |
| Modifications | `appendInstant` |

## Skip blocks (gap manifest)

| Section | Gap |
|---|---|
| Utility | `mobilitydb_version()` / `mobilitydb_full_version()` not registered |
| Step interpolation parsing | `Interp=Step;[...]` literal — verify output formatting before activating |
| `tboolSeq` / `tintSeq` / `tfloatSeq` / `ttextSeq` with `'discrete'` | 2-arg form needs verification |
| `scaleValue(tint, n)` | Returns input unchanged for tint (verified). Likely a MobilityDuck wrapper bug; MEOS symbol: `tnumber_scale_value` |
| `tsample` / `tprecision` | Not yet checked. MEOS: `temporal_tsample`, `temporal_tprecision` |
| Aggregates (`tcount`, `tand`, `tor`, `tmin`, `tmax`, `tsum`) | Same architectural gap as PR #21 — no `AggregateFunction` registrations in MobilityDuck |

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes (778 assertions across 14 test cases).

Drafted because this is a representative sample, not a full 1:1 port. Follow-up parity files (e.g. per-section per-type) will refine.