### PR TITLE
feat(bindings): ever/always equality and inequality (eq, ne) — named functions

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -274,6 +274,45 @@ struct TemporalFunctions {
     static void Overafter_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Ever / always equality and inequality
+     * (DuckDB parser cannot accept ?= / #= operator names,
+     * so the upstream MobilityDB ?= / ?<> / #= / #<> map to
+     * named functions ever_eq / ever_ne / always_eq / always_ne.)
+     ****************************************************/
+    // ever_eq
+    static void Ever_eq_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_eq_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_eq_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_eq_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_eq_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_eq_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_eq_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // always_eq
+    static void Always_eq_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_eq_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_eq_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_eq_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_eq_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_eq_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_eq_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // ever_ne
+    static void Ever_ne_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ne_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ne_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ne_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ne_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ne_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ne_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // always_ne
+    static void Always_ne_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ne_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ne_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ne_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ne_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ne_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ne_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1419,6 +1419,25 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(ScalarFunction("overafter",  {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_tstzspan_temporal));
     }
 
+    // Ever / always equality and inequality (named functions; DuckDB
+    // parser does not accept ?= / #= operator names).
+#define REG_EA(NAME, FN)                                                                                                                                                          \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::BOOLEAN,        TemporalTypes::TBOOL()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_bool_tbool));             \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TBOOL(),      LogicalType::BOOLEAN},     LogicalType::BOOLEAN, TemporalFunctions::FN##_tbool_bool));             \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::INTEGER,        TemporalTypes::TINT()},    LogicalType::BOOLEAN, TemporalFunctions::FN##_int_tint));               \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),       LogicalType::INTEGER},     LogicalType::BOOLEAN, TemporalFunctions::FN##_tint_int));               \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::DOUBLE,         TemporalTypes::TFLOAT()},  LogicalType::BOOLEAN, TemporalFunctions::FN##_float_tfloat));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(),     LogicalType::DOUBLE},      LogicalType::BOOLEAN, TemporalFunctions::FN##_tfloat_float));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),       TemporalTypes::TINT()},    LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));      \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(),     TemporalTypes::TFLOAT()},  LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));      \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TBOOL(),      TemporalTypes::TBOOL()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));
+
+    REG_EA("ever_eq",   Ever_eq)
+    REG_EA("always_eq", Always_eq)
+    REG_EA("ever_ne",   Ever_ne)
+    REG_EA("always_ne", Always_ne)
+#undef REG_EA
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5014,6 +5014,82 @@ void TemporalFunctions::Overafter_tstzspan_temporal(DataChunk &args, ExpressionS
 }
 
 /* ***************************************************
+ * Ever / always equality and inequality
+ ****************************************************/
+
+namespace {
+
+// MEOS ever/always functions return int (1=true, 0=false, -1=null/error).
+template <typename TVal, typename Fn>
+void EverAlwaysValTemp(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<TVal, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](TVal v, string_t blob) -> bool {
+            Temporal *t = BlobToTemporal(blob);
+            int r = fn(v, t);
+            free(t);
+            return r > 0;
+        });
+}
+
+template <typename TVal, typename Fn>
+void EverAlwaysTempVal(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, TVal, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, TVal v) -> bool {
+            Temporal *t = BlobToTemporal(blob);
+            int r = fn(t, v);
+            free(t);
+            return r > 0;
+        });
+}
+
+template <typename Fn>
+void EverAlwaysTempTemp(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a_blob, string_t b_blob) -> bool {
+            Temporal *a = BlobToTemporal(a_blob);
+            Temporal *b = BlobToTemporal(b_blob);
+            int r = fn(a, b);
+            free(a); free(b);
+            return r > 0;
+        });
+}
+
+} // namespace
+
+#define DEFINE_EA_OP(NAME, MEOS_NAME)                                                                  \
+void TemporalFunctions::NAME##_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result) {   \
+    EverAlwaysValTemp<bool>(args, result, [](bool b, Temporal *t) { return MEOS_NAME##_bool_tbool(b, t); });   \
+}                                                                                                      \
+void TemporalFunctions::NAME##_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result) {   \
+    EverAlwaysTempVal<bool>(args, result, [](Temporal *t, bool b) { return MEOS_NAME##_tbool_bool(t, b); });   \
+}                                                                                                      \
+void TemporalFunctions::NAME##_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {     \
+    EverAlwaysValTemp<int32_t>(args, result, [](int32_t i, Temporal *t) { return MEOS_NAME##_int_tint(i, t); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {     \
+    EverAlwaysTempVal<int32_t>(args, result, [](Temporal *t, int32_t i) { return MEOS_NAME##_tint_int(t, i); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) { \
+    EverAlwaysValTemp<double>(args, result, [](double d, Temporal *t) { return MEOS_NAME##_float_tfloat(d, t); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) { \
+    EverAlwaysTempVal<double>(args, result, [](Temporal *t, double d) { return MEOS_NAME##_tfloat_float(t, d); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) { \
+    EverAlwaysTempTemp(args, result, [](Temporal *a, Temporal *b) { return MEOS_NAME##_temporal_temporal(a, b); }); \
+}
+
+DEFINE_EA_OP(Ever_eq, ever_eq)
+DEFINE_EA_OP(Always_eq, always_eq)
+DEFINE_EA_OP(Ever_ne, ever_ne)
+DEFINE_EA_OP(Always_ne, always_ne)
+
+#undef DEFINE_EA_OP
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Adds 36 ScalarFunction registrations covering the temporal-comparison ever/always surface for `tbool` / `tint` / `tfloat`:

| Function | Variants |
|---|---|
| `ever_eq`, `always_eq`, `ever_ne`, `always_ne` | value op temporal, temporal op value, temporal op temporal × {bool/tbool, int/tint, double/tfloat} |

DuckDB's parser does not accept `?` or `#` as operator-name characters, so the upstream MobilityDB operators `?=`, `?<>`, `#=`, `#<>` are unreachable from SQL — these named functions provide equivalent behaviour.

## Implementation

- 28 wrapper functions (4 named functions × 7 type-pair shapes) generated via a `DEFINE_EA_OP` macro that calls the matching MEOS function.
- 3 small templated helpers (`EverAlwaysValTemp`, `EverAlwaysTempVal`, `EverAlwaysTempTemp`).
- MEOS returns `int` (1=true, 0=false, -1=null/error), mapped to bool via `r > 0`.

## Out of scope (follow-up)

- `ttext_text` / `text_ttext` variants (would need PG-text encoding plumbing)
- Ordering ops (`ever_lt`, `always_lt`, etc.) — same shape; can extend the `DEFINE_EA_OP` macro

## Smoke test

```sql
SELECT ever_eq(1, tint '[1@01-01, 2@01-02]');                  -- true
SELECT always_eq(tint '[1@01-01, 1@01-02]', 1);                -- true
SELECT ever_ne(tint '[1@01-01, 2@01-02]', 1);                  -- true
SELECT always_ne(tint '[1@01-01, 2@01-02]', 5);                -- true
SELECT ever_eq(tbool '[t@01-01, f@01-02]', true);              -- true
SELECT ever_eq(tfloat '[1.5@01-01, 2.5@01-02]', 2.0::DOUBLE);  -- true
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.
- After merge, PR #24's `030_temporal_compops.test` skip block partially unwraps (the eq/ne queries become active when re-pointed from `?=` / `#=` to `ever_eq` / `always_eq` etc.). Ordering ops stay separate follow-up.

## Dependencies

**Stacked on PR #33** (temporal time-position predicates). Merge order: #27 → #29 → #30 → #31 → #32 → #33 → this.