### PR TITLE
feat(bindings): temporal similarity measures (Frechet, DTW, Hausdorff)

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -363,6 +363,13 @@ struct TemporalFunctions {
     static void Always_ge_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Similarity measures
+     ****************************************************/
+    static void Temporal_frechet_distance(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_dyntimewarp_distance(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_hausdorff_distance(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1457,6 +1457,14 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     REG_EA_ORD("always_ge", Always_ge)
 #undef REG_EA_ORD
 
+    // Similarity measures (tnumber × tnumber)
+    for (auto &t : {TemporalTypes::TINT(), TemporalTypes::TFLOAT()}) {
+        loader.RegisterFunction(ScalarFunction("frechetDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_frechet_distance));
+        loader.RegisterFunction(ScalarFunction("discreteFrechet", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_frechet_distance));
+        loader.RegisterFunction(ScalarFunction("dynTimeWarp",     {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_dyntimewarp_distance));
+        loader.RegisterFunction(ScalarFunction("hausdorffDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_hausdorff_distance));
+    }
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5119,6 +5119,37 @@ DEFINE_EA_ORD_OP(Always_ge, always_ge)
 #undef DEFINE_EA_ORD_OP
 
 /* ***************************************************
+ * Similarity measures
+ ****************************************************/
+
+namespace {
+
+template <typename Fn>
+void TempTempDoublePred(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, double>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a_blob, string_t b_blob) -> double {
+            Temporal *a = BlobToTemporal(a_blob);
+            Temporal *b = BlobToTemporal(b_blob);
+            double r = fn(a, b);
+            free(a); free(b);
+            return r;
+        });
+}
+
+} // namespace
+
+void TemporalFunctions::Temporal_frechet_distance(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempDoublePred(args, result, [](Temporal *a, Temporal *b) { return temporal_frechet_distance(a, b); });
+}
+void TemporalFunctions::Temporal_dyntimewarp_distance(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempDoublePred(args, result, [](Temporal *a, Temporal *b) { return temporal_dyntimewarp_distance(a, b); });
+}
+void TemporalFunctions::Temporal_hausdorff_distance(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempDoublePred(args, result, [](Temporal *a, Temporal *b) { return temporal_hausdorff_distance(a, b); });
+}
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Adds 8 ScalarFunction registrations for temporal similarity measures:

| Function | MEOS |
|---|---|
| `frechetDistance(t1, t2)` | `temporal_frechet_distance` |
| `discreteFrechet(t1, t2)` | `temporal_frechet_distance` (alias) |
| `dynTimeWarp(t1, t2)` | `temporal_dyntimewarp_distance` |
| `hausdorffDistance(t1, t2)` | `temporal_hausdorff_distance` |

For each: `(tint, tint)` and `(tfloat, tfloat)` registrations.

Implementation uses 3 thin wrappers + a single `TempTempDoublePred` templated helper.

`similarityPath` (table-returning, alignment) is intentionally NOT included — needs DuckDB `TableFunction` infrastructure (separate follow-up tracked in PR #23).

## Smoke test

```sql
SELECT frechetDistance(tfloat '[1@01-01, 2@01-02]', tfloat '[2@01-01, 3@01-02]');   -- 1.0
SELECT discreteFrechet(tfloat '[1@01-01, 2@01-02]', tfloat '[2@01-01, 3@01-02]');   -- 1.0
SELECT dynTimeWarp(tfloat '[1@01-01, 2@01-02]', tfloat '[2@01-01, 3@01-02]');       -- 2.0
SELECT hausdorffDistance(tfloat '[1@01-01, 5@01-05]', tfloat '[3@01-01, 3@01-05]'); -- 2.0
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.
- After merge, PR #23's `038_temporal_similarity.test` skip block partially unwraps (the scalar measures activate; `similarityPath` stays gated on TableFunction infra).

## Dependencies

**Stacked on PR #35** (ever/always ordering). Merge order: #27 → #29 → #30 → #31 → #32 → #33 → #34 → #35 → this.