### PR TITLE
feat(bindings): aggregate function infrastructure — extent(span) for all 5 span types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(EXTENSION_SOURCES
     src/temporal/set_functions.cpp
     src/temporal/span.cpp
     src/temporal/span_functions.cpp
+    src/temporal/span_aggregates.cpp
     src/geo/geoset.cpp
     src/temporal/spanset.cpp
     src/temporal/spanset_functions.cpp

--- a/src/include/temporal/span_aggregates.hpp
+++ b/src/include/temporal/span_aggregates.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+struct SpanAggregates {
+    static void RegisterAggregateFunctions(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -12,6 +12,7 @@
 #include "duckdb.hpp"
 #include "geo/tgeometry.hpp"
 #include "temporal/span.hpp"
+#include "temporal/span_aggregates.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar_function.hpp"
@@ -243,6 +244,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	SpanTypes::RegisterScalarFunctions(loader);
 	SpanTypes::RegisterTypes(loader);
 	SpanTypes::RegisterCastFunctions(loader);
+	SpanAggregates::RegisterAggregateFunctions(loader);
 
 	TgeompointType::RegisterType(loader);
 	TgeompointType::RegisterCastFunctions(loader);

--- a/src/temporal/span_aggregates.cpp
+++ b/src/temporal/span_aggregates.cpp
@@ -1,0 +1,99 @@
+#include "meos_wrapper_simple.hpp"
+
+#include "temporal/span.hpp"
+#include "temporal/span_aggregates.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+namespace {
+
+// State for the extent(span) aggregate. The MEOS Span is a fixed-size
+// struct, so we can hold it inline in the aggregate state.
+struct SpanExtentState {
+    Span span;
+    bool isset;
+};
+
+struct SpanExtentFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.isset = false;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    // Operation receives the input blob; we decode to Span and call MEOS
+    // span_extent_transfn, which expands state's bounds in place when
+    // state is non-null and otherwise returns a fresh palloc'd copy.
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        // INPUT_TYPE is string_t for blob-encoded spans.
+        const Span *input_span = reinterpret_cast<const Span *>(input.GetData());
+        if (!state.isset) {
+            // First call: initialize state with a copy of the input.
+            memcpy(&state.span, input_span, sizeof(Span));
+            state.isset = true;
+        } else {
+            // Subsequent calls: expand state in place.
+            // span_extent_transfn(state, s) calls span_expand(s, state).
+            (void) span_extent_transfn(&state.span, input_span);
+        }
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        // extent is idempotent in the value dimension, so a single
+        // application is equivalent to applying the same value `count`
+        // times.
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) {
+            return;
+        }
+        if (!target.isset) {
+            memcpy(&target.span, &source.span, sizeof(Span));
+            target.isset = true;
+        } else {
+            (void) span_extent_transfn(&target.span, &source.span);
+        }
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.isset) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        target = finalize_data.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    }
+};
+
+static AggregateFunction MakeExtentSpanAggregate(const LogicalType &span_type) {
+    return AggregateFunction::UnaryAggregate<SpanExtentState, string_t, string_t, SpanExtentFunction>(
+        span_type, span_type);
+}
+
+} // namespace
+
+void SpanAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
+    AggregateFunctionSet extent_set("extent");
+    for (const auto &span_type : {SpanTypes::INTSPAN(), SpanTypes::BIGINTSPAN(),
+                                  SpanTypes::FLOATSPAN(), SpanTypes::DATESPAN(),
+                                  SpanTypes::TSTZSPAN()}) {
+        extent_set.AddFunction(MakeExtentSpanAggregate(span_type));
+    }
+    loader.RegisterFunction(std::move(extent_set));
+}
+
+} // namespace duckdb


### PR DESCRIPTION
## Summary

Lands the first MobilityDuck **AggregateFunction** registration. Adds \`extent(span)\` that aggregates a column of spans into the bounding span over all values, for the 5 span types: \`intspan\`, \`bigintspan\`, \`floatspan\`, \`datespan\`, \`tstzspan\`.

\`\`\`sql
SELECT extent(s) FROM (VALUES (intspan '[1, 5)'), (intspan '[3, 8)'), (intspan '[10, 12)')) t(s);
-- [1, 12)

SELECT extent(s) FROM (VALUES (datespan '[2000-01-01, 2000-01-05]'), (datespan '[2000-01-03, 2000-01-10]')) t(s);
-- [2000-01-01, 2000-01-11)
\`\`\`

## Implementation pattern

New module: \`src/temporal/span_aggregates.cpp\` + \`src/include/temporal/span_aggregates.hpp\`.

| Component | What it does |
|---|---|
| \`SpanExtentState\` | Inline \`Span span\` + \`bool isset\`. MEOS Span is POD/fixed-size — state is trivially serialisable. |
| \`SpanExtentFunction::Initialize\` | Sets \`isset = false\`. |
| \`SpanExtentFunction::Operation\` | Decodes the input blob, calls MEOS \`span_extent_transfn\` to expand state in place. |
| \`SpanExtentFunction::Combine\` | Calls \`span_extent_transfn(&target.span, &source.span)\`. |
| \`SpanExtentFunction::Finalize\` | Returns \`finalize_data.ReturnString(string_t(&state.span, sizeof(Span)))\` or NULL when no input was seen. |
| Registration | One \`AggregateFunctionSet("extent")\` with 5 type-overloads (one per span type). Bundled because separate \`AggregateFunction\` registrations triggered DuckDB's catalog-alter path which doesn't implement \`GetAlterInfo\` for \`CreateAggregateFunctionInfo\`. |

The same scaffolding extends naturally to the rest of the aggregate surface (architectural blocker for parity tests #21, #40, parts of #25):

- \`extent(spanset)\` via \`spanset_extent_transfn\`
- \`extent(set)\` via \`set_extent_transfn\`
- \`extent(tnumber) → tbox\` via \`tnumber_extent_transfn\`
- \`tcount\` / \`tand\` / \`tor\` / \`tmin\` / \`tmax\` / \`tsum\` via skiplist-backed states (more state setup)
- \`spanUnion(span) → spanset\` via \`spanset_union_transfn\`

This PR establishes the bridging pattern; follow-up PRs land each of the above on the same scaffolding.

## Test plan
- [x] Smoke test all 5 span types — produces correct extent
- [x] NULL handling: mixed NULL + value → returns the value's extent; all-NULL → returns NULL
- [x] Multi-row aggregation produces correct expanding bounds
- [x] Existing test suite still passes locally