### PR TITLE
feat(bindings): re-land splitNspans aliases + spans(<set_type>) constructor

### DIFF
--- a/src/temporal/span.cpp
+++ b/src/temporal/span.cpp
@@ -319,6 +319,23 @@ void SpanTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
 
 
 
+    // spans(<set_type>) — list of unit spans, one per set element
+    loader.RegisterFunction(
+        ScalarFunction("spans", {SetTypes::intset()},
+                       LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_spans));
+    loader.RegisterFunction(
+        ScalarFunction("spans", {SetTypes::bigintset()},
+                       LogicalType::LIST(SpanTypes::BIGINTSPAN()), SpanFunctions::Set_spans));
+    loader.RegisterFunction(
+        ScalarFunction("spans", {SetTypes::floatset()},
+                       LogicalType::LIST(SpanTypes::FLOATSPAN()), SpanFunctions::Set_spans));
+    loader.RegisterFunction(
+        ScalarFunction("spans", {SetTypes::dateset()},
+                       LogicalType::LIST(SpanTypes::DATESPAN()), SpanFunctions::Set_spans));
+    loader.RegisterFunction(
+        ScalarFunction("spans", {SetTypes::tstzset()},
+                       LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_spans));
+
     loader.RegisterFunction(
         ScalarFunction("splitNSpans", {SetTypes::intset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_split_n_spans));

--- a/src/temporal/span.cpp
+++ b/src/temporal/span.cpp
@@ -349,7 +349,41 @@ void SpanTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(
         ScalarFunction("splitEachNSpans", {SetTypes::tstzset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_split_each_n_spans));
-                
+
+    // Lowercase-"spans" aliases matching MobilityDB's SQL surface
+    // (`splitNspans` / `splitEachNspans`). The camelCase forms above
+    // stay registered for back-compat with existing MobilityDuck callers.
+    loader.RegisterFunction(
+        ScalarFunction("splitNspans", {SetTypes::intset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_split_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitNspans", {SetTypes::bigintset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::BIGINTSPAN()), SpanFunctions::Set_split_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitNspans", {SetTypes::floatset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::FLOATSPAN()), SpanFunctions::Set_split_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitNspans", {SetTypes::dateset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::DATESPAN()), SpanFunctions::Set_split_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitNspans", {SetTypes::tstzset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_split_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitEachNspans", {SetTypes::intset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_split_each_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitEachNspans", {SetTypes::bigintset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::BIGINTSPAN()), SpanFunctions::Set_split_each_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitEachNspans", {SetTypes::floatset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::FLOATSPAN()), SpanFunctions::Set_split_each_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitEachNspans", {SetTypes::dateset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::DATESPAN()), SpanFunctions::Set_split_each_n_spans));
+    loader.RegisterFunction(
+        ScalarFunction("splitEachNspans", {SetTypes::tstzset(), LogicalType::INTEGER},
+                       LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_split_each_n_spans));
+
     loader.RegisterFunction(
         ScalarFunction("floor", {SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Floatspan_floor)
     );

--- a/src/temporal/span_functions.cpp
+++ b/src/temporal/span_functions.cpp
@@ -415,23 +415,56 @@ bool SpanFunctions::Set_to_span_cast(Vector &source, Vector &result, idx_t count
     return true;
 }
 
+// spans(<set_type>) — returns a LIST(<span_type>) of unit spans, one per
+// element of the input set. Mirrors SpansetFunctions::Spanset_spans but
+// reads a Set and uses set_spans() / set_num_values() from MEOS.
 void SpanFunctions::Set_spans(DataChunk &args, ExpressionState &state, Vector &result) {
-    BinaryExecutor::Execute<string_t, string_t, string_t>(
-        args.data[0], args.data[1], result, args.size(),
-        [&](string_t set_blob, string_t span_blob) -> string_t {
-            const uint8_t *set_data = reinterpret_cast<const uint8_t*>(set_blob.GetData());
-            size_t set_size = set_blob.GetSize();
-            const Set *s = reinterpret_cast<const Set*>(set_data);
-            Span *span = set_to_span(s);
-            if (span == NULL) {
-                throw InvalidInputException("Failed to convert set to span");
-            }
-            size_t span_size = sizeof(*span);
-            string_t out = StringVector::AddStringOrBlob(result, (const char *)span, span_size);
-            free(span);
-            return out;
+    auto &set_vec = args.data[0];
+    idx_t row_count = args.size();
+    set_vec.Flatten(row_count);
+
+    auto &result_validity = FlatVector::Validity(result);
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &child_vector = ListVector::GetEntry(result);
+    child_vector.SetVectorType(VectorType::FLAT_VECTOR);
+    ListVector::Reserve(result, row_count);
+
+    idx_t total_offset = 0;
+    const size_t span_bytes = sizeof(Span);
+
+    for (idx_t i = 0; i < row_count; ++i) {
+        if (FlatVector::IsNull(set_vec, i)) {
+            result_validity.SetInvalid(i);
+            continue;
         }
-    );
+
+        string_t blob = FlatVector::GetData<string_t>(set_vec)[i];
+        Set *s = (Set *)malloc(blob.GetSize());
+        memcpy(s, blob.GetData(), blob.GetSize());
+
+        int num = set_num_values(s);
+        Span *spans = set_spans(s);
+        free(s);
+
+        if (!spans || num <= 0) {
+            if (spans) free(spans);
+            result_validity.SetInvalid(i);
+            continue;
+        }
+
+        ListVector::SetListSize(result, total_offset + num);
+        list_entries[i] = list_entry_t{total_offset, static_cast<uint64_t>(num)};
+
+        auto *child_data = FlatVector::GetData<string_t>(child_vector);
+        for (int j = 0; j < num; ++j) {
+            child_data[total_offset + j] =
+                StringVector::AddStringOrBlob(child_vector, reinterpret_cast<const char *>(&spans[j]), span_bytes);
+        }
+
+        free(spans);
+        total_offset += num;
+        result_validity.SetValid(i);
+    }
 }
 
 // --- Conversion: intspan <-> floatspan ---

--- a/test/sql/parity/001_set.test
+++ b/test/sql/parity/001_set.test
@@ -195,13 +195,10 @@ SELECT span(tstzset '{2000-01-01, 2000-01-02, 2000-01-03}');
 ----
 [2000-01-01 00:00:00+00, 2000-01-03 00:00:00+00]
 
-mode skip
-# spans(<set_type>) not registered in MobilityDuck. MEOS symbol: set_spans.
 query I
 SELECT spans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}');
 ----
 {"[1, 2)","[2, 3)","[3, 4)","[4, 5)","[5, 6)","[6, 7)","[7, 8)","[8, 9)","[9, 10)","[10, 11)"}
-mode unskip
 
 query I
 SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);

--- a/test/sql/parity/001_set.test
+++ b/test/sql/parity/001_set.test
@@ -203,10 +203,6 @@ SELECT spans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}');
 {"[1, 2)","[2, 3)","[3, 4)","[4, 5)","[5, 6)","[6, 7)","[7, 8)","[8, 9)","[9, 10)","[10, 11)"}
 mode unskip
 
-mode skip
-# Naming divergence: MobilityDB uses lowercase splitNspans /
-# splitEachNspans; MobilityDuck registers camelCase splitNSpans /
-# splitEachNSpans in src/temporal/span.cpp.
 query I
 SELECT splitNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
 ----
@@ -281,7 +277,6 @@ statement error
 SELECT splitEachNspans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', -1);
 ----
 strictly positive
-mode unskip
 
 query I
 SELECT numValues(dateset '{2000-01-01}');


### PR DESCRIPTION
## Summary

Re-lands the contents of PRs #8 and #9, which were both in MERGED state but the merge commits went into intermediate stack-base branches (`fix/meos-error-handler` and `feat/splitnspans-lowercase-alias` themselves) instead of `main`. As a result none of those changes reached `main`.

This PR brings forward both commits as a single linear history on top of `main`:

- `cdea92e` — splitNspans / splitEachNspans lowercase aliases (originally PR #8)
- `9337c20` — spans(\<set_type\>) constructor — list of unit spans from a set (originally PR #9)

## Verification
- `splitNspans` / `splitEachNspans` (camelCase) already on main
- `splitnspans` / `spliteachnspans` (lowercase) — confirmed missing from main, added here
- `spans()` constructor on a SET type — confirmed missing from main, added here
- `spans()` already exists on the SPANSET type independently

## Replaces
- Re-lands #8 (merged into wrong base)
- Re-lands #9 (merged into wrong base)