### PR TITLE
feat(bindings): extent(tnumber) → tbox + bundle extent overloads in one set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(EXTENSION_SOURCES
     src/mobilityduck_extension.cpp        
     src/temporal/temporal.cpp
     src/temporal/temporal_functions.cpp
+    src/temporal/temporal_aggregates.cpp
     src/temporal/tbox.cpp
     src/temporal/tbox_functions.cpp
     src/geo/stbox.cpp

--- a/src/include/temporal/temporal_aggregates.hpp
+++ b/src/include/temporal/temporal_aggregates.hpp
@@ -5,8 +5,8 @@
 
 namespace duckdb {
 
-struct SpanAggregates {
-    // Add span / spanset / set overloads of extent() to the given set.
+struct TemporalAggregates {
+    // Add tnumber overloads of extent() to the given set.
     static void AddExtentOverloads(AggregateFunctionSet &extent_set);
 };
 

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -13,6 +13,7 @@
 #include "geo/tgeometry.hpp"
 #include "temporal/span.hpp"
 #include "temporal/span_aggregates.hpp"
+#include "temporal/temporal_aggregates.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar_function.hpp"
@@ -244,7 +245,12 @@ static void LoadInternal(ExtensionLoader &loader) {
 	SpanTypes::RegisterScalarFunctions(loader);
 	SpanTypes::RegisterTypes(loader);
 	SpanTypes::RegisterCastFunctions(loader);
-	SpanAggregates::RegisterAggregateFunctions(loader);
+	{
+		AggregateFunctionSet extent_set("extent");
+		SpanAggregates::AddExtentOverloads(extent_set);
+		TemporalAggregates::AddExtentOverloads(extent_set);
+		loader.RegisterFunction(std::move(extent_set));
+	}
 
 	TgeompointType::RegisterType(loader);
 	TgeompointType::RegisterCastFunctions(loader);

--- a/src/temporal/span_aggregates.cpp
+++ b/src/temporal/span_aggregates.cpp
@@ -131,9 +131,7 @@ static AggregateFunction MakeExtentAggregate(const LogicalType &input_type, cons
 
 } // namespace
 
-void SpanAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
-    AggregateFunctionSet extent_set("extent");
-
+void SpanAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
     // extent(<span>) -> <span>
     extent_set.AddFunction(MakeExtentAggregate<SpanExtentFunction>(SpanTypes::INTSPAN(), SpanTypes::INTSPAN()));
     extent_set.AddFunction(MakeExtentAggregate<SpanExtentFunction>(SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()));
@@ -154,8 +152,6 @@ void SpanAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
     extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::floatset(), SpanTypes::FLOATSPAN()));
     extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::dateset(), SpanTypes::DATESPAN()));
     extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::tstzset(), SpanTypes::TSTZSPAN()));
-
-    loader.RegisterFunction(std::move(extent_set));
 }
 
 } // namespace duckdb

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -1,0 +1,100 @@
+#include "meos_wrapper_simple.hpp"
+
+#include "temporal/tbox.hpp"
+#include "temporal/temporal.hpp"
+#include "temporal/temporal_aggregates.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+namespace {
+
+// State for extent(tnumber) → tbox. TBox is a fixed-size POD struct
+// (Span period + Span span + int16 flags) so it can live inline in
+// the aggregate state.
+struct TboxExtentState {
+    TBox box;
+    bool isset;
+};
+
+struct TnumberExtentFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.isset = false;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        // Temporal is varlena: copy the blob into a heap allocation
+        // before passing to MEOS so the lifetime is well-defined.
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+
+        if (!state.isset) {
+            // tnumber_extent_transfn(NULL, temp) palloc's a fresh TBox.
+            TBox *fresh = tnumber_extent_transfn(nullptr, temp);
+            memcpy(&state.box, fresh, sizeof(TBox));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) tnumber_extent_transfn(&state.box, temp);
+        }
+        free(temp);
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) {
+            return;
+        }
+        if (!target.isset) {
+            memcpy(&target.box, &source.box, sizeof(TBox));
+            target.isset = true;
+        } else {
+            // Combine two TBoxes: expand target with source via tbox_expand.
+            // Replicates the inline path in tnumber_extent_transfn when both
+            // operands are non-null TBox values.
+            tbox_expand(&source.box, &target.box);
+        }
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.isset) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(&state.box), sizeof(TBox)));
+    }
+};
+
+static AggregateFunction MakeExtentTnumberAggregate(const LogicalType &tnumber_type) {
+    return AggregateFunction::UnaryAggregate<TboxExtentState, string_t, string_t, TnumberExtentFunction>(
+        tnumber_type, TboxType::TBOX());
+}
+
+} // namespace
+
+void TemporalAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
+    extent_set.AddFunction(MakeExtentTnumberAggregate(TemporalTypes::TINT()));
+    extent_set.AddFunction(MakeExtentTnumberAggregate(TemporalTypes::TFLOAT()));
+}
+
+} // namespace duckdb


### PR DESCRIPTION
## Summary

Adds **2 new aggregate overloads**:

| Overload | Returns |
|---|---|
| \`extent(tint)\` | \`tbox\` (TBOXINT XT) |
| \`extent(tfloat)\` | \`tbox\` (TBOXFLOAT XT) |

\`\`\`sql
SELECT extent(t) FROM (VALUES (tint '[1@2000-01-01, 5@2000-01-05]'),
                              (tint '[10@2000-01-03, 20@2000-01-08]')) tt(t);
-- TBOXINT XT([1, 21),[2000-01-01 00:00:00+00, 2000-01-08 00:00:00+00])
\`\`\`

## Implementation

New module: \`src/temporal/temporal_aggregates.cpp\` + \`src/include/temporal/temporal_aggregates.hpp\`.

| Component | What it does |
|---|---|
| \`TboxExtentState\` | Inline \`TBox box\` + \`bool isset\`. TBox is fixed-size POD (Span period + Span span + int16 flags). |
| \`TnumberExtentFunction::Operation\` | Copies input Temporal blob into a heap allocation, calls MEOS \`tnumber_extent_transfn\`. First call returns a palloc'd TBox which we memcpy-and-free into state; subsequent calls expand state in place. |
| \`TnumberExtentFunction::Combine\` | Merges two TBox states via \`tbox_expand\` — replicates the inline path in MEOS when both operands are non-null TBoxes. |
| \`TnumberExtentFunction::Finalize\` | Returns blob or NULL. |

## API refactor (driven by adding the second module)

Previously each module registered its own \`AggregateFunctionSet(\"extent\")\` directly via the loader. That worked when only \`SpanAggregates\` existed (PR #47). Adding \`TemporalAggregates\` with the same set name surfaced a DuckDB constraint: a second registration with the same aggregate name triggers an ALTER path, but \`CreateAggregateFunctionInfo\` doesn't override \`GetAlterInfo()\`, so it throws \`NotImplementedException\`.

Fix: both modules now expose \`AddExtentOverloads(AggregateFunctionSet &)\` that mutate a shared set. The load site in \`LoadInternal\` builds one set, calls both, then registers exactly once:

\`\`\`cpp
AggregateFunctionSet extent_set("extent");
SpanAggregates::AddExtentOverloads(extent_set);
TemporalAggregates::AddExtentOverloads(extent_set);
loader.RegisterFunction(std::move(extent_set));
\`\`\`

## Stacked on
- #47 (AggregateFunction infrastructure + extent(span))
- #48 (extent(spanset/set))

## Test plan
- [x] \`extent(tint)\`, \`extent(tfloat)\` produce correct TBOXINT/TBOXFLOAT
- [x] NULL handling
- [x] Regression: existing span/spanset/set overloads from #47/#48 still work after the bundling refactor
- [x] Existing test suite still passes