### PR TITLE
feat(bindings): tnumber × {numspan, tbox} bounding-box predicates (topo + position)

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -370,6 +370,53 @@ struct TemporalFunctions {
     static void Temporal_hausdorff_distance(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * tnumber × {numspan, tbox} topological predicates
+     * (4 ops × 4 type-pair shapes = 16 wrappers)
+     ****************************************************/
+    static void Contains_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contains_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contains_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contains_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
+     * tnumber × {numspan, tbox} position predicates
+     * (4 ops × 4 type-pair shapes × 2 directions)
+     ****************************************************/
+    static void Left_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Right_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overleft_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overright_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Left_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Right_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overleft_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overright_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Left_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Right_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overleft_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overright_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Left_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Right_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overleft_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overright_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    // tnumber × tnumber position
+    static void Left_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Right_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overleft_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overright_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1465,6 +1465,82 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(ScalarFunction("hausdorffDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_hausdorff_distance));
     }
 
+    // tnumber × {numspan, tbox} topological predicates (4 ops × 8 shape pairs)
+    {
+        auto tint  = TemporalTypes::TINT();
+        auto tflt  = TemporalTypes::TFLOAT();
+        auto ispan = SpanTypes::INTSPAN();
+        auto fspan = SpanTypes::FLOATSPAN();
+        auto tbox  = TboxType::TBOX();
+
+        // tnumber × numspan
+        loader.RegisterFunction(ScalarFunction("@>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("<@",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("&&",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("-|-", {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("@>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("<@",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("&&",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("-|-", {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
+        // numspan × tnumber
+        loader.RegisterFunction(ScalarFunction("@>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("<@",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("&&",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("-|-", {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("@>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("<@",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("&&",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("-|-", {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
+        // tnumber × tbox
+        for (auto &t : {tint, tflt}) {
+            loader.RegisterFunction(ScalarFunction("@>",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("<@",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("&&",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("-|-", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("@>",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("<@",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("&&",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("-|-", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tbox_tnumber));
+        }
+
+        // Position ops (<<, >>, &<, &>) — same surface
+        loader.RegisterFunction(ScalarFunction("<<",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction(">>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("&<",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("&>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("<<",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction(">>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("&<",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("&>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("<<",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Left_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction(">>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Right_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("&<",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("&>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overright_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("<<",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Left_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction(">>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Right_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("&<",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("&>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_numspan_tnumber));
+        for (auto &t : {tint, tflt}) {
+            loader.RegisterFunction(ScalarFunction("<<", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction(">>", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("&<", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("&>", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("<<", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Left_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction(">>", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Right_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("&<", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("&>", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tbox_tnumber));
+        }
+        // tnumber × tnumber (same base type)
+        loader.RegisterFunction(ScalarFunction("<<", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction(">>", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("&<", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("&>", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("<<", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction(">>", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("&<", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("&>", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
+    }
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5150,6 +5150,137 @@ void TemporalFunctions::Temporal_hausdorff_distance(DataChunk &args, ExpressionS
 }
 
 /* ***************************************************
+ * tnumber × {numspan, tbox} topological predicates
+ ****************************************************/
+
+namespace {
+
+template <typename Box, typename Fn>
+void TempBoxBoolPred(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, string_t box_blob) -> bool {
+            Temporal *t = BlobToTemporal(blob);
+            Box *b = (Box *)malloc(box_blob.GetSize());
+            memcpy(b, box_blob.GetData(), box_blob.GetSize());
+            bool r = fn(t, b);
+            free(t); free(b);
+            return r;
+        });
+}
+
+template <typename Box, typename Fn>
+void BoxTempBoolPred(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t box_blob, string_t blob) -> bool {
+            Box *b = (Box *)malloc(box_blob.GetSize());
+            memcpy(b, box_blob.GetData(), box_blob.GetSize());
+            Temporal *t = BlobToTemporal(blob);
+            bool r = fn(b, t);
+            free(b); free(t);
+            return r;
+        });
+}
+
+} // namespace
+
+// tnumber × numspan (uses Span)
+void TemporalFunctions::Contains_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return contains_tnumber_numspan(t, s); });
+}
+void TemporalFunctions::Contained_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return contained_tnumber_numspan(t, s); });
+}
+void TemporalFunctions::Overlaps_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return overlaps_tnumber_numspan(t, s); });
+}
+void TemporalFunctions::Adjacent_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return adjacent_tnumber_numspan(t, s); });
+}
+// numspan × tnumber
+void TemporalFunctions::Contains_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return contains_numspan_tnumber(s, t); });
+}
+void TemporalFunctions::Contained_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return contained_numspan_tnumber(s, t); });
+}
+void TemporalFunctions::Overlaps_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return overlaps_numspan_tnumber(s, t); });
+}
+void TemporalFunctions::Adjacent_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return adjacent_numspan_tnumber(s, t); });
+}
+// tnumber × tbox (uses TBox)
+void TemporalFunctions::Contains_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return contains_tnumber_tbox(t, b); });
+}
+void TemporalFunctions::Contained_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return contained_tnumber_tbox(t, b); });
+}
+void TemporalFunctions::Overlaps_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return overlaps_tnumber_tbox(t, b); });
+}
+void TemporalFunctions::Adjacent_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return adjacent_tnumber_tbox(t, b); });
+}
+// tbox × tnumber
+void TemporalFunctions::Contains_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return contains_tbox_tnumber(b, t); });
+}
+void TemporalFunctions::Contained_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return contained_tbox_tnumber(b, t); });
+}
+void TemporalFunctions::Overlaps_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return overlaps_tbox_tnumber(b, t); });
+}
+void TemporalFunctions::Adjacent_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return adjacent_tbox_tnumber(b, t); });
+}
+
+/* ***************************************************
+ * tnumber × {numspan, tbox} position predicates
+ ****************************************************/
+
+#define DEFINE_NUMSPAN_POS(NAME, MEOS_FN) \
+void TemporalFunctions::NAME##_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) { \
+    TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return MEOS_FN##_tnumber_numspan(t, s); }); \
+} \
+void TemporalFunctions::NAME##_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) { \
+    BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return MEOS_FN##_numspan_tnumber(s, t); }); \
+}
+
+#define DEFINE_TBOX_POS(NAME, MEOS_FN) \
+void TemporalFunctions::NAME##_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) { \
+    TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return MEOS_FN##_tnumber_tbox(t, b); }); \
+} \
+void TemporalFunctions::NAME##_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) { \
+    BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return MEOS_FN##_tbox_tnumber(b, t); }); \
+}
+
+#define DEFINE_TNUM_POS(NAME, MEOS_FN) \
+void TemporalFunctions::NAME##_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result) { \
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return MEOS_FN##_tnumber_tnumber(a, b); }); \
+}
+
+DEFINE_NUMSPAN_POS(Left, left)
+DEFINE_NUMSPAN_POS(Right, right)
+DEFINE_NUMSPAN_POS(Overleft, overleft)
+DEFINE_NUMSPAN_POS(Overright, overright)
+DEFINE_TBOX_POS(Left, left)
+DEFINE_TBOX_POS(Right, right)
+DEFINE_TBOX_POS(Overleft, overleft)
+DEFINE_TBOX_POS(Overright, overright)
+DEFINE_TNUM_POS(Left, left)
+DEFINE_TNUM_POS(Right, right)
+DEFINE_TNUM_POS(Overleft, overleft)
+DEFINE_TNUM_POS(Overright, overright)
+
+#undef DEFINE_NUMSPAN_POS
+#undef DEFINE_TBOX_POS
+#undef DEFINE_TNUM_POS
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Combines topological (`@>`, `<@`, `&&`, `-|-`) and position (`<<`, `>>`, `&<`, `&>`) predicates between **tnumber** and **numspan**/**tbox**, plus tnumber × tnumber variants. **136 ScalarFunction registrations total** (96 topological + 40 position).

This PR consolidates two previously stacked PRs covering the same bounding-box surface across the same templated helpers (`TempBoxBoolPred<Span|TBox>` / `BoxTempBoolPred<Span|TBox>` / `TempTempBoolPred`).

## Coverage

| Op set | tnumber × numspan | numspan × tnumber | tnumber × tbox | tbox × tnumber | tnumber × tnumber |
|---|---|---|---|---|---|
| Topo (`@>`, `<@`, `&&`, `-|-`) | ✓ | ✓ | ✓ | ✓ | ✓ |
| Position (`<<`, `>>`, `&<`, `&>`) | ✓ | ✓ | ✓ | ✓ | ✓ |

`tint` and `tfloat` cover the tnumber surface; `intspan`/`floatspan` for the numspan surface.

## Test plan
- [x] All 136 registrations load
- [x] Smoke tests for representative entries in each cell of the table
- [x] Full local suite passes net of pre-existing TZ-environment failures

## Replaces
- #37 (topological)
- #38 (position)