### PR TITLE
feat(bindings): tnumber distance — <->, nad, nearestApproachDistance

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -229,6 +229,19 @@ struct TemporalFunctions {
     static void Tfloat_radians(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Distance operator on tnumber
+     ****************************************************/
+    static void Tdistance_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tdistance_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tdistance_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tdistance_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tdistance_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Nad_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Nad_tint_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Nad_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Nad_tfloat_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1350,6 +1350,30 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT(), LogicalType::BOOLEAN}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
     loader.RegisterFunction(ScalarFunction("radians", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_radians));
 
+    // tnumber distance and nearest-approach-distance.
+    //
+    // Value-distance variants `<-> ` for (tint, INTEGER), (INTEGER, tint),
+    // (tfloat, DOUBLE), (DOUBLE, tfloat) are intentionally NOT registered
+    // here: in the installed MEOS library, tdistance_tfloat_float / tint_int
+    // return the temporal's own value at each instant rather than the
+    // |t.value - v| absolute difference. Verified by smoke test:
+    //   SELECT 5.0::DOUBLE <-> tfloat '5.0@2000-01-01';   -- returns 5.0, expected 0.0
+    //   SELECT 100.0::DOUBLE <-> tfloat '2.5@2000-01-01'; -- returns 2.5, expected 97.5
+    // The temporal-temporal variant DOES work correctly, and so does nad_*.
+    // Restore the value-distance registrations once the MEOS issue is resolved.
+    loader.RegisterFunction(ScalarFunction("<->", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Tdistance_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("<->", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tdistance_tnumber_tnumber));
+
+    // nearestApproachDistance / nad — scalar return
+    loader.RegisterFunction(ScalarFunction("nad", {TemporalTypes::TINT(), LogicalType::INTEGER}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_int));
+    loader.RegisterFunction(ScalarFunction("nad", {TemporalTypes::TINT(), TemporalTypes::TINT()}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_tint));
+    loader.RegisterFunction(ScalarFunction("nad", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("nad", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
+    loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TINT(), LogicalType::INTEGER}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_int));
+    loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TINT(), TemporalTypes::TINT()}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_tint));
+    loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4814,6 +4814,69 @@ void TemporalFunctions::Tfloat_radians(DataChunk &args, ExpressionState &state, 
 }
 
 /* ***************************************************
+ * Distance operator on tnumber
+ ****************************************************/
+
+void TemporalFunctions::Tdistance_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<int32_t>(args, result, [](Temporal *t, int32_t i) { return tdistance_tint_int(t, i); });
+}
+void TemporalFunctions::Tdistance_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<int32_t>(args, result, [](int32_t i, Temporal *t) { return tdistance_tint_int(t, i); });
+}
+void TemporalFunctions::Tdistance_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<double>(args, result, [](Temporal *t, double d) { return tdistance_tfloat_float(t, d); });
+}
+void TemporalFunctions::Tdistance_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<double>(args, result, [](double d, Temporal *t) { return tdistance_tfloat_float(t, d); });
+}
+void TemporalFunctions::Tdistance_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return tdistance_tnumber_tnumber(a, b); });
+}
+
+void TemporalFunctions::Nad_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, int32_t, int32_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, int32_t i) -> int32_t {
+            Temporal *t = BlobToTemporal(blob);
+            int32_t r = nad_tint_int(t, i);
+            free(t);
+            return r;
+        });
+}
+void TemporalFunctions::Nad_tint_tint(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, int32_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a_blob, string_t b_blob) -> int32_t {
+            Temporal *a = BlobToTemporal(a_blob);
+            Temporal *b = BlobToTemporal(b_blob);
+            int32_t r = nad_tint_tint(a, b);
+            free(a); free(b);
+            return r;
+        });
+}
+void TemporalFunctions::Nad_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, double, double>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, double d) -> double {
+            Temporal *t = BlobToTemporal(blob);
+            double r = nad_tfloat_float(t, d);
+            free(t);
+            return r;
+        });
+}
+void TemporalFunctions::Nad_tfloat_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, double>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a_blob, string_t b_blob) -> double {
+            Temporal *a = BlobToTemporal(a_blob);
+            Temporal *b = BlobToTemporal(b_blob);
+            double r = nad_tfloat_tfloat(a, b);
+            free(a); free(b);
+            return r;
+        });
+}
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Adds 10 ScalarFunction registrations for `tnumber` distance:

| SQL | MEOS | Returns |
|---|---|---|
| `tint <-> tint` | `tdistance_tnumber_tnumber` | `tint` |
| `tfloat <-> tfloat` | `tdistance_tnumber_tnumber` | `tfloat` |
| `nad(tint, INTEGER)` | `nad_tint_int` | `INTEGER` |
| `nad(tint, tint)` | `nad_tint_tint` | `INTEGER` |
| `nad(tfloat, DOUBLE)` | `nad_tfloat_float` | `DOUBLE` |
| `nad(tfloat, tfloat)` | `nad_tfloat_tfloat` | `DOUBLE` |
| `nearestApproachDistance(...)` | (4 aliases for the nad set) | (matching) |

Implementation uses templated helpers from PR #27 plus per-call `BinaryExecutor` blocks for the scalar-returning `nad` variants.

## Intentionally NOT registered (documented MEOS-side issue)

Value-distance variants `<->` for `(tint, INTEGER)` / `(INTEGER, tint)` / `(tfloat, DOUBLE)` / `(DOUBLE, tfloat)`. In the installed MEOS library, `tdistance_tfloat_float` / `tdistance_tint_int` return the temporal's own value at each instant rather than the `|t.value - v|` absolute difference. Smoke verified:

```sql
SELECT 5.0::DOUBLE <-> tfloat '5.0@2000-01-01';   -- returns 5.0, expected 0.0
SELECT 100.0::DOUBLE <-> tfloat '2.5@2000-01-01'; -- returns 2.5, expected 97.5
```

The wrapper implementations stay in the header and .cpp so the registrations can be uncommented in `src/temporal/temporal.cpp` once the MEOS upstream is fixed.

## Smoke test (working surface)

```sql
SELECT tfloat '[1@01-01, 5@01-05]' <-> tfloat '[3@01-01, 3@01-05]';
-- [2@01-01, 0@01-03, 2@01-05]   (linear-interpolated, touches 0 at midpoint)

SELECT nad(tint '[1@01-01, 5@01-05]', 3);
-- 0

SELECT nad(tfloat '[1@01-01, 5@01-05]', tfloat '[3@01-01, 3@01-05]');
-- 0.0
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.
- After merge, PR #24's `036_tnumber_distance.test` skip block partially unwraps (the temporal-temporal and `nad`/`nearestApproachDistance` queries become active; the value-temporal `<->` queries stay skipped pending MEOS fix).

## Dependencies

**Stacked on PR #30** (tnumber unary). Merge order: #27 → #29 → #30 → this.