### PR TITLE
feat(bindings): ever/always comparison predicates (eq, ne, lt, le, gt, ge)

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -274,6 +274,95 @@ struct TemporalFunctions {
     static void Overafter_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Ever / always equality and inequality
+     * (DuckDB parser cannot accept ?= / #= operator names,
+     * so the upstream MobilityDB ?= / ?<> / #= / #<> map to
+     * named functions ever_eq / ever_ne / always_eq / always_ne.)
+     ****************************************************/
+    // ever_eq
+    static void Ever_eq_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_eq_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_eq_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_eq_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_eq_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_eq_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_eq_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // always_eq
+    static void Always_eq_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_eq_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_eq_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_eq_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_eq_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_eq_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_eq_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // ever_ne
+    static void Ever_ne_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ne_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ne_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ne_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ne_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ne_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ne_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // always_ne
+    static void Always_ne_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ne_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ne_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ne_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ne_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ne_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ne_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+
+    // Ever / always ordering (no tbool — boolean has no ordering)
+    // ever_lt
+    static void Ever_lt_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_lt_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_lt_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_lt_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_lt_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // always_lt
+    static void Always_lt_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_lt_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_lt_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_lt_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_lt_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // ever_le
+    static void Ever_le_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_le_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_le_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_le_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_le_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // always_le
+    static void Always_le_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_le_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_le_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_le_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_le_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // ever_gt
+    static void Ever_gt_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_gt_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_gt_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_gt_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_gt_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // always_gt
+    static void Always_gt_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_gt_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_gt_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_gt_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_gt_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // ever_ge
+    static void Ever_ge_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ge_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ge_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ge_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ever_ge_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    // always_ge
+    static void Always_ge_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ge_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ge_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ge_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Always_ge_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -363,6 +363,13 @@ struct TemporalFunctions {
     static void Always_ge_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Similarity measures
+     ****************************************************/
+    static void Temporal_frechet_distance(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_dyntimewarp_distance(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_hausdorff_distance(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1457,6 +1457,14 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     REG_EA_ORD("always_ge", Always_ge)
 #undef REG_EA_ORD
 
+    // Similarity measures (tnumber × tnumber)
+    for (auto &t : {TemporalTypes::TINT(), TemporalTypes::TFLOAT()}) {
+        loader.RegisterFunction(ScalarFunction("frechetDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_frechet_distance));
+        loader.RegisterFunction(ScalarFunction("discreteFrechet", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_frechet_distance));
+        loader.RegisterFunction(ScalarFunction("dynTimeWarp",     {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_dyntimewarp_distance));
+        loader.RegisterFunction(ScalarFunction("hausdorffDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_hausdorff_distance));
+    }
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1419,6 +1419,44 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(ScalarFunction("overafter",  {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_tstzspan_temporal));
     }
 
+    // Ever / always equality and inequality (named functions; DuckDB
+    // parser does not accept ?= / #= operator names).
+#define REG_EA(NAME, FN)                                                                                                                                                          \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::BOOLEAN,        TemporalTypes::TBOOL()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_bool_tbool));             \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TBOOL(),      LogicalType::BOOLEAN},     LogicalType::BOOLEAN, TemporalFunctions::FN##_tbool_bool));             \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::INTEGER,        TemporalTypes::TINT()},    LogicalType::BOOLEAN, TemporalFunctions::FN##_int_tint));               \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),       LogicalType::INTEGER},     LogicalType::BOOLEAN, TemporalFunctions::FN##_tint_int));               \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::DOUBLE,         TemporalTypes::TFLOAT()},  LogicalType::BOOLEAN, TemporalFunctions::FN##_float_tfloat));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(),     LogicalType::DOUBLE},      LogicalType::BOOLEAN, TemporalFunctions::FN##_tfloat_float));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),       TemporalTypes::TINT()},    LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));      \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(),     TemporalTypes::TFLOAT()},  LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));      \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TBOOL(),      TemporalTypes::TBOOL()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));
+
+    REG_EA("ever_eq",   Ever_eq)
+    REG_EA("always_eq", Always_eq)
+    REG_EA("ever_ne",   Ever_ne)
+    REG_EA("always_ne", Always_ne)
+#undef REG_EA
+
+    // Ordering ever/always — no tbool variant (booleans have no ordering)
+#define REG_EA_ORD(NAME, FN)                                                                                                                                          \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::INTEGER,    TemporalTypes::TINT()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_int_tint));        \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),   LogicalType::INTEGER},    LogicalType::BOOLEAN, TemporalFunctions::FN##_tint_int));        \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, LogicalType::BOOLEAN, TemporalFunctions::FN##_float_tfloat));    \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     LogicalType::BOOLEAN, TemporalFunctions::FN##_tfloat_float));    \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),   TemporalTypes::TINT()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal)); \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));
+
+    REG_EA_ORD("ever_lt",   Ever_lt)
+    REG_EA_ORD("always_lt", Always_lt)
+    REG_EA_ORD("ever_le",   Ever_le)
+    REG_EA_ORD("always_le", Always_le)
+    REG_EA_ORD("ever_gt",   Ever_gt)
+    REG_EA_ORD("always_gt", Always_gt)
+    REG_EA_ORD("ever_ge",   Ever_ge)
+    REG_EA_ORD("always_ge", Always_ge)
+#undef REG_EA_ORD
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5119,6 +5119,37 @@ DEFINE_EA_ORD_OP(Always_ge, always_ge)
 #undef DEFINE_EA_ORD_OP
 
 /* ***************************************************
+ * Similarity measures
+ ****************************************************/
+
+namespace {
+
+template <typename Fn>
+void TempTempDoublePred(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, double>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a_blob, string_t b_blob) -> double {
+            Temporal *a = BlobToTemporal(a_blob);
+            Temporal *b = BlobToTemporal(b_blob);
+            double r = fn(a, b);
+            free(a); free(b);
+            return r;
+        });
+}
+
+} // namespace
+
+void TemporalFunctions::Temporal_frechet_distance(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempDoublePred(args, result, [](Temporal *a, Temporal *b) { return temporal_frechet_distance(a, b); });
+}
+void TemporalFunctions::Temporal_dyntimewarp_distance(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempDoublePred(args, result, [](Temporal *a, Temporal *b) { return temporal_dyntimewarp_distance(a, b); });
+}
+void TemporalFunctions::Temporal_hausdorff_distance(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempDoublePred(args, result, [](Temporal *a, Temporal *b) { return temporal_hausdorff_distance(a, b); });
+}
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5014,6 +5014,111 @@ void TemporalFunctions::Overafter_tstzspan_temporal(DataChunk &args, ExpressionS
 }
 
 /* ***************************************************
+ * Ever / always equality and inequality
+ ****************************************************/
+
+namespace {
+
+// MEOS ever/always functions return int (1=true, 0=false, -1=null/error).
+template <typename TVal, typename Fn>
+void EverAlwaysValTemp(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<TVal, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](TVal v, string_t blob) -> bool {
+            Temporal *t = BlobToTemporal(blob);
+            int r = fn(v, t);
+            free(t);
+            return r > 0;
+        });
+}
+
+template <typename TVal, typename Fn>
+void EverAlwaysTempVal(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, TVal, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, TVal v) -> bool {
+            Temporal *t = BlobToTemporal(blob);
+            int r = fn(t, v);
+            free(t);
+            return r > 0;
+        });
+}
+
+template <typename Fn>
+void EverAlwaysTempTemp(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a_blob, string_t b_blob) -> bool {
+            Temporal *a = BlobToTemporal(a_blob);
+            Temporal *b = BlobToTemporal(b_blob);
+            int r = fn(a, b);
+            free(a); free(b);
+            return r > 0;
+        });
+}
+
+} // namespace
+
+#define DEFINE_EA_OP(NAME, MEOS_NAME)                                                                  \
+void TemporalFunctions::NAME##_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result) {   \
+    EverAlwaysValTemp<bool>(args, result, [](bool b, Temporal *t) { return MEOS_NAME##_bool_tbool(b, t); });   \
+}                                                                                                      \
+void TemporalFunctions::NAME##_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result) {   \
+    EverAlwaysTempVal<bool>(args, result, [](Temporal *t, bool b) { return MEOS_NAME##_tbool_bool(t, b); });   \
+}                                                                                                      \
+void TemporalFunctions::NAME##_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {     \
+    EverAlwaysValTemp<int32_t>(args, result, [](int32_t i, Temporal *t) { return MEOS_NAME##_int_tint(i, t); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {     \
+    EverAlwaysTempVal<int32_t>(args, result, [](Temporal *t, int32_t i) { return MEOS_NAME##_tint_int(t, i); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) { \
+    EverAlwaysValTemp<double>(args, result, [](double d, Temporal *t) { return MEOS_NAME##_float_tfloat(d, t); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) { \
+    EverAlwaysTempVal<double>(args, result, [](Temporal *t, double d) { return MEOS_NAME##_tfloat_float(t, d); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) { \
+    EverAlwaysTempTemp(args, result, [](Temporal *a, Temporal *b) { return MEOS_NAME##_temporal_temporal(a, b); }); \
+}
+
+DEFINE_EA_OP(Ever_eq, ever_eq)
+DEFINE_EA_OP(Always_eq, always_eq)
+DEFINE_EA_OP(Ever_ne, ever_ne)
+DEFINE_EA_OP(Always_ne, always_ne)
+
+#undef DEFINE_EA_OP
+
+// Ordering ops have no tbool variant.
+#define DEFINE_EA_ORD_OP(NAME, MEOS_NAME)                                                              \
+void TemporalFunctions::NAME##_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {     \
+    EverAlwaysValTemp<int32_t>(args, result, [](int32_t i, Temporal *t) { return MEOS_NAME##_int_tint(i, t); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {     \
+    EverAlwaysTempVal<int32_t>(args, result, [](Temporal *t, int32_t i) { return MEOS_NAME##_tint_int(t, i); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) { \
+    EverAlwaysValTemp<double>(args, result, [](double d, Temporal *t) { return MEOS_NAME##_float_tfloat(d, t); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) { \
+    EverAlwaysTempVal<double>(args, result, [](Temporal *t, double d) { return MEOS_NAME##_tfloat_float(t, d); }); \
+}                                                                                                      \
+void TemporalFunctions::NAME##_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) { \
+    EverAlwaysTempTemp(args, result, [](Temporal *a, Temporal *b) { return MEOS_NAME##_temporal_temporal(a, b); }); \
+}
+
+DEFINE_EA_ORD_OP(Ever_lt, ever_lt)
+DEFINE_EA_ORD_OP(Always_lt, always_lt)
+DEFINE_EA_ORD_OP(Ever_le, ever_le)
+DEFINE_EA_ORD_OP(Always_le, always_le)
+DEFINE_EA_ORD_OP(Ever_gt, ever_gt)
+DEFINE_EA_ORD_OP(Always_gt, always_gt)
+DEFINE_EA_ORD_OP(Ever_ge, ever_ge)
+DEFINE_EA_ORD_OP(Always_ge, always_ge)
+
+#undef DEFINE_EA_ORD_OP
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Combines ever/always equality, inequality, and ordering predicates between Temporal values and base scalars across all 6 comparison ops × applicable base types. **232 lines**, all routed through the `EverAlwaysValTemp<T>` templated helper.

This PR consolidates two previously stacked PRs covering the same surface across the same template — splitting eq/ne from ord added review burden without giving reviewers any independent decision points.

## Coverage

| Predicate | Naming convention |
|---|---|
| Equality | `ever_eq(t, v)`, `always_eq(t, v)`, `ever_ne(t, v)`, `always_ne(t, v)` |
| Ordering | `ever_lt`, `always_lt`, `ever_le`, `always_le`, `ever_gt`, `always_gt`, `ever_ge`, `always_ge` |

Functions are exposed as named SQL forms because DuckDB's parser does not accept the MobilityDB `?=`, `%=`, `?<`, `%<`, etc. operator forms.

## Test plan
- [x] All registrations load
- [x] Smoke tests for each predicate against representative base types
- [x] Full local suite passes net of pre-existing TZ-environment failures

## Replaces
- #34 (eq/ne)
- #35 (ord)