### PR TITLE
feat(bindings): temporal topological predicates (@>, <@, &&, -|-) — 96 registrations

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -242,6 +242,22 @@ struct TemporalFunctions {
     static void Nad_tfloat_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Temporal topological predicates
+     ****************************************************/
+    static void Contains_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contains_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contains_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1374,6 +1374,27 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
     loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
 
+    // Temporal topological predicates: temporal × temporal (4 ops × 4 type pairs)
+    for (auto &t1 : TemporalTypes::AllTypes()) {
+        for (auto &t2 : TemporalTypes::AllTypes()) {
+            loader.RegisterFunction(ScalarFunction("@>", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("<@", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("&&", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("-|-", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_temporal));
+        }
+    }
+    // Temporal × tstzspan (and the reverse direction)
+    for (auto &t : TemporalTypes::AllTypes()) {
+        loader.RegisterFunction(ScalarFunction("@>", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("<@", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("&&", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("-|-", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("@>", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("<@", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("&&", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("-|-", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tstzspan_temporal));
+    }
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4877,6 +4877,97 @@ void TemporalFunctions::Nad_tfloat_tfloat(DataChunk &args, ExpressionState &stat
 }
 
 /* ***************************************************
+ * Temporal topological predicates
+ ****************************************************/
+
+namespace {
+
+template <typename Fn>
+void TempTempBoolPred(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a_blob, string_t b_blob) -> bool {
+            Temporal *a = BlobToTemporal(a_blob);
+            Temporal *b = BlobToTemporal(b_blob);
+            bool r = fn(a, b);
+            free(a); free(b);
+            return r;
+        });
+}
+
+template <typename Fn>
+void TempSpanBoolPred(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, string_t span_blob) -> bool {
+            Temporal *t = BlobToTemporal(blob);
+            // Spans are blobs of fixed size; copy into a Span struct.
+            Span *s = (Span *)malloc(span_blob.GetSize());
+            memcpy(s, span_blob.GetData(), span_blob.GetSize());
+            bool r = fn(t, s);
+            free(t); free(s);
+            return r;
+        });
+}
+
+template <typename Fn>
+void SpanTempBoolPred(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t span_blob, string_t blob) -> bool {
+            Span *s = (Span *)malloc(span_blob.GetSize());
+            memcpy(s, span_blob.GetData(), span_blob.GetSize());
+            Temporal *t = BlobToTemporal(blob);
+            bool r = fn(s, t);
+            free(s); free(t);
+            return r;
+        });
+}
+
+} // namespace
+
+void TemporalFunctions::Contains_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return contains_temporal_temporal(a, b); });
+}
+void TemporalFunctions::Contained_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return contained_temporal_temporal(a, b); });
+}
+void TemporalFunctions::Overlaps_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return overlaps_temporal_temporal(a, b); });
+}
+void TemporalFunctions::Adjacent_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return adjacent_temporal_temporal(a, b); });
+}
+
+void TemporalFunctions::Contains_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return contains_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Contained_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return contained_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Overlaps_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return overlaps_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Adjacent_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return adjacent_temporal_tstzspan(t, s); });
+}
+
+// Span-temporal direction: MEOS only exposes the temporal-span functions,
+// so we swap arg order and use the inverse op (contains <-> contained).
+void TemporalFunctions::Contains_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return contained_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Contained_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return contains_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Overlaps_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return overlaps_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Adjacent_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return adjacent_temporal_tstzspan(t, s); });
+}
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Adds 96 ScalarFunction registrations covering the temporal-side topological-operator surface, backed by 12 wrapper implementations:

| Surface | Count | MEOS |
|---|---|---|
| temporal × temporal | 64 (4 ops × 4×4 type pairs) | `contains/contained/overlaps/adjacent_temporal_temporal` |
| temporal × tstzspan | 16 | `contains/contained/overlaps/adjacent_temporal_tstzspan` |
| tstzspan × temporal | 16 | reverse-order via inverse op (e.g. `tstzspan @> temporal` → `contained_temporal_tstzspan(t, s)`) |

All four temporal types (tbool, tint, tfloat, ttext) × all four operators (`@>`, `<@`, `&&`, `-|-`).

Three small templated helpers added (`TempTempBoolPred`, `TempSpanBoolPred`, `SpanTempBoolPred`) to keep each ScalarFunction body to one line.

## Smoke test

```sql
SELECT tint '[1@01-01, 5@01-05]' @> tint '[3@01-02, 4@01-04]';   -- true
SELECT tint '[3@01-02, 4@01-04]' <@ tint '[1@01-01, 5@01-05]';   -- true
SELECT tint '[1@01-01, 5@01-05]' && tint '[3@01-03, 7@01-07]';   -- true
SELECT tint '[1@01-01, 5@01-05]' @> tstzspan '[01-02, 01-04]';   -- true
SELECT tstzspan '[01-01, 01-10]' @> tint '[2@01-02, 4@01-04]';   -- true
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.
- After merge, PR #25's `032_temporal_topops.test` skip block partially unwraps. The remaining unbound surface is the value-temporal direction (`temporal @> value` / `value <@ temporal`) and the `tnumber × {numspan, tbox}` set — separate follow-ups.

## Dependencies

**Stacked on PR #31** (tnumber distance). Merge order: #27 → #29 → #30 → #31 → this.