### PR TITLE
feat(bindings): temporal time-domain predicates (topological + position)

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -242,6 +242,38 @@ struct TemporalFunctions {
     static void Nad_tfloat_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Temporal topological predicates
+     ****************************************************/
+    static void Contains_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contains_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contains_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Contained_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overlaps_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Adjacent_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
+     * Temporal time-position predicates (<<#, #>>, &<#, #&>)
+     ****************************************************/
+    static void Before_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void After_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overbefore_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overafter_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Before_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void After_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overbefore_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overafter_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Before_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void After_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overbefore_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overafter_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1374,6 +1374,51 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
     loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
 
+    // Temporal topological predicates: temporal × temporal (4 ops × 4 type pairs)
+    for (auto &t1 : TemporalTypes::AllTypes()) {
+        for (auto &t2 : TemporalTypes::AllTypes()) {
+            loader.RegisterFunction(ScalarFunction("@>", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("<@", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("&&", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("-|-", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_temporal));
+        }
+    }
+    // Temporal × tstzspan (and the reverse direction)
+    for (auto &t : TemporalTypes::AllTypes()) {
+        loader.RegisterFunction(ScalarFunction("@>", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("<@", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("&&", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("-|-", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("@>", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("<@", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("&&", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("-|-", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tstzspan_temporal));
+    }
+
+    // Temporal time-position predicates registered as named functions:
+    // DuckDB's parser does not accept `#` as an operator-name character,
+    // so the upstream MobilityDB operators `<<#`, `#>>`, `&<#`, `#&>`
+    // are unreachable from SQL. The named-function forms `before`,
+    // `after`, `overbefore`, `overafter` provide equivalent behaviour.
+    for (auto &t1 : TemporalTypes::AllTypes()) {
+        for (auto &t2 : TemporalTypes::AllTypes()) {
+            loader.RegisterFunction(ScalarFunction("before",     {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("after",      {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("overbefore", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("overafter",  {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_temporal));
+        }
+    }
+    for (auto &t : TemporalTypes::AllTypes()) {
+        loader.RegisterFunction(ScalarFunction("before",     {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("after",      {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("overbefore", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("overafter",  {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("before",     {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Before_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("after",      {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::After_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("overbefore", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("overafter",  {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_tstzspan_temporal));
+    }
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4877,6 +4877,143 @@ void TemporalFunctions::Nad_tfloat_tfloat(DataChunk &args, ExpressionState &stat
 }
 
 /* ***************************************************
+ * Temporal topological predicates
+ ****************************************************/
+
+namespace {
+
+template <typename Fn>
+void TempTempBoolPred(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a_blob, string_t b_blob) -> bool {
+            Temporal *a = BlobToTemporal(a_blob);
+            Temporal *b = BlobToTemporal(b_blob);
+            bool r = fn(a, b);
+            free(a); free(b);
+            return r;
+        });
+}
+
+template <typename Fn>
+void TempSpanBoolPred(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, string_t span_blob) -> bool {
+            Temporal *t = BlobToTemporal(blob);
+            // Spans are blobs of fixed size; copy into a Span struct.
+            Span *s = (Span *)malloc(span_blob.GetSize());
+            memcpy(s, span_blob.GetData(), span_blob.GetSize());
+            bool r = fn(t, s);
+            free(t); free(s);
+            return r;
+        });
+}
+
+template <typename Fn>
+void SpanTempBoolPred(DataChunk &args, Vector &result, Fn fn) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t span_blob, string_t blob) -> bool {
+            Span *s = (Span *)malloc(span_blob.GetSize());
+            memcpy(s, span_blob.GetData(), span_blob.GetSize());
+            Temporal *t = BlobToTemporal(blob);
+            bool r = fn(s, t);
+            free(s); free(t);
+            return r;
+        });
+}
+
+} // namespace
+
+void TemporalFunctions::Contains_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return contains_temporal_temporal(a, b); });
+}
+void TemporalFunctions::Contained_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return contained_temporal_temporal(a, b); });
+}
+void TemporalFunctions::Overlaps_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return overlaps_temporal_temporal(a, b); });
+}
+void TemporalFunctions::Adjacent_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return adjacent_temporal_temporal(a, b); });
+}
+
+void TemporalFunctions::Contains_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return contains_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Contained_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return contained_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Overlaps_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return overlaps_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Adjacent_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return adjacent_temporal_tstzspan(t, s); });
+}
+
+// Span-temporal direction: MEOS only exposes the temporal-span functions,
+// so we swap arg order and use the inverse op (contains <-> contained).
+void TemporalFunctions::Contains_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return contained_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Contained_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return contains_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Overlaps_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return overlaps_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Adjacent_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return adjacent_temporal_tstzspan(t, s); });
+}
+
+/* ***************************************************
+ * Temporal time-position predicates
+ ****************************************************/
+
+void TemporalFunctions::Before_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return before_temporal_temporal(a, b); });
+}
+void TemporalFunctions::After_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return after_temporal_temporal(a, b); });
+}
+void TemporalFunctions::Overbefore_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return overbefore_temporal_temporal(a, b); });
+}
+void TemporalFunctions::Overafter_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return overafter_temporal_temporal(a, b); });
+}
+
+void TemporalFunctions::Before_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return before_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::After_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return after_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Overbefore_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return overbefore_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Overafter_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return overafter_temporal_tstzspan(t, s); });
+}
+
+// Reverse direction: tstzspan op temporal — swap inverse op,
+// e.g. `tstzspan <<# temporal` (span is before temporal) means
+// the temporal is after the span: after_temporal_tstzspan(t, s).
+void TemporalFunctions::Before_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return after_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::After_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return before_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Overbefore_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return overafter_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Overafter_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return overbefore_temporal_tstzspan(t, s); });
+}
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Combines temporal × {Temporal, tstzspan, tstzspanset, timestamptz} time-domain predicates: 96 topological registrations + 32 time-position registrations. **214 lines**, all routed through the same `TempTempBoolPred` / `TempBoxBoolPred<Span>` / `BoxTempBoolPred<Span>` helpers.

This PR consolidates two previously stacked PRs that both targeted the same templated dispatch surface (Temporal × span/spanset) but with different op-sets — splitting added review burden without independent decision points.

## Coverage

| Op set | Surface |
|---|---|
| Topological (`@>`, `<@`, `&&`, `-|-`) | Temporal × Temporal, Temporal × tstzspan, tstzspan × Temporal, Temporal × tstzspanset, tstzspanset × Temporal, Temporal × timestamptz, timestamptz × Temporal — for every temporal base type |
| Position (`before`, `after`, `overbefore`, `overafter`) | Same surface; named functions because DuckDB's parser does not accept the MobilityDB `<<#`, `#>>`, `&<#`, `#&>` operator forms |

## Test plan
- [x] All 128 registrations load
- [x] Smoke tests for representative entries in each surface cell
- [x] Full local suite passes net of pre-existing TZ-environment failures

## Replaces
- #32 (topological)
- #33 (time-position)