### PR TITLE
feat(bindings): tCount(temporal) aggregate — first skiplist-backed aggregate

### DIFF
--- a/src/include/temporal/temporal_aggregates.hpp
+++ b/src/include/temporal/temporal_aggregates.hpp
@@ -8,6 +8,9 @@ namespace duckdb {
 struct TemporalAggregates {
     // Add tnumber overloads of extent() to the given set.
     static void AddExtentOverloads(AggregateFunctionSet &extent_set);
+
+    // Register tCount(temporal) → tint as its own AggregateFunctionSet.
+    static void RegisterTCount(ExtensionLoader &loader);
 };
 
 } // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -251,6 +251,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 		TemporalAggregates::AddExtentOverloads(extent_set);
 		loader.RegisterFunction(std::move(extent_set));
 	}
+	TemporalAggregates::RegisterTCount(loader);
 
 	TgeompointType::RegisterType(loader);
 	TgeompointType::RegisterCastFunctions(loader);

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -90,11 +90,119 @@ static AggregateFunction MakeExtentTnumberAggregate(const LogicalType &tnumber_t
         tnumber_type, TboxType::TBOX());
 }
 
+// ============================================================================
+// tCount(temporal) → tint
+//
+// State holds a MEOS SkipList* (heap-allocated separately from the inline
+// aggregate state). The state size is just `sizeof(SkipList *)`. Lifetime
+// is managed via the aggregate destructor which calls skiplist_free.
+// ============================================================================
+
+struct TCountState {
+    SkipList *skiplist;
+};
+
+// Local equivalent of MEOS's datum_sum_int32 (not exported from MEOS public
+// or internal headers). Used as the merge function when splicing two
+// tcount skiplists during Combine.
+static Datum mduck_datum_sum_int32(Datum l, Datum r) {
+    int32_t li = static_cast<int32_t>(l);
+    int32_t ri = static_cast<int32_t>(r);
+    return static_cast<Datum>(static_cast<int32_t>(li + ri));
+}
+
+struct TCountFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.skiplist = nullptr;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+        // MEOS allocates the SkipList on the first call (state == NULL) and
+        // returns the same/extended state on subsequent calls.
+        state.skiplist = temporal_tcount_transfn(state.skiplist, temp);
+        free(temp);
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.skiplist || source.skiplist->length == 0) {
+            return;
+        }
+        if (!target.skiplist) {
+            const_cast<STATE &>(target).skiplist = temporal_skiplist_make();
+        }
+        // Splice source's already-counted instants into target with a
+        // sum merge function. Equivalent to MEOS's internal
+        // temporal_tagg_combinefn(state1, state2, datum_sum_int32, false)
+        // without depending on the unexported symbol.
+        void **values = skiplist_values(source.skiplist);
+        int count = source.skiplist->length;
+        temporal_skiplist_splice(target.skiplist, values, count,
+                                 &mduck_datum_sum_int32, false);
+        free(values);
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.skiplist || state.skiplist->length == 0) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        Temporal *result = temporal_tagg_finalfn(state.skiplist);
+        // temporal_tagg_finalfn calls skiplist_free internally; null out
+        // the pointer so our destructor doesn't double-free.
+        state.skiplist = nullptr;
+        if (!result) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        size_t out_size = temporal_mem_size(result);
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(result), out_size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
 } // namespace
 
 void TemporalAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
     extent_set.AddFunction(MakeExtentTnumberAggregate(TemporalTypes::TINT()));
     extent_set.AddFunction(MakeExtentTnumberAggregate(TemporalTypes::TFLOAT()));
+}
+
+void TemporalAggregates::RegisterTCount(ExtensionLoader &loader) {
+    AggregateFunctionSet tcount_set("tCount");
+    for (const auto &t : TemporalTypes::AllTypes()) {
+        AggregateFunction fn =
+            AggregateFunction::UnaryAggregateDestructor<TCountState, string_t, string_t, TCountFunction>(
+                t, TemporalTypes::TINT());
+        tcount_set.AddFunction(fn);
+    }
+    loader.RegisterFunction(std::move(tcount_set));
 }
 
 } // namespace duckdb


### PR DESCRIPTION
## Summary

Adds \`tCount()\` aggregate over all 4 temporal base types (\`tint\`, \`tbool\`, \`tfloat\`, \`ttext\`). Returns a \`tint\` where each instant carries the count of input temporal values valid at that instant.

\`\`\`sql
-- distinct timestamps, count = 1 at each instant
SELECT tCount(t) FROM (VALUES (tint '1@2000-01-01'), (tint '2@2000-01-02')) tt(t);
-- {1@2000-01-01, 1@2000-01-02}

-- duplicate timestamp, count sums to 2
SELECT tCount(t) FROM (VALUES (tint '1@2000-01-01'), (tint '5@2000-01-01')) tt(t);
-- {2@2000-01-01}

-- overlapping sequences, count = 2 in overlap region
SELECT tCount(t) FROM (VALUES (tint '[1@2000-01-01, 1@2000-01-05]'),
                              (tint '[1@2000-01-03, 1@2000-01-07]')) tt(t);
-- {[1@2000-01-01, 2@2000-01-03, 2@2000-01-05], (1@2000-01-05, 1@2000-01-07]}
\`\`\`

## Implementation pattern (new for MobilityDuck)

This is the first **skiplist-backed** aggregate in MobilityDuck. The pattern established here generalises to \`tand\`, \`tor\`, \`tmin\`, \`tmax\`, \`tsum\`, \`tavg\`, \`twAvg\`, etc. — only the underlying \`*_transfn\` and merge function differ.

| Component | What it does |
|---|---|
| \`TCountState\` | Holds a heap-allocated \`SkipList *skiplist\` — the skiplist itself lives outside the inline aggregate state buffer. |
| Registration | \`AggregateFunction::UnaryAggregateDestructor\` instead of \`UnaryAggregate\` — installs a destructor calling \`TCountFunction::Destroy\` → \`skiplist_free\`. |
| \`Operation\` | Copies the input Temporal blob (varlena) into a heap allocation and calls \`temporal_tcount_transfn\` — MEOS allocates a fresh skiplist on the first call and extends it in place on subsequent calls. |
| \`Combine\` | Merges two skiplists via \`temporal_skiplist_splice\` with a sum merge function. MEOS's \`datum_sum_int32\` is not exported, so we provide a local equivalent (\`mduck_datum_sum_int32\`). |
| \`Finalize\` | Calls \`temporal_tagg_finalfn\` which produces a \`Temporal*\` **and** internally calls \`skiplist_free\`. We null \`state.skiplist\` after the call so the destructor doesn't double-free. |

## Stacked on

- #47 (AggregateFunction infra)
- #48 (extent spanset/set)
- #49 (extent tnumber)

## Test plan
- [x] Single-row tCount on tint/tfloat/tbool/ttext
- [x] Multi-row distinct timestamps (count = 1 at each instant)
- [x] Multi-row duplicate timestamps (count sums correctly)
- [x] Overlapping sequences (count rises in overlap region)
- [x] NULL handling: NULL ignored mid-run, all-NULL returns NULL
- [x] No segfaults on aggregate state cleanup (destructor + Finalize ordering)