### PR TITLE
feat(bindings): tnumber numeric functions (arithmetic + unary + distance)

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -197,6 +197,51 @@ struct TemporalFunctions {
     static void Tnot_tbool(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Arithmetic operators on tnumber
+     ****************************************************/
+    static void Add_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Add_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Add_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Add_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Add_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Sub_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Sub_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Sub_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Sub_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Sub_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Mult_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Mult_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Mult_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Mult_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Mult_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Div_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Div_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Div_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Div_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Div_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
+     * Unary tnumber functions
+     ****************************************************/
+    static void Tnumber_abs(DataChunk &args, ExpressionState &state, Vector &result);
+    // Temporal_derivative declared in the math-functions block below.
+    static void Tfloat_degrees(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tfloat_radians(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
+     * Distance operator on tnumber
+     ****************************************************/
+    static void Tdistance_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tdistance_int_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tdistance_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tdistance_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tdistance_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Nad_tint_int(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Nad_tint_tint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Nad_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Nad_tfloat_tfloat(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1313,6 +1313,67 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("|", {TemporalTypes::TBOOL(), TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tor_tbool_tbool));
     loader.RegisterFunction(ScalarFunction("~", {TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tnot_tbool));
 
+    // tnumber arithmetic operators
+    loader.RegisterFunction(ScalarFunction("+", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Add_int_tint));
+    loader.RegisterFunction(ScalarFunction("+", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Add_tint_int));
+    loader.RegisterFunction(ScalarFunction("+", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("+", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("+", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Add_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("+", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_tnumber_tnumber));
+
+    loader.RegisterFunction(ScalarFunction("-", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Sub_int_tint));
+    loader.RegisterFunction(ScalarFunction("-", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Sub_tint_int));
+    loader.RegisterFunction(ScalarFunction("-", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("-", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("-", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Sub_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("-", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_tnumber_tnumber));
+
+    loader.RegisterFunction(ScalarFunction("*", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Mult_int_tint));
+    loader.RegisterFunction(ScalarFunction("*", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Mult_tint_int));
+    loader.RegisterFunction(ScalarFunction("*", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("*", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("*", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Mult_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("*", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_tnumber_tnumber));
+
+    loader.RegisterFunction(ScalarFunction("/", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Div_int_tint));
+    loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Div_tint_int));
+    loader.RegisterFunction(ScalarFunction("/", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Div_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_tnumber_tnumber));
+
+    // Unary tnumber functions
+    loader.RegisterFunction(ScalarFunction("abs", {TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Tnumber_abs));
+    loader.RegisterFunction(ScalarFunction("abs", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tnumber_abs));
+    loader.RegisterFunction(ScalarFunction("derivative", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Temporal_derivative));
+    loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
+    loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT(), LogicalType::BOOLEAN}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
+    loader.RegisterFunction(ScalarFunction("radians", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_radians));
+
+    // tnumber distance and nearest-approach-distance.
+    //
+    // Value-distance variants `<-> ` for (tint, INTEGER), (INTEGER, tint),
+    // (tfloat, DOUBLE), (DOUBLE, tfloat) are intentionally NOT registered
+    // here: in the installed MEOS library, tdistance_tfloat_float / tint_int
+    // return the temporal's own value at each instant rather than the
+    // |t.value - v| absolute difference. Verified by smoke test:
+    //   SELECT 5.0::DOUBLE <-> tfloat '5.0@2000-01-01';   -- returns 5.0, expected 0.0
+    //   SELECT 100.0::DOUBLE <-> tfloat '2.5@2000-01-01'; -- returns 2.5, expected 97.5
+    // The temporal-temporal variant DOES work correctly, and so does nad_*.
+    // Restore the value-distance registrations once the MEOS issue is resolved.
+    loader.RegisterFunction(ScalarFunction("<->", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Tdistance_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("<->", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tdistance_tnumber_tnumber));
+
+    // nearestApproachDistance / nad — scalar return
+    loader.RegisterFunction(ScalarFunction("nad", {TemporalTypes::TINT(), LogicalType::INTEGER}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_int));
+    loader.RegisterFunction(ScalarFunction("nad", {TemporalTypes::TINT(), TemporalTypes::TINT()}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_tint));
+    loader.RegisterFunction(ScalarFunction("nad", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("nad", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
+    loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TINT(), LogicalType::INTEGER}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_int));
+    loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TINT(), TemporalTypes::TINT()}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_tint));
+    loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
+
     // ttext text functions
     loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
     loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4721,6 +4721,162 @@ void TemporalFunctions::Tnot_tbool(DataChunk &args, ExpressionState &state, Vect
 }
 
 /* ***************************************************
+ * Arithmetic operators on tnumber
+ ****************************************************/
+
+void TemporalFunctions::Add_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<int32_t>(args, result, [](int32_t i, Temporal *t) { return add_int_tint(i, t); });
+}
+void TemporalFunctions::Add_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<int32_t>(args, result, [](Temporal *t, int32_t i) { return add_tint_int(t, i); });
+}
+void TemporalFunctions::Add_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<double>(args, result, [](double d, Temporal *t) { return add_float_tfloat(d, t); });
+}
+void TemporalFunctions::Add_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<double>(args, result, [](Temporal *t, double d) { return add_tfloat_float(t, d); });
+}
+void TemporalFunctions::Add_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return add_tnumber_tnumber(a, b); });
+}
+
+void TemporalFunctions::Sub_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<int32_t>(args, result, [](int32_t i, Temporal *t) { return sub_int_tint(i, t); });
+}
+void TemporalFunctions::Sub_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<int32_t>(args, result, [](Temporal *t, int32_t i) { return sub_tint_int(t, i); });
+}
+void TemporalFunctions::Sub_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<double>(args, result, [](double d, Temporal *t) { return sub_float_tfloat(d, t); });
+}
+void TemporalFunctions::Sub_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<double>(args, result, [](Temporal *t, double d) { return sub_tfloat_float(t, d); });
+}
+void TemporalFunctions::Sub_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return sub_tnumber_tnumber(a, b); });
+}
+
+void TemporalFunctions::Mult_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<int32_t>(args, result, [](int32_t i, Temporal *t) { return mult_int_tint(i, t); });
+}
+void TemporalFunctions::Mult_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<int32_t>(args, result, [](Temporal *t, int32_t i) { return mult_tint_int(t, i); });
+}
+void TemporalFunctions::Mult_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<double>(args, result, [](double d, Temporal *t) { return mult_float_tfloat(d, t); });
+}
+void TemporalFunctions::Mult_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<double>(args, result, [](Temporal *t, double d) { return mult_tfloat_float(t, d); });
+}
+void TemporalFunctions::Mult_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return mult_tnumber_tnumber(a, b); });
+}
+
+void TemporalFunctions::Div_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<int32_t>(args, result, [](int32_t i, Temporal *t) { return div_int_tint(i, t); });
+}
+void TemporalFunctions::Div_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<int32_t>(args, result, [](Temporal *t, int32_t i) { return div_tint_int(t, i); });
+}
+void TemporalFunctions::Div_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<double>(args, result, [](double d, Temporal *t) { return div_float_tfloat(d, t); });
+}
+void TemporalFunctions::Div_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<double>(args, result, [](Temporal *t, double d) { return div_tfloat_float(t, d); });
+}
+void TemporalFunctions::Div_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return div_tnumber_tnumber(a, b); });
+}
+
+/* ***************************************************
+ * Unary tnumber functions
+ ****************************************************/
+
+void TemporalFunctions::Tnumber_abs(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tnumber_abs(t); });
+}
+
+// Temporal_derivative is implemented later in this file in the Math
+// functions block (existed before the unary-tnumber additions).
+
+void TemporalFunctions::Tfloat_degrees(DataChunk &args, ExpressionState &state, Vector &result) {
+    if (args.ColumnCount() == 2) {
+        TemporalBinaryV<bool>(args, result, [](Temporal *t, bool normalize) {
+            return tfloat_degrees(t, normalize);
+        });
+    } else {
+        TemporalUnary(args, result, [](Temporal *t) { return tfloat_degrees(t, false); });
+    }
+}
+
+void TemporalFunctions::Tfloat_radians(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tfloat_radians(t); });
+}
+
+/* ***************************************************
+ * Distance operator on tnumber
+ ****************************************************/
+
+void TemporalFunctions::Tdistance_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<int32_t>(args, result, [](Temporal *t, int32_t i) { return tdistance_tint_int(t, i); });
+}
+void TemporalFunctions::Tdistance_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<int32_t>(args, result, [](int32_t i, Temporal *t) { return tdistance_tint_int(t, i); });
+}
+void TemporalFunctions::Tdistance_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV<double>(args, result, [](Temporal *t, double d) { return tdistance_tfloat_float(t, d); });
+}
+void TemporalFunctions::Tdistance_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryV1<double>(args, result, [](double d, Temporal *t) { return tdistance_tfloat_float(t, d); });
+}
+void TemporalFunctions::Tdistance_tnumber_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return tdistance_tnumber_tnumber(a, b); });
+}
+
+void TemporalFunctions::Nad_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, int32_t, int32_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, int32_t i) -> int32_t {
+            Temporal *t = BlobToTemporal(blob);
+            int32_t r = nad_tint_int(t, i);
+            free(t);
+            return r;
+        });
+}
+void TemporalFunctions::Nad_tint_tint(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, int32_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a_blob, string_t b_blob) -> int32_t {
+            Temporal *a = BlobToTemporal(a_blob);
+            Temporal *b = BlobToTemporal(b_blob);
+            int32_t r = nad_tint_tint(a, b);
+            free(a); free(b);
+            return r;
+        });
+}
+void TemporalFunctions::Nad_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, double, double>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, double d) -> double {
+            Temporal *t = BlobToTemporal(blob);
+            double r = nad_tfloat_float(t, d);
+            free(t);
+            return r;
+        });
+}
+void TemporalFunctions::Nad_tfloat_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, double>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a_blob, string_t b_blob) -> double {
+            Temporal *a = BlobToTemporal(a_blob);
+            Temporal *b = BlobToTemporal(b_blob);
+            double r = nad_tfloat_tfloat(a, b);
+            free(a); free(b);
+            return r;
+        });
+}
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 


### PR DESCRIPTION
## Summary

Combines the tnumber numeric surface into a single PR (~262 lines):

| Family | Functions | Registrations |
|---|---|---|
| Arithmetic | `+`, `-`, `*`, `/` for `{tint, tfloat} × {scalar, tnumber}` | 24 |
| Unary | `abs`, `derivative`, `degrees`, `radians` | 12 |
| Distance | `<->` for tnumber × tnumber, `nad`, `nearestApproachDistance` | 5 |

Each family routes through one of the existing templated helpers (`TemporalBinaryV<T>`, `TemporalUnary`, `TempTempBoolPred`-style) so each `ScalarFunction` body is a single-line lambda calling the corresponding MEOS entrypoint.

This PR consolidates three previously stacked PRs that all targeted the tnumber numeric surface and shared the same dispatch helpers — splitting them by op family added review burden without independent decision points.

## Test plan
- [x] All ~41 registrations load
- [x] Smoke tests for representative entries in each family
- [x] Full local suite passes net of pre-existing TZ-environment failures

## Replaces
- #29 (arithmetic)
- #30 (unary)
- #31 (distance)