### PR TITLE
feat(bindings): tnumber arithmetic operators (+, -, *, /) — 24 registrations

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -197,6 +197,30 @@ struct TemporalFunctions {
     static void Tnot_tbool(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Arithmetic operators on tnumber
+     ****************************************************/
+    static void Add_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Add_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Add_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Add_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Add_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Sub_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Sub_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Sub_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Sub_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Sub_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Mult_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Mult_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Mult_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Mult_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Mult_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Div_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Div_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Div_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Div_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Div_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1313,6 +1313,35 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("|", {TemporalTypes::TBOOL(), TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tor_tbool_tbool));
     loader.RegisterFunction(ScalarFunction("~", {TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tnot_tbool));
 
+    // tnumber arithmetic operators
+    loader.RegisterFunction(ScalarFunction("+", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Add_int_tint));
+    loader.RegisterFunction(ScalarFunction("+", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Add_tint_int));
+    loader.RegisterFunction(ScalarFunction("+", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("+", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("+", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Add_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("+", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_tnumber_tnumber));
+
+    loader.RegisterFunction(ScalarFunction("-", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Sub_int_tint));
+    loader.RegisterFunction(ScalarFunction("-", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Sub_tint_int));
+    loader.RegisterFunction(ScalarFunction("-", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("-", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("-", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Sub_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("-", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_tnumber_tnumber));
+
+    loader.RegisterFunction(ScalarFunction("*", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Mult_int_tint));
+    loader.RegisterFunction(ScalarFunction("*", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Mult_tint_int));
+    loader.RegisterFunction(ScalarFunction("*", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("*", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("*", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Mult_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("*", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_tnumber_tnumber));
+
+    loader.RegisterFunction(ScalarFunction("/", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Div_int_tint));
+    loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Div_tint_int));
+    loader.RegisterFunction(ScalarFunction("/", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Div_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_tnumber_tnumber));
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4721,6 +4721,74 @@ void TemporalFunctions::Tnot_tbool(DataChunk &args, ExpressionState &state, Vect
 }
 
 /* ***************************************************
+ * Arithmetic operators on tnumber
+ ****************************************************/
+
+void TemporalFunctions::Add_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<int32_t>(args, result, [](int32_t i, Temporal *t) { return add_int_tint(i, t); });
+}
+void TemporalFunctions::Add_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<int32_t>(args, result, [](Temporal *t, int32_t i) { return add_tint_int(t, i); });
+}
+void TemporalFunctions::Add_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<double>(args, result, [](double d, Temporal *t) { return add_float_tfloat(d, t); });
+}
+void TemporalFunctions::Add_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<double>(args, result, [](Temporal *t, double d) { return add_tfloat_float(t, d); });
+}
+void TemporalFunctions::Add_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return add_tnumber_tnumber(a, b); });
+}
+
+void TemporalFunctions::Sub_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<int32_t>(args, result, [](int32_t i, Temporal *t) { return sub_int_tint(i, t); });
+}
+void TemporalFunctions::Sub_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<int32_t>(args, result, [](Temporal *t, int32_t i) { return sub_tint_int(t, i); });
+}
+void TemporalFunctions::Sub_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<double>(args, result, [](double d, Temporal *t) { return sub_float_tfloat(d, t); });
+}
+void TemporalFunctions::Sub_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<double>(args, result, [](Temporal *t, double d) { return sub_tfloat_float(t, d); });
+}
+void TemporalFunctions::Sub_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return sub_tnumber_tnumber(a, b); });
+}
+
+void TemporalFunctions::Mult_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<int32_t>(args, result, [](int32_t i, Temporal *t) { return mult_int_tint(i, t); });
+}
+void TemporalFunctions::Mult_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<int32_t>(args, result, [](Temporal *t, int32_t i) { return mult_tint_int(t, i); });
+}
+void TemporalFunctions::Mult_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<double>(args, result, [](double d, Temporal *t) { return mult_float_tfloat(d, t); });
+}
+void TemporalFunctions::Mult_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<double>(args, result, [](Temporal *t, double d) { return mult_tfloat_float(t, d); });
+}
+void TemporalFunctions::Mult_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return mult_tnumber_tnumber(a, b); });
+}
+
+void TemporalFunctions::Div_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<int32_t>(args, result, [](int32_t i, Temporal *t) { return div_int_tint(i, t); });
+}
+void TemporalFunctions::Div_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<int32_t>(args, result, [](Temporal *t, int32_t i) { return div_tint_int(t, i); });
+}
+void TemporalFunctions::Div_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<double>(args, result, [](double d, Temporal *t) { return div_float_tfloat(d, t); });
+}
+void TemporalFunctions::Div_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<double>(args, result, [](Temporal *t, double d) { return div_tfloat_float(t, d); });
+}
+void TemporalFunctions::Div_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return div_tnumber_tnumber(a, b); });
+}
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Adds 24 ScalarFunction registrations for `tnumber` arithmetic across both base types (`tint`, `tfloat`) and all three operand-shape patterns:

| Operator | Shape | Type pair |
|---|---|---|
| `+`, `-`, `*`, `/` | value op tnumber | `INTEGER op tint`, `DOUBLE op tfloat` |
| `+`, `-`, `*`, `/` | tnumber op value | `tint op INTEGER`, `tfloat op DOUBLE` |
| `+`, `-`, `*`, `/` | tnumber op tnumber | `tint op tint`, `tfloat op tfloat` |

Backed by 20 MEOS bindings (`add_int_tint`, `add_tint_int`, `add_float_tfloat`, `add_tfloat_float`, `add_tnumber_tnumber`, and the same 5 variants for `sub_*`, `mult_*`, `div_*`).

## Implementation

Reuses the templated wrapper helpers from PR #27 (`TemporalUnary`, `TemporalBinaryV`, `TemporalBinaryV1`, `TemporalBinaryTT`), keeping each `ScalarFunction` body to one line. Each MEOS function is called via the matching helper template specialisation.

## Smoke test

```sql
SELECT 1 + tint '1@2000-01-01';                                 -- 2@2000-01-01 00:00:00+00
SELECT tint '[1@2000-01-01, 5@2000-01-05]' + 10;                -- [11@..., 15@...]
SELECT 2.5 * tfloat '1.5@2000-01-01';                            -- 3.75@2000-01-01 00:00:00+00
SELECT tfloat '[1@2000-01-01, 4@2000-01-04]' / 2;               -- [0.5@..., 2@...]
SELECT tint '[1@2000-01-01, 5@2000-01-05]' - tint '[1@2000-01-01, 1@2000-01-05]';
                                                                -- [0@..., 4@...]
SELECT tfloat '[2@2000-01-01, 4@2000-01-04]' * tfloat '[1@2000-01-01, 2@2000-01-04]';
                                                                -- linear-interpolated product
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.
- When this lands (after PR #27), PR #24's `026_tnumber_mathfuncs.test` skip block unwraps into ~6 active assertions covering value-op-tnumber, tnumber-op-value, and tnumber-op-tnumber across all 4 operators.

## Dependencies

**Stacked on PR #27** (reuses its `TemporalBinaryV` / `TemporalBinaryV1` / `TemporalBinaryTT` helpers). Merge order: #27 → this.