### PR TITLE
feat(bindings): temporal time-position predicates (before, after, overbefore, overafter)

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -258,6 +258,22 @@ struct TemporalFunctions {
     static void Adjacent_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Temporal time-position predicates (<<#, #>>, &<#, #&>)
+     ****************************************************/
+    static void Before_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void After_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overbefore_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overafter_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Before_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void After_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overbefore_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overafter_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Before_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void After_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overbefore_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overafter_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1395,6 +1395,30 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(ScalarFunction("-|-", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tstzspan_temporal));
     }
 
+    // Temporal time-position predicates registered as named functions:
+    // DuckDB's parser does not accept `#` as an operator-name character,
+    // so the upstream MobilityDB operators `<<#`, `#>>`, `&<#`, `#&>`
+    // are unreachable from SQL. The named-function forms `before`,
+    // `after`, `overbefore`, `overafter` provide equivalent behaviour.
+    for (auto &t1 : TemporalTypes::AllTypes()) {
+        for (auto &t2 : TemporalTypes::AllTypes()) {
+            loader.RegisterFunction(ScalarFunction("before",     {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("after",      {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("overbefore", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("overafter",  {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_temporal));
+        }
+    }
+    for (auto &t : TemporalTypes::AllTypes()) {
+        loader.RegisterFunction(ScalarFunction("before",     {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("after",      {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("overbefore", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("overafter",  {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("before",     {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Before_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("after",      {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::After_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("overbefore", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("overafter",  {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_tstzspan_temporal));
+    }
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4968,6 +4968,52 @@ void TemporalFunctions::Adjacent_tstzspan_temporal(DataChunk &args, ExpressionSt
 }
 
 /* ***************************************************
+ * Temporal time-position predicates
+ ****************************************************/
+
+void TemporalFunctions::Before_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return before_temporal_temporal(a, b); });
+}
+void TemporalFunctions::After_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return after_temporal_temporal(a, b); });
+}
+void TemporalFunctions::Overbefore_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return overbefore_temporal_temporal(a, b); });
+}
+void TemporalFunctions::Overafter_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return overafter_temporal_temporal(a, b); });
+}
+
+void TemporalFunctions::Before_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return before_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::After_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return after_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Overbefore_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return overbefore_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Overafter_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return overafter_temporal_tstzspan(t, s); });
+}
+
+// Reverse direction: tstzspan op temporal — swap inverse op,
+// e.g. `tstzspan <<# temporal` (span is before temporal) means
+// the temporal is after the span: after_temporal_tstzspan(t, s).
+void TemporalFunctions::Before_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return after_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::After_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return before_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Overbefore_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return overafter_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Overafter_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return overbefore_temporal_tstzspan(t, s); });
+}
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Adds 96 ScalarFunction registrations for temporal time-position predicates as **named functions**. DuckDB's parser does not accept `#` as an operator-name character, so the upstream MobilityDB operators `<<#`, `#>>`, `&<#`, `#&>` cannot be reached from SQL — the named forms `before` / `after` / `overbefore` / `overafter` provide equivalent behaviour.

| Surface | Count | MEOS |
|---|---|---|
| temporal × temporal | 64 (4 ops × 4×4 type pairs) | `before/after/overbefore/overafter_temporal_temporal` |
| temporal × tstzspan | 16 (4 ops × 4 temporal × 1 span) | `before/after/overbefore/overafter_temporal_tstzspan` |
| tstzspan × temporal | 16 (4 ops × 4 reverse direction) | reverse-order via inverse op |

Backed by 12 wrapper functions reusing `TempTempBoolPred` / `TempSpanBoolPred` / `SpanTempBoolPred` from PR #32.

For reverse direction, MEOS only exposes the temporal-span variant; the reverse calls swap arg order and use the inverse op (`span before temporal` → `after_temporal_tstzspan(t, s)`, etc.).

## Smoke test

```sql
SELECT before(tint '[1@01-01, 2@01-02]', tint '[3@01-05, 4@01-06]');     -- true
SELECT after (tint '[3@01-05, 4@01-06]', tint '[1@01-01, 2@01-02]');     -- true
SELECT overbefore(tint '[1@01-01, 2@01-02]', tint '[2@01-02, 3@01-03]'); -- true
SELECT before(tint '[1@01-01, 5@01-05]', tstzspan '[01-08, 01-10]');     -- true
SELECT after (tstzspan '[01-01, 01-03]', tint '[5@01-05, 6@01-06]');     -- false
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.
- After merge, PR #25's `034_temporal_posops.test` skip block partially unwraps for the time-position subset. The spatial-side `<<` / `>>` / `&<` / `&>` (parseable by DuckDB) and value-temporal direction stay separate follow-ups.

## Dependencies

**Stacked on PR #32** (temporal topological predicates). Merge order: #27 → #29 → #30 → #31 → #32 → this.