### PR TITLE
feat(bindings): ever/always ordering (lt, le, gt, ge) — named functions

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -312,6 +312,56 @@ struct TemporalFunctions {
     static void Always_ne_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
     static void Always_ne_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
 
+    // Ever / always ordering (no tbool — boolean has no ordering)
+    // ever_lt
+    static void Ever_lt_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_lt_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_lt_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_lt_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_lt_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // always_lt
+    static void Always_lt_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_lt_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_lt_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_lt_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_lt_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // ever_le
+    static void Ever_le_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_le_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_le_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_le_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_le_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // always_le
+    static void Always_le_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_le_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_le_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_le_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_le_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // ever_gt
+    static void Ever_gt_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_gt_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_gt_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_gt_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_gt_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // always_gt
+    static void Always_gt_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_gt_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_gt_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_gt_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_gt_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // ever_ge
+    static void Ever_ge_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ge_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ge_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ge_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ge_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // always_ge
+    static void Always_ge_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ge_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ge_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ge_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ge_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+
     /* ***************************************************
      * Text functions on ttext
      ****************************************************/

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1438,6 +1438,25 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     REG_EA("always_ne", Always_ne)
 #undef REG_EA
 
+    // Ordering ever/always — no tbool variant (booleans have no ordering)
+#define REG_EA_ORD(NAME, FN)                                                                                                                                          \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::INTEGER,    TemporalTypes::TINT()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_int_tint));        \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),   LogicalType::INTEGER},    LogicalType::BOOLEAN, TemporalFunctions::FN##_tint_int));        \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, LogicalType::BOOLEAN, TemporalFunctions::FN##_float_tfloat));    \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     LogicalType::BOOLEAN, TemporalFunctions::FN##_tfloat_float));    \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),   TemporalTypes::TINT()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal)); \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));
+
+    REG_EA_ORD("ever_lt",   Ever_lt)
+    REG_EA_ORD("always_lt", Always_lt)
+    REG_EA_ORD("ever_le",   Ever_le)
+    REG_EA_ORD("always_le", Always_le)
+    REG_EA_ORD("ever_gt",   Ever_gt)
+    REG_EA_ORD("always_gt", Always_gt)
+    REG_EA_ORD("ever_ge",   Ever_ge)
+    REG_EA_ORD("always_ge", Always_ge)
+#undef REG_EA_ORD
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5089,6 +5089,35 @@ DEFINE_EA_OP(Always_ne, always_ne)
 
 #undef DEFINE_EA_OP
 
+// Ordering ops have no tbool variant.
+#define DEFINE_EA_ORD_OP(NAME, MEOS_NAME)                                                              \
+void TemporalFunctions::NAME##_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {     \
+    EverAlwaysValTemp<int32_t>(args, result, [](int32_t i, Temporal *t) { return MEOS_NAME##_int_tint(i, t); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {     \
+    EverAlwaysTempVal<int32_t>(args, result, [](Temporal *t, int32_t i) { return MEOS_NAME##_tint_int(t, i); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) { \
+    EverAlwaysValTemp<double>(args, result, [](double d, Temporal *t) { return MEOS_NAME##_float_tfloat(d, t); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) { \
+    EverAlwaysTempVal<double>(args, result, [](Temporal *t, double d) { return MEOS_NAME##_tfloat_float(t, d); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) { \
+    EverAlwaysTempTemp(args, result, [](Temporal *a, Temporal *b) { return MEOS_NAME##_temporal_temporal(a, b); }); \
+}
+
+DEFINE_EA_ORD_OP(Ever_lt, ever_lt)
+DEFINE_EA_ORD_OP(Always_lt, always_lt)
+DEFINE_EA_ORD_OP(Ever_le, ever_le)
+DEFINE_EA_ORD_OP(Always_le, always_le)
+DEFINE_EA_ORD_OP(Ever_gt, ever_gt)
+DEFINE_EA_ORD_OP(Always_gt, always_gt)
+DEFINE_EA_ORD_OP(Ever_ge, ever_ge)
+DEFINE_EA_ORD_OP(Always_ge, always_ge)
+
+#undef DEFINE_EA_ORD_OP
+
 /* ***************************************************
  * Text functions on ttext
  ****************************************************/


### PR DESCRIPTION
## Summary

Adds 48 ScalarFunction registrations covering the temporal-comparison ever/always ordering surface for `tint` / `tfloat` (no `tbool` — booleans have no ordering).

| Functions | Variants |
|---|---|
| `ever_lt`, `always_lt`, `ever_le`, `always_le`, `ever_gt`, `always_gt`, `ever_ge`, `always_ge` | value op temporal, temporal op value, temporal op temporal × {int/tint, double/tfloat} |

DuckDB's parser does not accept `?` or `#` as operator-name characters, so the upstream MobilityDB operators (`?<`, `?<=`, `?>`, `?>=`, `#<`, `#<=`, `#>`, `#>=`) are unreachable from SQL — these named functions provide equivalent behaviour.

## Implementation

- 40 wrapper functions (8 named functions × 5 type-pair shapes) generated via a `DEFINE_EA_ORD_OP` macro.
- Reuses the `EverAlwaysValTemp` / `EverAlwaysTempVal` / `EverAlwaysTempTemp` helpers + 1 macro added in PR #34 (eq+ne).

## Smoke test

```sql
SELECT ever_lt(tint '[1@01-01, 5@01-05]', 3);                 -- true
SELECT always_lt(tint '[1@01-01, 2@01-02]', 3);               -- true
SELECT ever_le(0, tint '[1@01-01, 2@01-02]');                 -- true
SELECT always_ge(tint '[5@01-01, 10@01-05]', 5);              -- true
SELECT ever_gt(tfloat '[1.5@01-01, 2.5@01-02]', 2.0::DOUBLE); -- true
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.
- Combined with PR #34, PR #24's `030_temporal_compops.test` skip block fully unwraps for tnumber types when re-pointed from `?<` / `#<` etc. to the equivalent named functions. ttext ordering stays a separate follow-up.

## Dependencies

**Stacked on PR #34** (ever/always eq+ne). Merge order: #27 → #29 → #30 → #31 → #32 → #33 → #34 → this.