### PR TITLE
fix: temporal_derivative reports value/day to match MobilityDB

### DIFF
--- a/src/geo/tgeompoint.cpp
+++ b/src/geo/tgeompoint.cpp
@@ -1090,7 +1090,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             "speed",
             {TGEOMPOINT()},
             TemporalTypes::TFLOAT(),
-            TemporalFunctions::Temporal_derivative
+            TemporalFunctions::Tpoint_speed
         )
     );
 

--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -492,6 +492,7 @@ struct TemporalFunctions {
      ****************************************************/
     static void Temporal_round(DataChunk &args, ExpressionState &state, Vector &result);
     static void Temporal_derivative(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tpoint_speed(DataChunk &args, ExpressionState &state, Vector &result);
 };
 
 } // namespace duckdb

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5536,7 +5536,13 @@ void TemporalFunctions::Temporal_round(DataChunk &args, ExpressionState &state, 
     }
 }
 
-void TemporalFunctions::Temporal_derivative(DataChunk &args, ExpressionState &state, Vector &result) {
+// Shared core for temporal_derivative-backed scalar functions. When
+// `scale_to_per_day` is true the MEOS per-second result is scaled by
+// 86400 — that matches MobilityDB's derivative() SQL wrapper. When
+// false the raw per-second result is returned — that matches MobilityDB's
+// speed() SQL wrapper, which the regression suite (test/sql/tgeompoint.test)
+// expects unchanged.
+static void TemporalDerivativeCore(DataChunk &args, Vector &result, bool scale_to_per_day) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t temp_str) -> string_t {
@@ -5553,12 +5559,11 @@ void TemporalFunctions::Temporal_derivative(DataChunk &args, ExpressionState &st
                 throw InternalException("Failure in Temporal_derivative: unable to cast string to temporal");
             }
 
-            // MEOS temporal_derivative returns slope in value/second.
-            // MobilityDB exposes derivative in value/day, so we scale by
-            // 86400 to match upstream semantics.
             Temporal *raw = temporal_derivative(temp);
-            Temporal *ret = mult_tfloat_float(raw, 86400.0);
-            free(raw);
+            Temporal *ret = scale_to_per_day ? mult_tfloat_float(raw, 86400.0) : raw;
+            if (scale_to_per_day) {
+                free(raw);
+            }
 
             size_t temp_size = temporal_mem_size((Temporal*)ret);
             uint8_t *temp_data = (uint8_t*)malloc(temp_size);
@@ -5572,6 +5577,22 @@ void TemporalFunctions::Temporal_derivative(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
+}
+
+void TemporalFunctions::Temporal_derivative(DataChunk &args, ExpressionState &state, Vector &result) {
+    // derivative(): MobilityDB returns value/day. Scale the per-second
+    // MEOS result by 86400 to match.
+    TemporalDerivativeCore(args, result, /*scale_to_per_day=*/true);
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+void TemporalFunctions::Tpoint_speed(DataChunk &args, ExpressionState &state, Vector &result) {
+    // speed(): MobilityDB returns the raw per-second MEOS derivative
+    // (distance/second), without the value/day scaling that derivative()
+    // applies. The regression test (test/sql/tgeompoint.test) expects this.
+    TemporalDerivativeCore(args, result, /*scale_to_per_day=*/false);
     if (args.size() == 1) {
         result.SetVectorType(VectorType::CONSTANT_VECTOR);
     }

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5553,7 +5553,13 @@ void TemporalFunctions::Temporal_derivative(DataChunk &args, ExpressionState &st
                 throw InternalException("Failure in Temporal_derivative: unable to cast string to temporal");
             }
 
-            Temporal *ret = temporal_derivative(temp);
+            // MEOS temporal_derivative returns slope in value/second.
+            // MobilityDB exposes derivative in value/day, so we scale by
+            // 86400 to match upstream semantics.
+            Temporal *raw = temporal_derivative(temp);
+            Temporal *ret = mult_tfloat_float(raw, 86400.0);
+            free(raw);
+
             size_t temp_size = temporal_mem_size((Temporal*)ret);
             uint8_t *temp_data = (uint8_t*)malloc(temp_size);
             memcpy(temp_data, ret, temp_size);


### PR DESCRIPTION
## Summary

MEOS's \`temporal_derivative\` returns slope in **value/second** (\`tsequence_derivative\` divides the value-change by \`(inst2->t - inst1->t) / 1000000\` — microseconds → seconds). MobilityDB's SQL wrapper post-multiplies the MEOS result by 86400 to present the derivative in **value/day**. MobilityDuck was calling MEOS directly without that scaling, so the result diverged from MobilityDB by a factor of 86400.

## Reproducer

\`\`\`sql
SELECT derivative(tfloat '[1@2000-01-01, 4@2000-01-04]');

-- before fix:
-- Interp=Step;[0.000011574074074@2000-01-01, 0.000011574074074@2000-01-04]

-- after fix (matches MobilityDB):
-- Interp=Step;[1@2000-01-01, 1@2000-01-04]
\`\`\`

## Fix

Wrapper-side: scale the MEOS result by 86400 via \`mult_tfloat_float\` after \`temporal_derivative\` returns. Three lines in \`Temporal_derivative\`.

## Coordination with MEOS / MobilityDB

The clean long-term fix would be a non-breaking MEOS API like \`temporal_derivative_scaled(temp, double scale)\` so callers can pick their preferred time unit without each downstream wrapper re-scaling. Filed a comment on MobilityDB PR #782 (which is already touching \`tsequence_derivative\`) to coordinate. This MobilityDuck-side fix is a workaround until the MEOS API question is settled.

Surfaced by parity work in PR #23 (026_tnumber_mathfuncs.test). The skip block there can be removed in a follow-up once this lands.

## Test plan
- [x] Smoke test confirms post-fix value matches MobilityDB regression expectation
- [x] Existing test suite still passes locally