### PR TITLE
feat(bindings): tbool boolean operators + ttext text functions (13 functions)

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -185,6 +185,26 @@ struct TemporalFunctions {
      ****************************************************/
     static void Tbool_when_true(DataChunk &args, ExpressionState &state, Vector &result);
 
+    /* ***************************************************
+     * Boolean operators on tbool
+     ****************************************************/
+    static void Tand_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tand_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tand_tbool_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tor_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tor_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tor_tbool_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tnot_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
+     * Text functions on ttext
+     ****************************************************/
+    static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ttext_upper(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ttext_initcap(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Textcat_text_ttext(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Textcat_ttext_text(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Textcat_ttext_ttext(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
      * Comparison operators

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1303,6 +1303,23 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             TemporalFunctions::Tnumber_avg_value
         )
     );
+
+    // tbool boolean operators
+    loader.RegisterFunction(ScalarFunction("&", {TemporalTypes::TBOOL(), LogicalType::BOOLEAN}, TemporalTypes::TBOOL(), TemporalFunctions::Tand_tbool_bool));
+    loader.RegisterFunction(ScalarFunction("&", {LogicalType::BOOLEAN, TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tand_bool_tbool));
+    loader.RegisterFunction(ScalarFunction("&", {TemporalTypes::TBOOL(), TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tand_tbool_tbool));
+    loader.RegisterFunction(ScalarFunction("|", {TemporalTypes::TBOOL(), LogicalType::BOOLEAN}, TemporalTypes::TBOOL(), TemporalFunctions::Tor_tbool_bool));
+    loader.RegisterFunction(ScalarFunction("|", {LogicalType::BOOLEAN, TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tor_bool_tbool));
+    loader.RegisterFunction(ScalarFunction("|", {TemporalTypes::TBOOL(), TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tor_tbool_tbool));
+    loader.RegisterFunction(ScalarFunction("~", {TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tnot_tbool));
+
+    // ttext text functions
+    loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
+    loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));
+    loader.RegisterFunction(ScalarFunction("initcap", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_initcap));
+    loader.RegisterFunction(ScalarFunction("||", {LogicalType::VARCHAR, TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_text_ttext));
+    loader.RegisterFunction(ScalarFunction("||", {TemporalTypes::TTEXT(), LogicalType::VARCHAR}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_ttext_text));
+    loader.RegisterFunction(ScalarFunction("||", {TemporalTypes::TTEXT(), TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_ttext_ttext));
 }
 
 struct TemporalUnnestBindData : public TableFunctionData {

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4614,6 +4614,157 @@ void TemporalFunctions::Tbool_when_true(DataChunk &args, ExpressionState &state,
 }
 
 /* ***************************************************
+ * Boolean operators on tbool
+ ****************************************************/
+
+namespace {
+
+// Helper: Temporal* -> string_t result blob
+inline string_t TemporalToBlob(Vector &result, Temporal *t) {
+    size_t sz = temporal_mem_size(t);
+    string_t out = StringVector::AddStringOrBlob(result, (const char *)t, sz);
+    free(t);
+    return out;
+}
+
+// Helper: copy string_t blob into a malloc'd Temporal*
+inline Temporal *BlobToTemporal(string_t blob) {
+    size_t sz = blob.GetSize();
+    uint8_t *copy = (uint8_t *)malloc(sz);
+    memcpy(copy, blob.GetData(), sz);
+    return reinterpret_cast<Temporal *>(copy);
+}
+
+template <typename Fn>
+void TemporalUnary(DataChunk &args, Vector &result, Fn fn) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) -> string_t {
+            Temporal *t = BlobToTemporal(blob);
+            Temporal *r = fn(t);
+            free(t);
+            if (!r) throw InvalidInputException("MEOS returned null");
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <typename T2, typename Fn>
+void TemporalBinaryV(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, T2, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, T2 v) -> string_t {
+            Temporal *t = BlobToTemporal(blob);
+            Temporal *r = fn(t, v);
+            free(t);
+            if (!r) throw InvalidInputException("MEOS returned null");
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <typename T1, typename Fn>
+void TemporalBinaryV1(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<T1, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](T1 v, string_t blob) -> string_t {
+            Temporal *t = BlobToTemporal(blob);
+            Temporal *r = fn(v, t);
+            free(t);
+            if (!r) throw InvalidInputException("MEOS returned null");
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <typename Fn>
+void TemporalBinaryTT(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a_blob, string_t b_blob) -> string_t {
+            Temporal *a = BlobToTemporal(a_blob);
+            Temporal *b = BlobToTemporal(b_blob);
+            Temporal *r = fn(a, b);
+            free(a);
+            free(b);
+            if (!r) throw InvalidInputException("MEOS returned null");
+            return TemporalToBlob(result, r);
+        });
+}
+
+inline text *TextFromBlob(string_t s) {
+    text *t = (text *)malloc(VARHDRSZ + s.GetSize());
+    SET_VARSIZE(t, VARHDRSZ + s.GetSize());
+    memcpy(VARDATA(t), s.GetData(), s.GetSize());
+    return t;
+}
+
+} // namespace
+
+void TemporalFunctions::Tand_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<bool>(args, result, [](Temporal *t, bool b) { return tand_tbool_bool(t, b); });
+}
+void TemporalFunctions::Tand_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<bool>(args, result, [](bool b, Temporal *t) { return tand_tbool_bool(t, b); });
+}
+void TemporalFunctions::Tand_tbool_tbool(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return tand_tbool_tbool(a, b); });
+}
+void TemporalFunctions::Tor_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<bool>(args, result, [](Temporal *t, bool b) { return tor_tbool_bool(t, b); });
+}
+void TemporalFunctions::Tor_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<bool>(args, result, [](bool b, Temporal *t) { return tor_tbool_bool(t, b); });
+}
+void TemporalFunctions::Tor_tbool_tbool(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return tor_tbool_tbool(a, b); });
+}
+void TemporalFunctions::Tnot_tbool(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tnot_tbool(t); });
+}
+
+/* ***************************************************
+ * Text functions on ttext
+ ****************************************************/
+
+void TemporalFunctions::Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return ttext_lower(t); });
+}
+void TemporalFunctions::Ttext_upper(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return ttext_upper(t); });
+}
+void TemporalFunctions::Ttext_initcap(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return ttext_initcap(t); });
+}
+
+void TemporalFunctions::Textcat_text_ttext(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t txt_str, string_t blob) -> string_t {
+            text *txt = TextFromBlob(txt_str);
+            Temporal *t = BlobToTemporal(blob);
+            Temporal *r = textcat_text_ttext(txt, t);
+            free(txt);
+            free(t);
+            if (!r) throw InvalidInputException("MEOS returned null");
+            return TemporalToBlob(result, r);
+        });
+}
+void TemporalFunctions::Textcat_ttext_text(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, string_t txt_str) -> string_t {
+            Temporal *t = BlobToTemporal(blob);
+            text *txt = TextFromBlob(txt_str);
+            Temporal *r = textcat_ttext_text(t, txt);
+            free(t);
+            free(txt);
+            if (!r) throw InvalidInputException("MEOS returned null");
+            return TemporalToBlob(result, r);
+        });
+}
+void TemporalFunctions::Textcat_ttext_ttext(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return textcat_ttext_ttext(a, b); });
+}
+
+/* ***************************************************
  * Workaround functions
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Adds 13 ScalarFunction registrations for two MobilityDB feature groups that were previously unbound in MobilityDuck.

### tbool boolean operators (7)

| SQL | MEOS |
|---|---|
| `tbool & BOOL`, `BOOL & tbool`, `tbool & tbool` | `tand_tbool_bool`, `tand_tbool_tbool` |
| `tbool | BOOL`, `BOOL | tbool`, `tbool | tbool` | `tor_tbool_bool`, `tor_tbool_tbool` |
| `~ tbool` | `tnot_tbool` |

### ttext text functions (6)

| SQL | MEOS |
|---|---|
| `lower(ttext)`, `upper(ttext)`, `initcap(ttext)` | `ttext_lower`, `ttext_upper`, `ttext_initcap` |
| `text || ttext`, `ttext || text`, `ttext || ttext` | `textcat_text_ttext`, `textcat_ttext_text`, `textcat_ttext_ttext` |

## Implementation

Adds five small templated wrapper helpers in `src/temporal/temporal_functions.cpp`:

- `TemporalToBlob` / `BlobToTemporal` — round-trip the `Temporal *` blob between MEOS and DuckDB string vectors
- `TemporalUnary<Fn>` — for `f(Temporal*) -> Temporal*` patterns
- `TemporalBinaryV<T2, Fn>` / `TemporalBinaryV1<T1, Fn>` — for value/temporal mixed-arg patterns
- `TemporalBinaryTT<Fn>` — for `f(Temporal*, Temporal*) -> Temporal*`
- `TextFromBlob` — for `string_t -> text *` (PG-text format) conversion

Each ScalarFunction body is now one or two lines. Same pattern can be reused for tnumber arithmetic (PR #24's `026` gap, ~96 registrations).

## Smoke test

```sql
SELECT TRUE & tbool 't@2000-01-01';                     -- t@2000-01-01 00:00:00+00
SELECT tbool 't@...' & tbool 'f@...';                   -- f@2000-01-01 00:00:00+00
SELECT ~ tbool 't@...';                                  -- f@2000-01-01 00:00:00+00
SELECT lower(ttext '"AAA"@...');                        -- "aaa"@2000-01-01 00:00:00+00
SELECT initcap(ttext '"hello world"@...');              -- "Hello World"@2000-01-01 00:00:00+00
SELECT ttext '"AA"@...' || ttext '"BB"@...';            -- "AABB"@2000-01-01 00:00:00+00
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes (747 assertions, 13 test cases).

When this lands, PR #24's `028_tbool_boolops.test` and `029_ttext_textfuncs.test` skip blocks both unwrap into ~10 active assertions each.