### PR TITLE
feat(bindings): extend extent(*) to spanset and set surfaces

### DIFF
--- a/src/temporal/span_aggregates.cpp
+++ b/src/temporal/span_aggregates.cpp
@@ -1,7 +1,9 @@
 #include "meos_wrapper_simple.hpp"
 
+#include "temporal/set.hpp"
 #include "temporal/span.hpp"
 #include "temporal/span_aggregates.hpp"
+#include "temporal/spanset.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
@@ -12,14 +14,17 @@ namespace duckdb {
 
 namespace {
 
-// State for the extent(span) aggregate. The MEOS Span is a fixed-size
-// struct, so we can hold it inline in the aggregate state.
+// Shared state for all extent(*) aggregates: the result is always a Span.
+// MEOS Span is a fixed-size struct so the state is POD.
 struct SpanExtentState {
     Span span;
     bool isset;
 };
 
-struct SpanExtentFunction {
+// Generic Initialize / Combine / Finalize. Operation differs per input
+// type because it dispatches to a different MEOS transfn — those are
+// in the typed functors below.
+struct SpanExtentBase {
     template <class STATE>
     static void Initialize(STATE &state) {
         state.isset = false;
@@ -27,33 +32,6 @@ struct SpanExtentFunction {
 
     static bool IgnoreNull() {
         return true;
-    }
-
-    // Operation receives the input blob; we decode to Span and call MEOS
-    // span_extent_transfn, which expands state's bounds in place when
-    // state is non-null and otherwise returns a fresh palloc'd copy.
-    template <class INPUT_TYPE, class STATE, class OP>
-    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
-        // INPUT_TYPE is string_t for blob-encoded spans.
-        const Span *input_span = reinterpret_cast<const Span *>(input.GetData());
-        if (!state.isset) {
-            // First call: initialize state with a copy of the input.
-            memcpy(&state.span, input_span, sizeof(Span));
-            state.isset = true;
-        } else {
-            // Subsequent calls: expand state in place.
-            // span_extent_transfn(state, s) calls span_expand(s, state).
-            (void) span_extent_transfn(&state.span, input_span);
-        }
-    }
-
-    template <class INPUT_TYPE, class STATE, class OP>
-    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
-                                  idx_t /*count*/) {
-        // extent is idempotent in the value dimension, so a single
-        // application is equivalent to applying the same value `count`
-        // times.
-        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
     }
 
     template <class STATE, class OP>
@@ -75,24 +53,108 @@ struct SpanExtentFunction {
             finalize_data.ReturnNull();
             return;
         }
-        target = finalize_data.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
     }
 };
 
-static AggregateFunction MakeExtentSpanAggregate(const LogicalType &span_type) {
-    return AggregateFunction::UnaryAggregate<SpanExtentState, string_t, string_t, SpanExtentFunction>(
-        span_type, span_type);
+// extent(span)
+struct SpanExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Span *input_span = reinterpret_cast<const Span *>(input.GetData());
+        if (!state.isset) {
+            memcpy(&state.span, input_span, sizeof(Span));
+            state.isset = true;
+        } else {
+            (void) span_extent_transfn(&state.span, input_span);
+        }
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+// extent(spanset)
+struct SpansetExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const SpanSet *input_ss = reinterpret_cast<const SpanSet *>(input.GetData());
+        if (!state.isset) {
+            // spanset_extent_transfn(NULL, ss) returns palloc'd Span; copy into state.
+            Span *fresh = spanset_extent_transfn(nullptr, input_ss);
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) spanset_extent_transfn(&state.span, input_ss);
+        }
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+// extent(set)
+struct SetExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Set *input_set = reinterpret_cast<const Set *>(input.GetData());
+        if (!state.isset) {
+            Span *fresh = set_extent_transfn(nullptr, input_set);
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) set_extent_transfn(&state.span, input_set);
+        }
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+template <class FUNC>
+static AggregateFunction MakeExtentAggregate(const LogicalType &input_type, const LogicalType &output_span_type) {
+    return AggregateFunction::UnaryAggregate<SpanExtentState, string_t, string_t, FUNC>(
+        input_type, output_span_type);
 }
 
 } // namespace
 
 void SpanAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
     AggregateFunctionSet extent_set("extent");
-    for (const auto &span_type : {SpanTypes::INTSPAN(), SpanTypes::BIGINTSPAN(),
-                                  SpanTypes::FLOATSPAN(), SpanTypes::DATESPAN(),
-                                  SpanTypes::TSTZSPAN()}) {
-        extent_set.AddFunction(MakeExtentSpanAggregate(span_type));
-    }
+
+    // extent(<span>) -> <span>
+    extent_set.AddFunction(MakeExtentAggregate<SpanExtentFunction>(SpanTypes::INTSPAN(), SpanTypes::INTSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpanExtentFunction>(SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpanExtentFunction>(SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpanExtentFunction>(SpanTypes::DATESPAN(), SpanTypes::DATESPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpanExtentFunction>(SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()));
+
+    // extent(<spanset>) -> <span>
+    extent_set.AddFunction(MakeExtentAggregate<SpansetExtentFunction>(SpansetTypes::intspanset(), SpanTypes::INTSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpansetExtentFunction>(SpansetTypes::bigintspanset(), SpanTypes::BIGINTSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpansetExtentFunction>(SpansetTypes::floatspanset(), SpanTypes::FLOATSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpansetExtentFunction>(SpansetTypes::datespanset(), SpanTypes::DATESPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpansetExtentFunction>(SpansetTypes::tstzspanset(), SpanTypes::TSTZSPAN()));
+
+    // extent(<set>) -> <span>. textset has no span equivalent.
+    extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::intset(), SpanTypes::INTSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::bigintset(), SpanTypes::BIGINTSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::floatset(), SpanTypes::FLOATSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::dateset(), SpanTypes::DATESPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::tstzset(), SpanTypes::TSTZSPAN()));
+
     loader.RegisterFunction(std::move(extent_set));
 }
 


### PR DESCRIPTION
## Summary

Adds **10 new aggregate overloads** to the \`extent()\` set introduced in #47:

- \`extent(<spanset>) → <span>\` for int/bigint/float/date/tstzspanset (5 overloads)
- \`extent(<set>) → <span>\` for int/bigint/float/date/tstzset (5 overloads — \`textset\` has no span equivalent so it's skipped)

\`\`\`sql
SELECT extent(s) FROM (VALUES (intspanset '{[1, 3), [5, 7)}'), (intspanset '{[10, 12)}')) t(s);
-- [1, 12)

SELECT extent(s) FROM (VALUES (intset '{1, 3, 5}'), (intset '{10, 20}')) t(s);
-- [1, 21)

SELECT extent(s) FROM (VALUES (datespanset '{[2000-01-01, 2000-01-03)}'), (datespanset '{[2000-01-05, 2000-01-10)}')) t(s);
-- [2000-01-01, 2000-01-10)
\`\`\`

## Implementation

Adds \`SpansetExtentFunction\` and \`SetExtentFunction\` functors. Both reuse the shared \`SpanExtentState\` (\`Span span + bool isset\`) and \`SpanExtentBase\` (Initialize / Combine / Finalize). Only \`Operation\` differs — it dispatches to the corresponding MEOS transfn:

- \`spanset_extent_transfn(state, ss)\`
- \`set_extent_transfn(state, s)\`

These return a palloc'd \`Span*\` on first call (when state is NULL); the wrapper memcpy-into-state-and-frees, then expands the inline state in place on subsequent calls — same convention as the original \`SpanExtentFunction\`.

## Stacked on
- #47 (AggregateFunction infrastructure + extent(span))

## Test plan
- [x] Smoke test all 3 surfaces (span / spanset / set) for all 5 base types
- [x] NULL handling: mixed NULL + value works for each surface
- [x] Existing test suite still passes locally