### PR TITLE
feat(bindings): tnumber position predicates (<<, >>, &<, &>)

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -391,6 +391,32 @@ struct TemporalFunctions {
     static void Adjacent_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * tnumber × {numspan, tbox} position predicates
+     * (4 ops × 4 type-pair shapes × 2 directions)
+     ****************************************************/
+    static void Left_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Right_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overleft_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overright_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Left_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Right_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overleft_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overright_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Left_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Right_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overleft_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overright_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Left_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Right_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overleft_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overright_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    // tnumber × tnumber position
+    static void Left_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Right_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overleft_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overright_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1502,6 +1502,43 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             loader.RegisterFunction(ScalarFunction("&&",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tbox_tnumber));
             loader.RegisterFunction(ScalarFunction("-|-", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tbox_tnumber));
         }
+
+        // Position ops (<<, >>, &<, &>) — same surface
+        loader.RegisterFunction(ScalarFunction("<<",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction(">>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("&<",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("&>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("<<",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction(">>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("&<",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("&>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("<<",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Left_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction(">>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Right_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("&<",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("&>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overright_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("<<",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Left_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction(">>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Right_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("&<",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("&>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_numspan_tnumber));
+        for (auto &t : {tint, tflt}) {
+            loader.RegisterFunction(ScalarFunction("<<", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction(">>", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("&<", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("&>", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("<<", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Left_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction(">>", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Right_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("&<", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("&>", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tbox_tnumber));
+        }
+        // tnumber × tnumber (same base type)
+        loader.RegisterFunction(ScalarFunction("<<", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction(">>", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("&<", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("&>", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("<<", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction(">>", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("&<", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("&>", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
     }
 
     // ttext text functions

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5239,6 +5239,48 @@ void TemporalFunctions::Adjacent_tbox_tnumber(DataChunk &args, ExpressionState &
 }
 
 /* ***************************************************
+ * tnumber × {numspan, tbox} position predicates
+ ****************************************************/
+
+#define DEFINE_NUMSPAN_POS(NAME, MEOS_FN) \
+void TemporalFunctions::NAME##_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) { \
+    TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return MEOS_FN##_tnumber_numspan(t, s); }); \
+} \
+void TemporalFunctions::NAME##_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) { \
+    BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return MEOS_FN##_numspan_tnumber(s, t); }); \
+}
+
+#define DEFINE_TBOX_POS(NAME, MEOS_FN) \
+void TemporalFunctions::NAME##_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) { \
+    TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return MEOS_FN##_tnumber_tbox(t, b); }); \
+} \
+void TemporalFunctions::NAME##_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) { \
+    BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return MEOS_FN##_tbox_tnumber(b, t); }); \
+}
+
+#define DEFINE_TNUM_POS(NAME, MEOS_FN) \
+void TemporalFunctions::NAME##_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result) { \
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return MEOS_FN##_tnumber_tnumber(a, b); }); \
+}
+
+DEFINE_NUMSPAN_POS(Left, left)
+DEFINE_NUMSPAN_POS(Right, right)
+DEFINE_NUMSPAN_POS(Overleft, overleft)
+DEFINE_NUMSPAN_POS(Overright, overright)
+DEFINE_TBOX_POS(Left, left)
+DEFINE_TBOX_POS(Right, right)
+DEFINE_TBOX_POS(Overleft, overleft)
+DEFINE_TBOX_POS(Overright, overright)
+DEFINE_TNUM_POS(Left, left)
+DEFINE_TNUM_POS(Right, right)
+DEFINE_TNUM_POS(Overleft, overleft)
+DEFINE_TNUM_POS(Overright, overright)
+
+#undef DEFINE_NUMSPAN_POS
+#undef DEFINE_TBOX_POS
+#undef DEFINE_TNUM_POS
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Adds 40 ScalarFunction registrations for tnumber value-position predicates, backed by 20 wrapper functions:

| Op | tnumber × numspan | tnumber × tbox | tnumber × tnumber |
|---|---|---|---|
| `<<`, `>>`, `&<`, `&>` | (intspan↔tint, floatspan↔tfloat) × both directions | (tint, tfloat) × both directions | tint-tint, tfloat-tfloat |

## MEOS bindings (20)

`left/right/overleft/overright_tnumber_numspan` + `_numspan_tnumber` + `_tnumber_tbox` + `_tbox_tnumber` + `_tnumber_tnumber` — all in MEOS public API.

Implementation reuses the `TempBoxBoolPred` / `BoxTempBoolPred` / `TempTempBoolPred` helpers from PR #37 plus three new macros (`DEFINE_NUMSPAN_POS`, `DEFINE_TBOX_POS`, `DEFINE_TNUM_POS`) that generate the wrappers.

## Smoke test

```sql
SELECT tint '[1@01-01, 5@01-05]' << intspan '[10, 20]';                  -- true
SELECT intspan '[10, 20]' >> tint '[1@01-01, 5@01-05]';                  -- true
SELECT tfloat '[1@01-01, 5@01-05]' &< floatspan '[6, 10]';               -- true
SELECT tint '[1@01-01, 5@01-05]' << tbox 'TBOXINT XT([10,20],...)';      -- true
SELECT tint '[1@01-01, 5@01-05]' << tint '[10@01-01, 20@01-05]';         -- true
```

## Test plan

- `make release` then `TZ=UTC ./build/release/test/unittest "<proj>/test/*"` — full suite passes.
- After merge, PR #25's `034_temporal_posops.test` skip block clears for the value-position subset (the time-position `<<#`/`#>>` etc. were closed by PR #33).

## Dependencies

**Stacked on PR #37** (tnumber topological). Merge order: ... #36 → #37 → this.