### PR TITLE
test(parity): batch 3 — time_ops / temporal_box / temporal_topops / temporal_waggfuncs

### DIFF
--- a/test/sql/parity/009_time_ops.test
+++ b/test/sql/parity/009_time_ops.test
@@ -1,0 +1,48 @@
+# name: test/sql/parity/009_time_ops.test
+# description: MobilityDB regression file 009_time_ops.test.sql adapted for MobilityDuck
+# group: [sql]
+#
+# Time-only specialisations of operators between dateset / datespan /
+# datespanset / tstzset / tstzspan / tstzspanset and timestamptz /
+# date — most of the surface is covered transitively by the existing
+# set / span / spanset operator registrations (containment, overlap,
+# union, intersection, difference, distance), which already pass in
+# the parity files for those types.
+#
+# What this file additionally exercises that is NOT yet bound:
+# - Time-shift arithmetic: `+ interval`, `- interval` between
+#   tstzset / tstzspan / tstzspanset and INTERVAL.
+# - Time-difference operator `<->` returning INTERVAL between
+#   timestamptz / tstzset / tstzspan / tstzspanset pairs (only the
+#   span-span / set-span / spanset-spanset distance variants are
+#   bound; the timestamptz-vs-time-type variants are not).
+
+require mobilityduck
+
+mode skip
+
+# tstzset / tstzspan / tstzspanset + interval (shift)
+
+query I
+SELECT tstzset '{2000-01-01}' + interval '1 day';
+----
+{"2000-01-02 00:00:00+00"}
+
+query I
+SELECT tstzspan '[2000-01-01, 2000-01-02]' + interval '1 day';
+----
+[2000-01-02 00:00:00+00, 2000-01-03 00:00:00+00]
+
+# Time-difference distance
+
+query I
+SELECT timestamptz '2000-01-01' <-> tstzset '{2000-01-03}';
+----
+2 days
+
+query I
+SELECT tstzspan '[2000-01-01, 2000-01-02]' <-> tstzspan '[2000-01-04, 2000-01-05]';
+----
+2 days
+
+mode unskip

--- a/test/sql/parity/032_temporal_box.test
+++ b/test/sql/parity/032_temporal_box.test
@@ -1,0 +1,35 @@
+# name: test/sql/parity/032_temporal_box.test
+# description: MobilityDB regression file 032_temporal_box.test.sql adapted for MobilityDuck
+# group: [sql]
+#
+# Whole file under `mode skip`. Exercises tbox-from-temporal
+# constructors: tbox(<tnumber>), tbox(<tnumber>, <tnumber>), and the
+# expand-temporal helpers expandValue / expandTime over tnumber. The
+# corresponding `tbox` accessor is registered in
+# src/temporal/temporal.cpp but the conversions / expand operations
+# are not.
+#
+# MEOS symbols: tnumber_to_tbox, tbox_expand_value,
+# tbox_expand_time. Plus the related tbox <-> tnumber comparison
+# casts.
+
+require mobilityduck
+
+mode skip
+
+query I
+SELECT tbox(tint '[1@2000-01-01, 5@2000-01-05]');
+----
+TBOXINT XT([1, 6),[2000-01-01 00:00:00+00, 2000-01-05 00:00:00+00])
+
+query I
+SELECT expandValue(tbox 'TBOXINT XT([1, 5],[2000-01-01, 2000-01-05])', 2);
+----
+TBOXINT XT([-1, 7],[2000-01-01 00:00:00+00, 2000-01-05 00:00:00+00])
+
+query I
+SELECT expandTime(tbox 'TBOXINT XT([1, 5],[2000-01-01, 2000-01-05])', interval '1 day');
+----
+TBOXINT XT([1, 6),[1999-12-31 00:00:00+00, 2000-01-06 00:00:00+00])
+
+mode unskip

--- a/test/sql/parity/032_temporal_topops.test
+++ b/test/sql/parity/032_temporal_topops.test
@@ -1,0 +1,56 @@
+# name: test/sql/parity/032_temporal_topops.test
+# description: MobilityDB regression file 032_temporal_topops.test.sql adapted for MobilityDuck
+# group: [sql]
+#
+# Whole file under `mode skip`. Topological operators (`@>`, `<@`,
+# `&&`, `-|-`) between temporal and {value, span, spanset, tbox,
+# temporal} pairs are not registered in MobilityDuck. The set / span
+# / spanset variants of these operators ARE bound (and pass in the
+# corresponding parity files), but the temporal-side variants are
+# not.
+#
+# MEOS symbols: contains_temporal_value, contained_value_temporal,
+# overlaps_temporal_temporal, adjacent_temporal_temporal — and the
+# matrix of (temporal × {value, tbox, tstzspan, temporal}) for each
+# of @>, <@, &&, -|-.
+
+require mobilityduck
+
+mode skip
+
+# temporal @> value
+
+query I
+SELECT tint '[1@2000-01-01, 5@2000-01-05]' @> 3;
+----
+true
+
+# value <@ temporal
+
+query I
+SELECT 3 <@ tint '[1@2000-01-01, 5@2000-01-05]';
+----
+true
+
+# temporal && temporal
+
+query I
+SELECT tint '[1@2000-01-01, 5@2000-01-05]' && tint '[3@2000-01-03, 7@2000-01-07]';
+----
+true
+
+# temporal @> tbox
+
+query I
+SELECT tint '[1@2000-01-01, 10@2000-01-10]' @> tbox 'TBOXINT XT([2,5],[2000-01-02,2000-01-05])';
+----
+true
+
+# temporal -|- tstzspan
+
+query I
+SELECT tint '[1@2000-01-01, 5@2000-01-05]' -|- tstzspan '[2000-01-05, 2000-01-06]';
+----
+true
+
+mode unskip

--- a/test/sql/parity/042_temporal_waggfuncs.test
+++ b/test/sql/parity/042_temporal_waggfuncs.test
@@ -1,0 +1,35 @@
+# name: test/sql/parity/042_temporal_waggfuncs.test
+# description: MobilityDB regression file 042_temporal_waggfuncs.test.sql adapted for MobilityDuck
+# group: [sql]
+#
+# Whole file under `mode skip`. Windowed temporal aggregates
+# (wcount, wmin, wmax, wsum, wavg) over a fixed-width interval
+# window. Same architectural blocker as PR #21 (015) and PR #24
+# (040): MobilityDuck has no AggregateFunction infrastructure, and
+# windowed aggregates additionally need DuckDB's WindowFunction
+# infrastructure (also unused in temporal/geo today).
+#
+# MEOS symbols: tnumber_wcount_transfn, tnumber_wmin_transfn,
+# tnumber_wmax_transfn, tnumber_wsum_transfn, tnumber_wavg_transfn,
+# plus the corresponding combinefn / finalfn for each.
+
+require mobilityduck
+
+mode skip
+
+query I
+SELECT wcount(temp, '1 day') FROM (VALUES (tint '[1@2000-01-01, 5@2000-01-05]')) t(temp);
+----
+{[1@2000-01-01 00:00:00+00, 1@2000-01-05 00:00:00+00]}
+
+query I
+SELECT wmin(temp, '1 day') FROM (VALUES (tint '[1@2000-01-01, 5@2000-01-05]')) t(temp);
+----
+{[1@2000-01-01 00:00:00+00, 5@2000-01-05 00:00:00+00]}
+
+query I
+SELECT wsum(temp, '1 day') FROM (VALUES (tint '[1@2000-01-01, 5@2000-01-05]')) t(temp);
+----
+{[1@2000-01-01 00:00:00+00, ...]}
+
+mode unskip


### PR DESCRIPTION
## Summary

Four more wholesale-skip manifest files completing the temporal directory's non-table-driven regression files.

| File | Surface | Notes |
|---|---|---|
| `009_time_ops.test` | Time-shift arithmetic (`+ interval`, `- interval`) and `<->` distance over time types | Span-span / set-span / spanset-spanset distance variants ARE bound (covered in `005_span_ops.test` parity); the timestamptz-with-time-type variants are not |
| `032_temporal_box.test` | `tbox(<tnumber>)`, `tbox(<tnumber>, <tnumber>)`, `expandValue` / `expandTime` over tbox | MEOS: `tnumber_to_tbox`, `tbox_expand_value`, `tbox_expand_time` |
| `032_temporal_topops.test` | `@>`, `<@`, `&&`, `-|-` between temporal × {value, tbox, tstzspan, temporal} | Set / span / spanset variants bound; temporal layer missing |
| `042_temporal_waggfuncs.test` | Windowed temporal aggregates: `wcount`, `wmin`, `wmax`, `wsum`, `wavg` | Aggregate-infra gap (PR #21, #24) PLUS no `WindowFunction` infrastructure |

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes (747 assertions across 22 test cases).

Drafted because every file is wholesale-skipped; the value is the manifest, not the assertions. With this PR, every non-table-driven file in `mobilitydb/test/temporal/queries/` has a parity port (PRs #6, #13, #17, #18, #21, #22, #23, #24, this).