### PR TITLE
feat(bindings): tnumber unary functions (abs, derivative, degrees, radians)

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -221,6 +221,14 @@ struct TemporalFunctions {
     static void Div_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Unary tnumber functions
+     ****************************************************/
+    static void Tnumber_abs(DataChunk &args, ExpressionState &state, Vector &result);
+    // Temporal_derivative declared in the math-functions block below.
+    static void Tfloat_degrees(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tfloat_radians(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1342,6 +1342,14 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Div_tnumber_tnumber));
     loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_tnumber_tnumber));
 
+    // Unary tnumber functions
+    loader.RegisterFunction(ScalarFunction("abs", {TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Tnumber_abs));
+    loader.RegisterFunction(ScalarFunction("abs", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tnumber_abs));
+    loader.RegisterFunction(ScalarFunction("derivative", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Temporal_derivative));
+    loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
+    loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT(), LogicalType::BOOLEAN}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
+    loader.RegisterFunction(ScalarFunction("radians", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_radians));
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4789,6 +4789,31 @@ void TemporalFunctions::Div_tnumber_tnumber(DataChunk &args, ExpressionState &st
 }
 
 /* ***************************************************
+ * Unary tnumber functions
+ ****************************************************/
+
+void TemporalFunctions::Tnumber_abs(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tnumber_abs(t); });
+}
+
+// Temporal_derivative is implemented later in this file in the Math
+// functions block (existed before the unary-tnumber additions).
+
+void TemporalFunctions::Tfloat_degrees(DataChunk &args, ExpressionState &state, Vector &result) {
+    if (args.ColumnCount() == 2) {
+        TemporalBinaryV<bool>(args, result, [](Temporal *t, bool normalize) {
+            return tfloat_degrees(t, normalize);
+        });
+    } else {
+        TemporalUnary(args, result, [](Temporal *t) { return tfloat_degrees(t, false); });
+    }
+}
+
+void TemporalFunctions::Tfloat_radians(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tfloat_radians(t); });
+}
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Adds 6 ScalarFunction registrations for unary tnumber functions:

| SQL | MEOS |
|---|---|
| `abs(tint) -> tint` | `tnumber_abs` |
| `abs(tfloat) -> tfloat` | `tnumber_abs` |
| `derivative(tfloat) -> tfloat` | `temporal_derivative` |
| `degrees(tfloat) -> tfloat` | `tfloat_degrees(t, false)` |
| `degrees(tfloat, BOOL) -> tfloat` | `tfloat_degrees(t, normalize)` |
| `radians(tfloat) -> tfloat` | `tfloat_radians` |

`Temporal_derivative` was already declared and implemented in `src/temporal/temporal_functions.cpp` but was never registered; this PR registers it without duplicating the body.

Implementation reuses the templated wrapper helpers from PR #27 (`TemporalUnary` / `TemporalBinaryV<bool>`).

## Smoke test

```sql
SELECT abs(tint '[-1@2000-01-01, 2@2000-01-02]');
-- [1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00]

SELECT derivative(tfloat '[1@2000-01-01, 4@2000-01-04]');
-- Interp=Step;[1.157e-05@..., 1.157e-05@...]

SELECT degrees(tfloat '[0@2000-01-01, 3.14159@2000-01-02]');
-- [0@..., 179.9998479605043@...]

SELECT radians(tfloat '[0@2000-01-01, 180@2000-01-02]');
-- linear-radians value sequence
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.
- After PR #29 (tnumber arithmetic) and this lands, PR #24's `026_tnumber_mathfuncs.test` skip block fully unwraps.

## Dependencies

**Stacked on PR #29** (tnumber arithmetic). Merge order: #27 → #29 → this.