### PR TITLE
feat(bindings): mobilityduck_version() / mobilityduck_full_version()

### DIFF
--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -41,6 +41,7 @@ extern "C" {
     #include <stdarg.h>
     #include <geos_c.h>
     #include <meos.h>
+    #include <proj.h>
 }
 
 // OpenSSL linked through vcpkg
@@ -50,7 +51,7 @@ namespace duckdb {
 #include "spatial_ref_sys_csv.inc"
 
 // =====================================================================
-// 2. Utility: OpenSSL version scalar function
+// 2. Utility: version scalar functions
 // =====================================================================
 
 inline void MobilityduckOpenSSLVersionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -62,6 +63,49 @@ inline void MobilityduckOpenSSLVersionScalarFun(DataChunk &args, ExpressionState
 		        ", my linked OpenSSL version is " + OPENSSL_VERSION_TEXT
 		);
 	});
+}
+
+// Keep this short pin in sync with vcpkg_ports/meos/portfile.cmake's REF.
+// MEOS does not expose a runtime version symbol, so the build-time pin
+// is the most precise version stamp the extension can report.
+#ifndef MOBILITYDUCK_MEOS_PIN
+#define MOBILITYDUCK_MEOS_PIN "f11b7443e"
+#endif
+
+inline std::string MobilityduckShortVersion() {
+#ifdef EXT_VERSION_MOBILITYDUCK
+	return std::string("MobilityDuck ") + EXT_VERSION_MOBILITYDUCK;
+#else
+	return std::string("MobilityDuck");
+#endif
+}
+
+inline std::string MobilityduckFullVersion() {
+	std::string out = MobilityduckShortVersion();
+	out += ", linked MEOS ";
+	out += MOBILITYDUCK_MEOS_PIN;
+	out += ", DuckDB ";
+	out += DuckDB::LibraryVersion();
+	out += ", GEOS ";
+	out += GEOSversion();
+	out += ", PROJ ";
+	out += std::to_string(PROJ_VERSION_MAJOR) + "." +
+	       std::to_string(PROJ_VERSION_MINOR) + "." +
+	       std::to_string(PROJ_VERSION_PATCH);
+	// OPENSSL_VERSION_TEXT already starts with "OpenSSL", so just append it.
+	out += ", ";
+	out += OPENSSL_VERSION_TEXT;
+	return out;
+}
+
+inline void MobilityduckVersionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+	const std::string s = MobilityduckShortVersion();
+	result.Reference(Value(s));
+}
+
+inline void MobilityduckFullVersionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+	const std::string s = MobilityduckFullVersion();
+	result.Reference(Value(s));
 }
 
 // =====================================================================
@@ -178,6 +222,13 @@ static void LoadInternal(ExtensionLoader &loader) {
 	        MobilityduckOpenSSLVersionScalarFun
 	    );
 	loader.RegisterFunction( mobilityduck_openssl_version_scalar_function);
+
+	loader.RegisterFunction(ScalarFunction(
+		"mobilityduck_version", {}, LogicalType::VARCHAR,
+		MobilityduckVersionScalarFun));
+	loader.RegisterFunction(ScalarFunction(
+		"mobilityduck_full_version", {}, LogicalType::VARCHAR,
+		MobilityduckFullVersionScalarFun));
 
 	// Temporal and related types/functions
 	TemporalTypes::RegisterTypes(loader);


### PR DESCRIPTION
## Summary

Adds two SQL scalar functions mirroring the shape of MobilityDB's `mobilitydb_version()` / `mobilitydb_full_version()`, but reporting **MobilityDuck's own brand and its own dependency stack** rather than MobilityDB's:

```sql
SELECT mobilityduck_version();
-- MobilityDuck <git-sha>

SELECT mobilityduck_full_version();
-- MobilityDuck <git-sha>, linked MEOS f11b7443e, DuckDB v1.4.4,
--   GEOS 3.13.1-CAPI-1.19.2, PROJ 9.1.1, OpenSSL 3.5.2 5 Aug 2025
```

This matches the precedent of the existing `mobilityduck_openssl_version()` SQL scalar (registered in `LoadInternal`) and the `DUCKDB_EXTENSION_API mobilityduck_version()` C-extern hook.

## Why brand-divergent

MEOS does not expose a runtime version symbol, and `mobilitydb_version()` itself is a private MEOS internal symbol (declared in `meos/include/temporal/temporal.h`, not in the installed public headers). The right answer is a MobilityDuck-side equivalent that reports what's actually linked into THIS distribution.

The MEOS pin SHA is exposed via a `MOBILITYDUCK_MEOS_PIN` macro defaulting to the SHA in `vcpkg_ports/meos/portfile.cmake`'s `REF`; a build-system follow-up could thread the actual `REF` through CMake so the two stay in sync automatically.

## Parity-test consequence

The upstream MobilityDB regression query:
```sql
SELECT mobilitydb_version() LIKE 'MobilityDB%';
```
ports to MobilityDuck's brand as:
```sql
SELECT mobilityduck_version() LIKE 'MobilityDuck%';
```
A brand divergence, not a missing binding. PR #22's `022_temporal.test` parity-port skip block can be re-pointed to the duck-branded form when this lands.

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes (747 assertions, 13 test cases).
- Smoke: `SELECT mobilityduck_full_version();` returns the formatted string above.