### PR TITLE
fix: span_union / + on span × span returns spanset, not garbage

### DIFF
--- a/src/temporal/span.cpp
+++ b/src/temporal/span.cpp
@@ -900,66 +900,66 @@ void SpanTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     );
     loader.RegisterFunction( ScalarFunction("span_union", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Union_span_span)
+    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Union_span_span)
     );
     loader.RegisterFunction( ScalarFunction("+", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpansetTypes::intspanset(), SpanFunctions::Union_span_value)
     );
     loader.RegisterFunction( ScalarFunction("+", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Union_span_span)
+    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Union_span_span)
     );
 
     loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpansetTypes::bigintspanset(), SpanFunctions::Union_span_value)
     );
     loader.RegisterFunction( ScalarFunction("span_union", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Union_span_span)
+    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Union_span_span)
     );
     loader.RegisterFunction( ScalarFunction("+", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpansetTypes::bigintspanset(), SpanFunctions::Union_span_value)
     );
     loader.RegisterFunction( ScalarFunction("+", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Union_span_span)
+    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Union_span_span)
     );
 
     loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpansetTypes::floatspanset(), SpanFunctions::Union_span_value)
     );
     loader.RegisterFunction( ScalarFunction("span_union", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Union_span_span)
+    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Union_span_span)
     );
     loader.RegisterFunction( ScalarFunction("+", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpansetTypes::floatspanset(), SpanFunctions::Union_span_value)
     );
     loader.RegisterFunction( ScalarFunction("+", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Union_span_span)
+    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Union_span_span)
     );
 
     loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpansetTypes::datespanset(), SpanFunctions::Union_span_value)
     );
     loader.RegisterFunction( ScalarFunction("span_union", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Union_span_span)
+    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Union_span_span)
     );
     loader.RegisterFunction( ScalarFunction("+", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpansetTypes::datespanset(), SpanFunctions::Union_span_value)
     );
     loader.RegisterFunction( ScalarFunction("+", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Union_span_span)
+    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Union_span_span)
     );  
 
     loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpansetTypes::tstzspanset(), SpanFunctions::Union_span_value)
     );
     loader.RegisterFunction( ScalarFunction("span_union", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Union_span_span)
+    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Union_span_span)
     );
     loader.RegisterFunction( ScalarFunction("+", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpansetTypes::tstzspanset(), SpanFunctions::Union_span_value)
     );
     loader.RegisterFunction( ScalarFunction("+", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Union_span_span)  
-    );  
+    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Union_span_span)
+    );
 
     loader.RegisterFunction( ScalarFunction("span_intersection", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_span_value)
     );

--- a/src/temporal/span_functions.cpp
+++ b/src/temporal/span_functions.cpp
@@ -3714,12 +3714,8 @@ void SpanFunctions::Union_span_span(DataChunk &args, ExpressionState &state, Vec
                 throw InvalidInputException("Invalid SPAN data: null pointer");
             }
             SpanSet *ret = union_span_span(span1, span2);
-            size_t span_size = sizeof(*ret);
-            uint8_t *span_buffer = (uint8_t*) malloc(span_size);
-            memcpy(span_buffer, ret, span_size);
-            string_t span_string_t((char *) span_buffer, span_size);
-            string_t stored_data = StringVector::AddStringOrBlob(result, span_string_t);
-            free(span_buffer);
+            size_t out_size = spanset_mem_size(ret);
+            string_t stored_data = StringVector::AddStringOrBlob(result, (const char *) ret, out_size);
             free(span1);
             free(span2);
             free(ret);


### PR DESCRIPTION
## Summary

Fixes two bugs in the \`Union_span_span\` wrapper that made \`+\` and \`span_union\` between two spans return the canonical empty span \`(t, t)\` regardless of input.

### Bug 1 — wrong byte count

\`\`\`cpp
SpanSet *ret = union_span_span(span1, span2);
size_t span_size = sizeof(*ret);  // <-- returns sizeof header only
uint8_t *span_buffer = (uint8_t*) malloc(span_size);
memcpy(span_buffer, ret, span_size);
\`\`\`

\`SpanSet\` is a varlena type with a flexible \`Span elems[1]\` member — \`sizeof\` returns only the fixed-header size, so the variable-length payload (the actual spans) was never copied. The decoded blob then read as the canonical empty span.

Fixed by switching to \`spanset_mem_size(ret)\` (the canonical size helper used elsewhere in \`spanset_functions.cpp\`).

### Bug 2 — wrong return type

The 10 \`ScalarFunction\` registrations for \`+\` and \`span_union\` over span × span declared return type \`SpanType\`, but MEOS's \`union_span_span\` returns \`SpanSet\` — the union of two disjoint spans cannot be expressed as a single span. Updated all 10 registrations across \`{int, bigint, float, date, tstz}span\` to return the matching spanset type.

## Verification

\`\`\`sql
-- before fix:
SELECT floatspan '[1, 3]' + floatspan '[1, 3]';   -- (t, t)
SELECT floatspan '[1, 3]' + floatspan '(3, 5]';   -- (t, t)
SELECT floatspan '[1, 1]' + floatspan '[3, 4]';   -- (t, t)

-- after fix:
SELECT floatspan '[1, 3]' + floatspan '[1, 3]';   -- {[1, 3]}
SELECT floatspan '[1, 3]' + floatspan '(3, 5]';   -- {[1, 5]}
SELECT floatspan '[1, 1]' + floatspan '[3, 4]';   -- {[1, 1], [3, 4]}
\`\`\`

Surfaced by parity work in PR #17 (005_span_ops.test). The skip block there can be removed in a follow-up once this lands.

## Test plan
- [x] Smoke tests for overlap, adjacent, disjoint cases pass locally
- [x] Existing parity test 005_span_ops.test still passes (the union skip block remains in place)