### PR TITLE
feat(bindings): tnumber × {numspan, tbox} topological predicates

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -370,6 +370,27 @@ struct TemporalFunctions {
     static void Temporal_hausdorff_distance(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * tnumber × {numspan, tbox} topological predicates
+     * (4 ops × 4 type-pair shapes = 16 wrappers)
+     ****************************************************/
+    static void Contains_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contains_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contains_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contains_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1465,6 +1465,45 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(ScalarFunction("hausdorffDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_hausdorff_distance));
     }
 
+    // tnumber × {numspan, tbox} topological predicates (4 ops × 8 shape pairs)
+    {
+        auto tint  = TemporalTypes::TINT();
+        auto tflt  = TemporalTypes::TFLOAT();
+        auto ispan = SpanTypes::INTSPAN();
+        auto fspan = SpanTypes::FLOATSPAN();
+        auto tbox  = TboxType::TBOX();
+
+        // tnumber × numspan
+        loader.RegisterFunction(ScalarFunction("@>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("<@",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("&&",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("-|-", {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("@>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("<@",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("&&",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("-|-", {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
+        // numspan × tnumber
+        loader.RegisterFunction(ScalarFunction("@>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("<@",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("&&",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("-|-", {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("@>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("<@",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("&&",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("-|-", {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
+        // tnumber × tbox
+        for (auto &t : {tint, tflt}) {
+            loader.RegisterFunction(ScalarFunction("@>",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("<@",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("&&",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("-|-", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("@>",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("<@",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("&&",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("-|-", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tbox_tnumber));
+        }
+    }
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5150,6 +5150,95 @@ void TemporalFunctions::Temporal_hausdorff_distance(DataChunk &args, ExpressionS
 }
 
 /* ***************************************************
+ * tnumber × {numspan, tbox} topological predicates
+ ****************************************************/
+
+namespace {
+
+template <typename Box, typename Fn>
+void TempBoxBoolPred(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, string_t box_blob) -> bool {
+            Temporal *t = BlobToTemporal(blob);
+            Box *b = (Box *)malloc(box_blob.GetSize());
+            memcpy(b, box_blob.GetData(), box_blob.GetSize());
+            bool r = fn(t, b);
+            free(t); free(b);
+            return r;
+        });
+}
+
+template <typename Box, typename Fn>
+void BoxTempBoolPred(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t box_blob, string_t blob) -> bool {
+            Box *b = (Box *)malloc(box_blob.GetSize());
+            memcpy(b, box_blob.GetData(), box_blob.GetSize());
+            Temporal *t = BlobToTemporal(blob);
+            bool r = fn(b, t);
+            free(b); free(t);
+            return r;
+        });
+}
+
+} // namespace
+
+// tnumber × numspan (uses Span)
+void TemporalFunctions::Contains_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return contains_tnumber_numspan(t, s); });
+}
+void TemporalFunctions::Contained_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return contained_tnumber_numspan(t, s); });
+}
+void TemporalFunctions::Overlaps_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return overlaps_tnumber_numspan(t, s); });
+}
+void TemporalFunctions::Adjacent_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return adjacent_tnumber_numspan(t, s); });
+}
+// numspan × tnumber
+void TemporalFunctions::Contains_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return contains_numspan_tnumber(s, t); });
+}
+void TemporalFunctions::Contained_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return contained_numspan_tnumber(s, t); });
+}
+void TemporalFunctions::Overlaps_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return overlaps_numspan_tnumber(s, t); });
+}
+void TemporalFunctions::Adjacent_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return adjacent_numspan_tnumber(s, t); });
+}
+// tnumber × tbox (uses TBox)
+void TemporalFunctions::Contains_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return contains_tnumber_tbox(t, b); });
+}
+void TemporalFunctions::Contained_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return contained_tnumber_tbox(t, b); });
+}
+void TemporalFunctions::Overlaps_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return overlaps_tnumber_tbox(t, b); });
+}
+void TemporalFunctions::Adjacent_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return adjacent_tnumber_tbox(t, b); });
+}
+// tbox × tnumber
+void TemporalFunctions::Contains_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return contains_tbox_tnumber(b, t); });
+}
+void TemporalFunctions::Contained_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return contained_tbox_tnumber(b, t); });
+}
+void TemporalFunctions::Overlaps_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return overlaps_tbox_tnumber(b, t); });
+}
+void TemporalFunctions::Adjacent_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return adjacent_tbox_tnumber(b, t); });
+}
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Adds 32 ScalarFunction registrations for the tnumber-vs-box topological surface, backed by 16 wrapper functions:

| Operator | Pairs |
|---|---|
| `@>`, `<@`, `&&`, `-|-` | tnumber × numspan, numspan × tnumber (intspan↔tint, floatspan↔tfloat) |
| `@>`, `<@`, `&&`, `-|-` | tnumber × tbox, tbox × tnumber (both base types) |

## MEOS bindings (16)

`contains/contained/overlaps/adjacent_tnumber_numspan` + `_numspan_tnumber` + `_tnumber_tbox` + `_tbox_tnumber` — all available in MEOS public API.

Two new templated helpers added (`TempBoxBoolPred`, `BoxTempBoolPred`) for handling blobs-as-fixed-size-struct (Span / TBox).

## Smoke test

```sql
SELECT tint '[1@01-01, 5@01-05]' @> intspan '[2, 4]';                          -- true
SELECT intspan '[1, 10]' @> tint '[2@01-01, 4@01-05]';                         -- true
SELECT tfloat '[1@01-01, 5@01-05]' && floatspan '[3, 8]';                      -- true
SELECT tint '[1@01-01, 5@01-05]' -|- intspan '[6, 10]';                        -- true
SELECT tint '[1@01-01, 10@01-10]' @> tbox 'TBOXINT XT([2,5],[01-02,01-05])';   -- true
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.
- After merge, PR #25's `032_temporal_topops.test` skip block fully unwraps for the tnumber-numspan / tnumber-tbox surface.

## Dependencies

**Stacked on PR #36** (temporal similarity). Merge order: #27 → #29 → #30 → #31 → #32 → #33 → #34 → #35 → #36 → this.