### PR TITLE
fix error for initializing Geos

### DIFF
--- a/src/geo/geoset.cpp
+++ b/src/geo/geoset.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "spatial/spatial_types.hpp"
+#include "mobilityduck/meos_exec_serial.hpp"
 
 extern "C" {    
     #include "meos.h"    
@@ -49,95 +50,95 @@ void SpatialSetType::RegisterCastFunctions(ExtensionLoader &loader) {
 }
 
 void SpatialSetType::RegisterScalarFunctions(ExtensionLoader &loader) {	    
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"asText", 
         {SpatialSetType::geomset()}, LogicalType::VARCHAR, SpatialSetFunctions::Spatialset_as_text));
     
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"asText", 
         {SpatialSetType::geogset()}, LogicalType::VARCHAR, SpatialSetFunctions::Spatialset_as_text));
 
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"asText", 
         {SpatialSetType::geomset(), LogicalType::INTEGER}, LogicalType::VARCHAR, SpatialSetFunctions::Spatialset_as_text));
     
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"asText", 
         {SpatialSetType::geogset(), LogicalType::INTEGER}, LogicalType::VARCHAR, SpatialSetFunctions::Spatialset_as_text));
 
-        loader.RegisterFunction( ScalarFunction(
+        duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"asEWKT", 
         {SpatialSetType::geomset()}, LogicalType::VARCHAR, SpatialSetFunctions::Spatialset_as_ewkt));
     
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"asEWKT", 
         {SpatialSetType::geogset()}, LogicalType::VARCHAR, SpatialSetFunctions::Spatialset_as_ewkt));
 
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"asEWKT", 
         {SpatialSetType::geomset(), LogicalType::INTEGER}, LogicalType::VARCHAR, SpatialSetFunctions::Spatialset_as_ewkt));
     
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"asEWKT", 
         {SpatialSetType::geogset(), LogicalType::INTEGER}, LogicalType::VARCHAR, SpatialSetFunctions::Spatialset_as_ewkt));    
 
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
         "memSize", 
         {SpatialSetType::geomset()}, LogicalType::INTEGER, SpatialSetFunctions::Set_mem_size));
     
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
         "memSize", 
         {SpatialSetType::geogset()}, LogicalType::INTEGER, SpatialSetFunctions::Set_mem_size));
 
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
         "SRID", 
         {SpatialSetType::geomset()}, LogicalType::INTEGER, SpatialSetFunctions::Spatialset_srid));
     
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
         "SRID", 
         {SpatialSetType::geogset()}, LogicalType::INTEGER, SpatialSetFunctions::Spatialset_srid));
 
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"setSRID", 
         {SpatialSetType::geomset(), LogicalType::INTEGER}, SpatialSetType::geomset(), SpatialSetFunctions::Spatialset_set_srid));
 
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"setSRID", 
         {SpatialSetType::geogset(), LogicalType::INTEGER}, SpatialSetType::geogset(), SpatialSetFunctions::Spatialset_set_srid));
 
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"transform", 
         {SpatialSetType::geomset(), LogicalType::INTEGER}, SpatialSetType::geomset(), SpatialSetFunctions::Spatialset_transform));
     
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"transform", 
         {SpatialSetType::geogset(), LogicalType::INTEGER}, SpatialSetType::geogset(), SpatialSetFunctions::Spatialset_transform));
 
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
 		"startValue", {SpatialSetType::geomset()},  
 		GeoTypes::GEOMETRY(),
 		SpatialSetFunctions::Set_start_value
 	));    
 
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
         "endValue", 
         {SpatialSetType::geomset()}, GeoTypes::GEOMETRY(), SpatialSetFunctions::Set_end_value));
 
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
         "numValues",
         {SpatialSetType::geomset()}, LogicalType::INTEGER, SpatialSetFunctions::Set_num_values));
     
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
         "numValues",
         {SpatialSetType::geogset()}, LogicalType::INTEGER, SpatialSetFunctions::Set_num_values));
 
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
         "valueN", {SpatialSetType::geomset(), LogicalType::INTEGER},
         GeoTypes::GEOMETRY(),
         SpatialSetFunctions::Set_value_n
     ));
 
-    loader.RegisterFunction( ScalarFunction(
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(
         "set", {LogicalType::LIST(GeoTypes::GEOMETRY())},
         SpatialSetType::geomset(),
         SpatialSetFunctions::Geomset_constructor

--- a/src/geo/stbox.cpp
+++ b/src/geo/stbox.cpp
@@ -11,6 +11,7 @@
 #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
 #include <scoped_allocator>
 #include "spatial/spatial_types.hpp"
+#include "mobilityduck/meos_exec_serial.hpp"
 
 namespace duckdb {
 
@@ -69,11 +70,11 @@ void StboxType::RegisterCastFunctions(ExtensionLoader &loader) {
 }
 
 void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("stbox", {LogicalType::VARCHAR}, STBOX(), StboxFunctions::Stbox_in, nullptr, nullptr, nullptr,
                      nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE));
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stboxFromBinary",
             {LogicalType::BLOB},
@@ -92,7 +93,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
     //     )
     // );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "asText",
             {STBOX()},
@@ -101,7 +102,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "asBinary",
             {STBOX()},
@@ -120,7 +121,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
     //     )
     // );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox",
             {GeoTypes::GEOMETRY(), LogicalType::TIMESTAMP_TZ},
@@ -129,7 +130,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox",
             {GeoTypes::GEOMETRY(), SpanTypes::TSTZSPAN()},
@@ -138,7 +139,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox",
             {LogicalType::TIMESTAMP_TZ},
@@ -147,7 +148,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox",
             {SetTypes::tstzset()},
@@ -156,7 +157,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox",
             {SpanTypes::TSTZSPAN()},
@@ -165,7 +166,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox",
             {SpansetTypes::tstzspanset()},
@@ -175,7 +176,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
     );
     
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox",
             {GeoTypes::GEOMETRY()},
@@ -184,7 +185,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "geometry",
             {STBOX()},
@@ -193,7 +194,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "hasX",
             {STBOX()},
@@ -201,7 +202,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_hasx
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "hasZ",
             {STBOX()},
@@ -209,7 +210,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_hasz
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "hasT",
             {STBOX()},
@@ -217,7 +218,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_hast
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "isGeodetic",
             {STBOX()},
@@ -226,7 +227,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "Xmin",
             {STBOX()},
@@ -235,7 +236,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "Ymin",
             {STBOX()},
@@ -243,7 +244,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_ymin
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "Zmin",
             {STBOX()},
@@ -252,7 +253,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "Tmin",
             {STBOX()},
@@ -261,7 +262,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "TminInc",
             {STBOX()},
@@ -270,7 +271,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "Xmax",
             {STBOX()},
@@ -279,7 +280,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "Ymax",
             {STBOX()},
@@ -288,7 +289,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "Zmax",
             {STBOX()},
@@ -297,7 +298,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
  
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "Tmax",
             {STBOX()},
@@ -305,7 +306,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_tmax
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "TmaxInc",
             {STBOX()},
@@ -314,7 +315,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "area",
             {STBOX()},
@@ -323,7 +324,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "volume",
             {STBOX()},
@@ -332,7 +333,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "shiftTime",
             {STBOX(), LogicalType::INTERVAL},
@@ -340,7 +341,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_shift_time
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "scaleTime",
             {STBOX(), LogicalType::INTERVAL},
@@ -348,7 +349,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_scale_time
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "shiftScaleTime",
             {STBOX(), LogicalType::INTERVAL, LogicalType::INTERVAL},
@@ -357,7 +358,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "getSpace",
             {STBOX()},
@@ -366,7 +367,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "expandTime",
             {STBOX(), LogicalType::INTERVAL},
@@ -375,7 +376,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "expandSpace",
             {STBOX(), LogicalType::DOUBLE},
@@ -384,7 +385,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_contains",
             {STBOX(), STBOX()},
@@ -393,7 +394,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_contained",
             {STBOX(), STBOX()},
@@ -401,7 +402,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Contained_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_overlaps",
             {STBOX(), STBOX()},
@@ -410,7 +411,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_same",
             {STBOX(), STBOX()},
@@ -418,7 +419,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Same_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_adjacent",
             {STBOX(), STBOX()},
@@ -426,7 +427,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Adjacent_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "@>",
             {STBOX(), STBOX()},
@@ -434,7 +435,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Contains_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<@",
             {STBOX(), STBOX()},
@@ -442,7 +443,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Contained_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "&&",
             {STBOX(), STBOX()},
@@ -450,7 +451,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Overlaps_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "~=",
             {STBOX(), STBOX()},
@@ -458,7 +459,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Same_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "-|-",
             {STBOX(), STBOX()},
@@ -467,7 +468,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_left",
             {STBOX(), STBOX()},
@@ -476,7 +477,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_overleft",
             {STBOX(), STBOX()},
@@ -484,7 +485,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Overleft_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_right",
             {STBOX(), STBOX()},
@@ -493,7 +494,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_overright",
             {STBOX(), STBOX()},
@@ -501,7 +502,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Overright_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_below",
             {STBOX(), STBOX()},
@@ -509,7 +510,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Below_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_overbelow",
             {STBOX(), STBOX()},
@@ -517,7 +518,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Overbelow_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_above",
             {STBOX(), STBOX()},
@@ -526,7 +527,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_overabove",
             {STBOX(), STBOX()},
@@ -535,7 +536,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_before",
             {STBOX(), STBOX()},
@@ -544,7 +545,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_overbefore",
             {STBOX(), STBOX()},
@@ -553,7 +554,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_after",
             {STBOX(), STBOX()},
@@ -562,7 +563,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_overafter",
             {STBOX(), STBOX()},
@@ -571,7 +572,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_front",
             {STBOX(), STBOX()},
@@ -580,7 +581,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_overfront",
             {STBOX(), STBOX()},
@@ -589,7 +590,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_back",
             {STBOX(), STBOX()},
@@ -598,7 +599,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_overback",
             {STBOX(), STBOX()},
@@ -607,7 +608,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<<",
             {STBOX(), STBOX()},
@@ -616,7 +617,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "&<",
             {STBOX(), STBOX()},
@@ -624,7 +625,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Overleft_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             ">>",
             {STBOX(), STBOX()},
@@ -633,7 +634,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "&>",
             {STBOX(), STBOX()},
@@ -641,7 +642,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Overright_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<<|",
             {STBOX(), STBOX()},
@@ -649,7 +650,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Below_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "&<|",
             {STBOX(), STBOX()},
@@ -657,7 +658,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Overbelow_stbox_stbox
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "|>>",
             {STBOX(), STBOX()},
@@ -666,7 +667,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "|&>",
             {STBOX(), STBOX()},
@@ -675,7 +676,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 // # is not a operator in Duckdb, fix later
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<<#",  
             {STBOX(), STBOX()},
@@ -684,7 +685,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "&<#",
             {STBOX(), STBOX()},
@@ -693,7 +694,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "#>>",
             {STBOX(), STBOX()},
@@ -702,7 +703,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "#&>",
             {STBOX(), STBOX()},
@@ -711,7 +712,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<</",
             {STBOX(), STBOX()},
@@ -720,7 +721,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "&</",
             {STBOX(), STBOX()},
@@ -729,7 +730,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "/>>",
             {STBOX(), STBOX()},
@@ -738,7 +739,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "/&>",
             {STBOX(), STBOX()},
@@ -747,7 +748,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_union",
             {STBOX(), STBOX()},
@@ -756,7 +757,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_intersection",
             {STBOX(), STBOX()},
@@ -765,7 +766,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "+",
             {STBOX(), STBOX()},
@@ -774,7 +775,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
     
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "*",
             {STBOX(), STBOX()},
@@ -783,7 +784,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_cmp",
             {STBOX(), STBOX()},
@@ -791,7 +792,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_cmp
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_eq",
             {STBOX(), STBOX()},
@@ -799,7 +800,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_eq
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_ne",
             {STBOX(), STBOX()},
@@ -807,7 +808,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_ne
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_lt",
             {STBOX(), STBOX()},
@@ -815,7 +816,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_lt
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_le",
             {STBOX(), STBOX()},
@@ -823,7 +824,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_le
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_ge",
             {STBOX(), STBOX()},
@@ -831,7 +832,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_ge
         )
     );  
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox_gt",
             {STBOX(), STBOX()},
@@ -840,7 +841,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "=",
             {STBOX(), STBOX()},
@@ -848,7 +849,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_eq
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<>",
             {STBOX(), STBOX()},
@@ -856,7 +857,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_ne
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<",
             {STBOX(), STBOX()},
@@ -864,7 +865,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_lt
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<=",
             {STBOX(), STBOX()},
@@ -872,7 +873,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_le
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             ">=",
             {STBOX(), STBOX()},
@@ -880,7 +881,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_ge
         )
     );  
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             ">",
             {STBOX(), STBOX()},

--- a/src/geo/tgeometry.cpp
+++ b/src/geo/tgeometry.cpp
@@ -7,6 +7,7 @@
 #include<time_util.hpp>
 #include "geo_util.hpp"
 #include "spatial/spatial_types.hpp"
+#include "mobilityduck/meos_exec_serial.hpp"
 
 extern "C" {
     #include <meos.h>
@@ -1089,14 +1090,14 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         TGeometryTypes::TGEOMETRY(),
         Tgeo_constructor
     );
-    loader.RegisterFunction( tgeometry_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometry_function);
         
     auto tgeometry_from_timestamp_function = ScalarFunction(
         "TGEOMETRY",
         {LogicalType::VARCHAR, LogicalType::TIMESTAMP_TZ}, 
         TGeometryTypes::TGEOMETRY(), 
         Tgeoinst_constructor);
-    loader.RegisterFunction( tgeometry_from_timestamp_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometry_from_timestamp_function);
 
      auto tgeometry_from_tstzspan_function = ScalarFunction(
         "TGEOMETRY", 
@@ -1104,7 +1105,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         TGeometryTypes::TGEOMETRY(),  
         Tsequence_from_base_tstzspan
     );
-    loader.RegisterFunction( tgeometry_from_tstzspan_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometry_from_tstzspan_function);
 
     auto tgeometry_from_tstzspan_default = ScalarFunction(
         "TGEOMETRY", 
@@ -1112,7 +1113,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         TGeometryTypes::TGEOMETRY(),  
         Tsequence_from_base_tstzspan
     );
-    loader.RegisterFunction( tgeometry_from_tstzspan_default);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometry_from_tstzspan_default);
 
      auto tgeometryseqarr_1param= ScalarFunction(
         "tgeometrySeq", 
@@ -1120,7 +1121,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         TGeometryTypes::TGEOMETRY(),
         Tsequence_constructor
     );
-    loader.RegisterFunction( tgeometryseqarr_1param);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometryseqarr_1param);
 
     auto tgeometryseqarr_2params = ScalarFunction(
         "tgeometrySeq", 
@@ -1128,7 +1129,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         TGeometryTypes::TGEOMETRY(),
         Tsequence_constructor
     );
-    loader.RegisterFunction( tgeometryseqarr_2params);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometryseqarr_2params);
 
     auto tgeometryseqarr_3params = ScalarFunction(
         "tgeometrySeq", 
@@ -1136,7 +1137,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         TGeometryTypes::TGEOMETRY(),
         Tsequence_constructor
     );
-    loader.RegisterFunction( tgeometryseqarr_3params);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometryseqarr_3params);
 
     auto tgeometryseqarr_4params = ScalarFunction(
         "tgeometrySeq", 
@@ -1144,21 +1145,21 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         TGeometryTypes::TGEOMETRY(),
         Tsequence_constructor
     );
-    loader.RegisterFunction( tgeometryseqarr_4params);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometryseqarr_4params);
 
     auto tgeometry_to_timespan_function = ScalarFunction(
         "timeSpan",
         {TGeometryTypes::TGEOMETRY()},     
         SpanTypes::TSTZSPAN(),               
         Temporal_to_tstzspan);
-    loader.RegisterFunction( tgeometry_to_timespan_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometry_to_timespan_function);
 
     auto tgeometry_to_tinstant_function = ScalarFunction(
         "tgeometryInst",
         {TGeometryTypes::TGEOMETRY()},
         TGeometryTypes::TGEOMETRY(),  
         Temporal_to_tinstant);
-    loader.RegisterFunction( tgeometry_to_tinstant_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometry_to_tinstant_function);
 
 
     auto setInterp_function = ScalarFunction(
@@ -1167,7 +1168,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         TGeometryTypes::TGEOMETRY(),
         Temporal_set_interp
     );
-    loader.RegisterFunction( setInterp_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  setInterp_function);
 
 
     auto merge_function = ScalarFunction(
@@ -1176,7 +1177,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         TGeometryTypes::TGEOMETRY(),
         Temporal_merge
     );
-    loader.RegisterFunction( merge_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  merge_function);
 
     auto tempSubtype_function = ScalarFunction(
         "tempSubtype",
@@ -1184,7 +1185,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         LogicalType::VARCHAR,
         Temporal_subtype
     );
-    loader.RegisterFunction( tempSubtype_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  tempSubtype_function);
 
     auto interp_function = ScalarFunction(
         "interp",
@@ -1192,7 +1193,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         LogicalType::VARCHAR,
         Temporal_interp
     );
-    loader.RegisterFunction( interp_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  interp_function);
 
     auto memSize_function = ScalarFunction(
         "memSize",
@@ -1200,7 +1201,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         LogicalType::INTEGER,
         Temporal_mem_size
     );
-    loader.RegisterFunction( memSize_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  memSize_function);
 
     auto getValue_function = ScalarFunction(
         "getValue",
@@ -1208,7 +1209,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         GeoTypes::GEOMETRY(),
         Tinstant_value
     );
-    loader.RegisterFunction( getValue_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  getValue_function);
     
 
     auto tgeometry_start_value_function = ScalarFunction(
@@ -1217,7 +1218,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         GeoTypes::GEOMETRY(),
         Temporal_start_value
     );
-    loader.RegisterFunction( tgeometry_start_value_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometry_start_value_function);
 
     auto tgeometry_end_value_function = ScalarFunction(
         "endValue", 
@@ -1225,7 +1226,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         GeoTypes::GEOMETRY(),
         Temporal_end_value
     );
-    loader.RegisterFunction( tgeometry_end_value_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometry_end_value_function);
 
     auto startInstant_function = ScalarFunction(
         "startInstant",
@@ -1233,7 +1234,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         TGeometryTypes::TGEOMETRY(), 
         Temporal_start_instant
     );
-    loader.RegisterFunction( startInstant_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  startInstant_function);
 
     auto endInstant_function = ScalarFunction(
         "endInstant",
@@ -1241,7 +1242,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         TGeometryTypes::TGEOMETRY(), 
         Temporal_end_instant
     );
-    loader.RegisterFunction( endInstant_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  endInstant_function);
 
     auto instantN_function = ScalarFunction(
         "instantN",
@@ -1249,7 +1250,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         TGeometryTypes::TGEOMETRY(),  
         Temporal_instant_n
     );
-    loader.RegisterFunction( instantN_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  instantN_function);
 
 
     auto tgeometry_gettimestamptz_function = ScalarFunction(
@@ -1257,7 +1258,7 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         {TGeometryTypes::TGEOMETRY()},
         LogicalType::TIMESTAMP_TZ,  
         Tinstant_timestamptz);
-    loader.RegisterFunction( tgeometry_gettimestamptz_function);
+    duckdb::RegisterSerializedScalarFunction(loader,  tgeometry_gettimestamptz_function);
     
 
 }

--- a/src/geo/tgeometry_in_out.cpp
+++ b/src/geo/tgeometry_in_out.cpp
@@ -4,6 +4,7 @@
 #include <regex>
 #include <string>
 #include <temporal/span.hpp>
+#include "mobilityduck/meos_exec_serial.hpp"
 
 extern "C" {
     #include <meos.h>
@@ -201,7 +202,7 @@ void TGeometryTypes::RegisterScalarInOutFunctions(ExtensionLoader &loader){
             LogicalType::VARCHAR,
             Tspatial_as_text
         );
-        loader.RegisterFunction( TgeometryAsText);
+        duckdb::RegisterSerializedScalarFunction(loader,  TgeometryAsText);
 
     auto TgeometryAsEWKT = ScalarFunction(
         "asEWKT",
@@ -209,7 +210,7 @@ void TGeometryTypes::RegisterScalarInOutFunctions(ExtensionLoader &loader){
         LogicalType::VARCHAR,
         Tspatial_as_ewkt
     );
-    loader.RegisterFunction( TgeometryAsEWKT);
+    duckdb::RegisterSerializedScalarFunction(loader,  TgeometryAsEWKT);
 }
 
 

--- a/src/geo/tgeompoint.cpp
+++ b/src/geo/tgeompoint.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
 #include "spatial/spatial_types.hpp"
+#include "mobilityduck/meos_exec_serial.hpp"
 
 namespace duckdb {
 
@@ -61,7 +62,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
      * In/out functions
      ****************************************************/
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "asText",
             {TGEOMPOINT()},
@@ -70,7 +71,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "asEWKT",
             {TGEOMPOINT()},
@@ -81,7 +82,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
 
     const auto varchar_list = LogicalType::LIST(LogicalType::VARCHAR);
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "asText",
             {LogicalType::LIST(TGEOMPOINT())},
@@ -89,7 +90,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Spatialarr_as_text
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "asText",
             {LogicalType::LIST(TGEOMPOINT()), LogicalType::INTEGER},
@@ -97,7 +98,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Spatialarr_as_text
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "asText",
             {LogicalType::LIST(GeoTypes::GEOMETRY())},
@@ -105,7 +106,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Spatialarr_as_text
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "asText",
             {LogicalType::LIST(GeoTypes::GEOMETRY()), LogicalType::INTEGER},
@@ -114,7 +115,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "asEWKT",
             {LogicalType::LIST(TGEOMPOINT())},
@@ -122,7 +123,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Spatialarr_as_ewkt
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "asEWKT",
             {LogicalType::LIST(TGEOMPOINT()), LogicalType::INTEGER},
@@ -130,7 +131,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Spatialarr_as_ewkt
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "asEWKT",
             {LogicalType::LIST(GeoTypes::GEOMETRY())},
@@ -138,7 +139,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Spatialarr_as_ewkt
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "asEWKT",
             {LogicalType::LIST(GeoTypes::GEOMETRY()), LogicalType::INTEGER},
@@ -150,7 +151,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     /* ***************************************************
     * Constructor functions
     ****************************************************/
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "TGEOMPOINT",
             {GeoTypes::GEOMETRY(), LogicalType::TIMESTAMP_TZ},
@@ -159,7 +160,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "TGEOMPOINT",
             {GeoTypes::GEOMETRY(), LogicalType::TIMESTAMP_TZ, LogicalType::INTEGER}, // with SRID
@@ -168,7 +169,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tgeompoint",
             {GeoTypes::GEOMETRY(), SetTypes::tstzset()},
@@ -177,7 +178,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tgeompoint",
             {GeoTypes::GEOMETRY(), SpanTypes::TSTZSPAN()},
@@ -186,7 +187,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-     loader.RegisterFunction(
+     duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tgeompoint",
             {GeoTypes::GEOMETRY(), SpanTypes::TSTZSPAN(), LogicalType::VARCHAR},
@@ -195,7 +196,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tgeompoint",
             {GeoTypes::GEOMETRY(), SpansetTypes::tstzspanset()},
@@ -204,7 +205,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tgeompoint",
             {GeoTypes::GEOMETRY(), SpansetTypes::tstzspanset(), LogicalType::VARCHAR},
@@ -213,7 +214,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tgeompointSeq",
             {LogicalType::LIST(TGEOMPOINT())},
@@ -223,7 +224,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tgeompointSeqSet",
             {LogicalType::LIST(TGEOMPOINT())},
@@ -232,7 +233,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stbox",
             {TGEOMPOINT()},
@@ -244,7 +245,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     /* ***************************************************
      * Conversion functions
      ****************************************************/
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "timeSpan",
             {TGEOMPOINT()},
@@ -257,7 +258,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
      * Transformation functions
      ****************************************************/
     
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tgeompointInst",
             {TGEOMPOINT()},
@@ -266,7 +267,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tgeompointSeq",
             {TGEOMPOINT(), LogicalType::VARCHAR},
@@ -275,7 +276,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tgeompointSeq",
             {TGEOMPOINT()},
@@ -284,7 +285,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tgeompointSeqSet",
             {TGEOMPOINT(), LogicalType::VARCHAR},
@@ -293,7 +294,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tgeompointSeqSet",
             {TGEOMPOINT()},
@@ -302,7 +303,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "setInterp",
             {TGEOMPOINT(), LogicalType::VARCHAR},
@@ -311,7 +312,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "appendInstant",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -320,7 +321,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "appendSequence",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -329,7 +330,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "merge",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -338,7 +339,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
      );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "merge",
             {LogicalType::LIST(TGEOMPOINT())},
@@ -350,7 +351,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     /* ***************************************************
     * Accessor functions
     ****************************************************/
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tempSubtype",
             {TGEOMPOINT()},
@@ -359,7 +360,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "interp",
             {TGEOMPOINT()},
@@ -368,7 +369,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "getValue",
             {TGEOMPOINT()},
@@ -377,7 +378,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "getTimestamp",
             {TGEOMPOINT()},
@@ -386,7 +387,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "valueSet",
             {TGEOMPOINT()},
@@ -395,7 +396,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "valueN",
             // BIGINT to match the sibling `valueN(<other temporal>, BIGINT)`
@@ -409,7 +410,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "getTime",
             {TGEOMPOINT()},
@@ -418,7 +419,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "startValue",
             {TGEOMPOINT()},
@@ -427,7 +428,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "endValue",
             {TGEOMPOINT()},
@@ -435,7 +436,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Tgeompoint_end_value
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "duration",
             {TGEOMPOINT()},
@@ -444,7 +445,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "duration",
             {TGEOMPOINT(), LogicalType::BOOLEAN},
@@ -453,7 +454,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "memSize",
             {TGEOMPOINT()},
@@ -462,7 +463,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "lowerInc",
             {TGEOMPOINT()},
@@ -471,7 +472,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "upperInc",
             {TGEOMPOINT()},
@@ -480,7 +481,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "numInstants",
             {TGEOMPOINT()},
@@ -489,7 +490,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "startInstant",
             {TGEOMPOINT()},
@@ -498,7 +499,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "endInstant",
             {TGEOMPOINT()},
@@ -507,7 +508,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "instantN",
             {TGEOMPOINT(), LogicalType::INTEGER},
@@ -516,7 +517,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "instants",
             {TGEOMPOINT()},
@@ -525,7 +526,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "numTimestamps",
             {TGEOMPOINT()},
@@ -533,7 +534,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TemporalFunctions::Temporal_num_timestamps
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "startTimestamp",
             {TGEOMPOINT()},
@@ -542,7 +543,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "endTimestamp",
             {TGEOMPOINT()},
@@ -551,7 +552,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "timestampN",
             {TGEOMPOINT(), LogicalType::INTEGER},
@@ -560,7 +561,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "timestamps",
             {TGEOMPOINT()},
@@ -569,7 +570,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "numSequences",
             {TGEOMPOINT()},
@@ -578,7 +579,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "startSequence",
             {TGEOMPOINT()},
@@ -587,7 +588,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "endSequence",
             {TGEOMPOINT()},
@@ -596,7 +597,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
     
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "sequenceN",
             {TGEOMPOINT(), LogicalType::INTEGER},
@@ -605,7 +606,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "sequences",
             {TGEOMPOINT()},
@@ -614,7 +615,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "segments",
             {TGEOMPOINT()},
@@ -626,7 +627,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     /* ***************************************************
      * Shift and Scale functions
      ****************************************************/
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "shiftTime",
             {TGEOMPOINT(), LogicalType::INTERVAL},
@@ -635,7 +636,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "scaleTime",
             {TGEOMPOINT(), LogicalType::INTERVAL},
@@ -644,7 +645,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "shiftScaleTime",
             {TGEOMPOINT(), LogicalType::INTERVAL, LogicalType::INTERVAL},
@@ -659,7 +660,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
      * Restriction functions
      ****************************************************/
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atValues",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -668,7 +669,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusValues",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -677,7 +678,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atValues",
             {TGEOMPOINT(), SpatialSetType::geomset()},
@@ -686,7 +687,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusValues",
             {TGEOMPOINT(), SpatialSetType::geomset()},
@@ -695,7 +696,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atTime",
             {TGEOMPOINT(), LogicalType::TIMESTAMP_TZ},
@@ -704,7 +705,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusTime",
             {TGEOMPOINT(), LogicalType::TIMESTAMP_TZ},
@@ -713,7 +714,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "valueAtTimestamp",
             {TGEOMPOINT(), LogicalType::TIMESTAMP_TZ},
@@ -722,7 +723,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
     
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atTime",
             {TGEOMPOINT(), SetTypes::tstzset()},
@@ -731,7 +732,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusTime",
             {TGEOMPOINT(), SetTypes::tstzset()},
@@ -740,7 +741,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atTime",
             {TGEOMPOINT(), SpanTypes::TSTZSPAN()},
@@ -749,7 +750,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusTime",
             {TGEOMPOINT(), SpanTypes::TSTZSPAN()},
@@ -758,7 +759,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atTime",
             {TGEOMPOINT(), SpansetTypes::tstzspanset()},
@@ -767,7 +768,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusTime",
             {TGEOMPOINT(), SpansetTypes::tstzspanset()},
@@ -776,7 +777,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "beforeTimestamp",
             {TGEOMPOINT(), LogicalType::TIMESTAMP_TZ},
@@ -785,7 +786,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "afterTimestamp",
             {TGEOMPOINT(), LogicalType::TIMESTAMP_TZ},
@@ -797,7 +798,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     /* ***************************************************
      * Modification function
      ****************************************************/
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "insert",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -806,7 +807,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "insert",
             {TGEOMPOINT(), TGEOMPOINT(), LogicalType::BOOLEAN},
@@ -815,7 +816,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "update",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -824,7 +825,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "update",
             {TGEOMPOINT(), TGEOMPOINT(), LogicalType::BOOLEAN},
@@ -833,7 +834,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "deleteTime",
             {TGEOMPOINT(), LogicalType::TIMESTAMP_TZ},
@@ -841,7 +842,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TemporalFunctions::Temporal_delete_timestamptz
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "deleteTime",
             {TGEOMPOINT(), LogicalType::TIMESTAMP_TZ, LogicalType::BOOLEAN},
@@ -850,7 +851,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "deleteTime",
             {TGEOMPOINT(), SetTypes::tstzset()},
@@ -858,7 +859,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TemporalFunctions::Temporal_delete_tstzset
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "deleteTime",
             {TGEOMPOINT(), SetTypes::tstzset(), LogicalType::BOOLEAN},
@@ -867,7 +868,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "deleteTime",
             {TGEOMPOINT(), SpanTypes::TSTZSPAN()},
@@ -876,7 +877,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "deleteTime",
             {TGEOMPOINT(), SpanTypes::TSTZSPAN(), LogicalType::BOOLEAN},
@@ -885,7 +886,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "deleteTime",
             {TGEOMPOINT(), SpansetTypes::tstzspanset()},
@@ -894,7 +895,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "deleteTime",
             {TGEOMPOINT(), SpansetTypes::tstzspanset(), LogicalType::BOOLEAN},
@@ -908,7 +909,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
      * Stops function
      ****************************************************/
     
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "stops",
             {TGEOMPOINT(), LogicalType::DOUBLE, LogicalType::INTERVAL},
@@ -920,7 +921,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     /* ***************************************************
      * Comparison functions
      ****************************************************/
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "temporal_eq",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -929,7 +930,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "temporal_ne",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -938,7 +939,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "temporal_lt",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -947,7 +948,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "temporal_le",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -956,7 +957,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "temporal_gt",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -965,7 +966,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "temporal_ge",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -974,7 +975,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "temporal_cmp",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -983,7 +984,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "=",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -992,7 +993,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<>",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1001,7 +1002,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1010,7 +1011,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<=",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1019,7 +1020,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             ">",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1028,7 +1029,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             ">=",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1040,7 +1041,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     /* ***************************************************
      * Spatial functions
      ****************************************************/
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "getX",
             {TGEOMPOINT()},
@@ -1049,7 +1050,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "getY",
             {TGEOMPOINT()},
@@ -1058,7 +1059,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "getZ",
             {TGEOMPOINT()},
@@ -1067,7 +1068,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "length",
             {TGEOMPOINT()},
@@ -1076,7 +1077,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "cumulativeLength",
             {TGEOMPOINT()},
@@ -1085,7 +1086,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "speed",
             {TGEOMPOINT()},
@@ -1094,7 +1095,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "twCentroid",
             {TGEOMPOINT()},
@@ -1103,7 +1104,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "direction",
             {TGEOMPOINT()},
@@ -1112,7 +1113,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "azimuth",
             {TGEOMPOINT()},
@@ -1121,7 +1122,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "angularDifference",
             {TGEOMPOINT()},
@@ -1130,7 +1131,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "isSimple",
             {TGEOMPOINT()},
@@ -1139,7 +1140,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "makeSimple",
             {TGEOMPOINT()},
@@ -1148,7 +1149,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "trajectory",
             {TGEOMPOINT()},
@@ -1157,7 +1158,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "trajectory_gs",
             {TGEOMPOINT()},
@@ -1166,7 +1167,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atGeometry",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -1175,7 +1176,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusGeometry",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -1184,7 +1185,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusGeometry",
             {TGEOMPOINT(), GeoTypes::GEOMETRY(), SpanTypes::FLOATSPAN()},
@@ -1193,7 +1194,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atStbox",
             {TGEOMPOINT(), StboxType::STBOX()},
@@ -1202,7 +1203,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atStbox",
             {TGEOMPOINT(), StboxType::STBOX(), LogicalType::BOOLEAN},
@@ -1211,7 +1212,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusStbox",
             {TGEOMPOINT(), StboxType::STBOX()},
@@ -1220,7 +1221,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusStbox",
             {TGEOMPOINT(), StboxType::STBOX(), LogicalType::BOOLEAN},
@@ -1229,7 +1230,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "transform",
             {TGEOMPOINT(), LogicalType::INTEGER},
@@ -1238,7 +1239,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "round",
             {TGEOMPOINT(), LogicalType::INTEGER},
@@ -1247,7 +1248,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "round",
             {TGEOMPOINT()},
@@ -1259,7 +1260,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     /* ***************************************************
      * Spatial relationships
      ****************************************************/
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "eContains",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1267,7 +1268,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Econtains_geo_tgeo
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "aContains",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1276,7 +1277,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
     
-     loader.RegisterFunction(
+     duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "eDisjoint",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1285,7 +1286,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "eDisjoint",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -1294,7 +1295,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "eDisjoint",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1303,7 +1304,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "aDisjoint",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1312,7 +1313,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "aDisjoint",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -1321,7 +1322,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "aDisjoint",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1330,7 +1331,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "eIntersects",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -1338,7 +1339,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Eintersects_tgeo_geo  
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "eIntersects",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1347,7 +1348,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "eIntersects",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1356,7 +1357,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "aIntersects",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -1364,7 +1365,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Aintersects_tgeo_geo  
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "aIntersects",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1373,7 +1374,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "aIntersects",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1382,7 +1383,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "eTouches",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1391,7 +1392,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "eTouches",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -1400,7 +1401,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "aTouches",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1409,7 +1410,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "aTouches",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -1418,7 +1419,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "eDwithin",
             {TGEOMPOINT(), TGEOMPOINT(), LogicalType::DOUBLE},
@@ -1427,7 +1428,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "eDwithin",
             {GeoTypes::GEOMETRY(), TGEOMPOINT(), LogicalType::DOUBLE},
@@ -1436,7 +1437,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "eDwithin",
             {TGEOMPOINT(), GeoTypes::GEOMETRY(), LogicalType::DOUBLE},
@@ -1445,7 +1446,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "aDwithin",
             {GeoTypes::GEOMETRY(), TGEOMPOINT(), LogicalType::DOUBLE},
@@ -1454,7 +1455,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "aDwithin",
             {TGEOMPOINT(), GeoTypes::GEOMETRY(), LogicalType::DOUBLE},
@@ -1463,7 +1464,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-     loader.RegisterFunction(
+     duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "aDwithin",
             {TGEOMPOINT(), TGEOMPOINT(), LogicalType::DOUBLE},
@@ -1475,7 +1476,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     /* ***************************************************
      * Temporal-spatial relationships
      ****************************************************/
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tContains",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1484,7 +1485,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
     
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tContains",
             {GeoTypes::GEOMETRY(), TGEOMPOINT(), LogicalType::BOOLEAN},
@@ -1493,7 +1494,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tDisjoint",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -1502,7 +1503,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tDisjoint",
             {TGEOMPOINT(), GeoTypes::GEOMETRY(), LogicalType::BOOLEAN},
@@ -1511,7 +1512,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tDisjoint",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1520,7 +1521,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tDisjoint",
             {GeoTypes::GEOMETRY(), TGEOMPOINT(), LogicalType::BOOLEAN},
@@ -1529,7 +1530,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tDisjoint",
             {TGEOMPOINT(), TGEOMPOINT(), LogicalType::BOOLEAN},
@@ -1538,7 +1539,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tDisjoint",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1547,7 +1548,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tIntersects",
             {GeoTypes::GEOMETRY(), TGEOMPOINT(), LogicalType::BOOLEAN},
@@ -1556,7 +1557,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tIntersects",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1565,7 +1566,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tIntersects",
             {TGEOMPOINT(), GeoTypes::GEOMETRY(), LogicalType::BOOLEAN},
@@ -1574,7 +1575,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tIntersects",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -1583,7 +1584,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tIntersects",
             {TGEOMPOINT(), TGEOMPOINT(), LogicalType::BOOLEAN},
@@ -1591,7 +1592,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Tintersects_tgeo_tgeo
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tIntersects",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1600,7 +1601,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tTouches",
             {GeoTypes::GEOMETRY(), TGEOMPOINT(), LogicalType::BOOLEAN},
@@ -1608,7 +1609,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Ttouches_geo_tgeo
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tTouches",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1616,7 +1617,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Ttouches_geo_tgeo
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tTouches",
             {TGEOMPOINT(), GeoTypes::GEOMETRY(), LogicalType::BOOLEAN},
@@ -1624,7 +1625,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Ttouches_tgeo_geo
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tTouches",
             {TGEOMPOINT(), GeoTypes::GEOMETRY()},
@@ -1632,7 +1633,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Ttouches_tgeo_geo
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tDwithin",
             {GeoTypes::GEOMETRY(), TGEOMPOINT(), LogicalType::DOUBLE},
@@ -1641,7 +1642,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tDwithin",
             {GeoTypes::GEOMETRY(), TGEOMPOINT(), LogicalType::DOUBLE, LogicalType::BOOLEAN},
@@ -1650,7 +1651,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tDwithin",
             {TGEOMPOINT(), GeoTypes::GEOMETRY(), LogicalType::DOUBLE, LogicalType::BOOLEAN},
@@ -1659,7 +1660,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tDwithin",
             {TGEOMPOINT(), GeoTypes::GEOMETRY(), LogicalType::DOUBLE},
@@ -1668,7 +1669,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tDwithin",
             {TGEOMPOINT(), TGEOMPOINT(), LogicalType::DOUBLE},
@@ -1677,7 +1678,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tDwithin",
             {TGEOMPOINT(), TGEOMPOINT(), LogicalType::DOUBLE, LogicalType::BOOLEAN},
@@ -1691,7 +1692,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
      * Operators (workaround as functions)
      ****************************************************/
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "&&", // overlaps
             {TGEOMPOINT(), StboxType::STBOX()},
@@ -1700,7 +1701,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "&&", // overlaps
             {TGEOMPOINT(), SpanTypes::TSTZSPAN()},
@@ -1709,7 +1710,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "@>", // contains
             {TGEOMPOINT(), StboxType::STBOX()},
@@ -1722,7 +1723,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
      * Distance functions
      ****************************************************/
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<->",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1731,7 +1732,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "shortestLine",
             {TGEOMPOINT(), TGEOMPOINT()},
@@ -1751,7 +1752,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     //     )
     // );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "collect_gs",
             {LogicalType::LIST(LogicalType::BLOB)},
@@ -1760,7 +1761,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "distance_gs",
             {LogicalType::BLOB, LogicalType::BLOB},

--- a/src/include/mobilityduck/bindings.hpp
+++ b/src/include/mobilityduck/bindings.hpp
@@ -35,6 +35,8 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/planner/expression.hpp"
 
+#include "mobilityduck/meos_exec_serial.hpp"
+
 extern "C" {
 #include <meos.h>
 }
@@ -165,11 +167,13 @@ inline void RegisterTemporalDatumAccessor(duckdb::ExtensionLoader &loader,
                                           const duckdb::LogicalType &input_type,
                                           const duckdb::LogicalType &return_type,
                                           uintptr_t (*meos_fn)(const Temporal *)) {
-	loader.RegisterFunction(duckdb::ScalarFunction(
-	    name,
-	    {input_type},
-	    return_type,
-	    MakeTemporalDatumAccessor<CppResult>(meos_fn, name.c_str())));
+	duckdb::RegisterSerializedScalarFunction(
+	    loader,
+	    duckdb::ScalarFunction(
+	        name,
+	        {input_type},
+	        return_type,
+	        MakeTemporalDatumAccessor<CppResult>(meos_fn, name.c_str())));
 }
 
 } // namespace mobilityduck

--- a/src/include/mobilityduck/meos_exec_serial.hpp
+++ b/src/include/mobilityduck/meos_exec_serial.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <mutex>
+
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+/**
+ * Mutex serialization for MobilityDuck scalar function bodies that ultimately call
+ * MEOS / liblwgeom. MEOS uses GEOS's legacy global API (`initGEOS` / `finishGEOS`)
+ * internally from worker threads; concurrent legacy GEOS init/teardown from DuckDB's
+ * parallelism triggers intermittent GEOS errors and allocator corruption when spatial
+ * and MobilityDuck coexist.
+ *
+ * Wrapping each MEOS-backed ScalarFunction execution prevents overlapping MEOS/GEOS
+ * legacy pairs across concurrent pipelines while preserving parallelism elsewhere.
+ */
+inline std::mutex &MeosSerializedExecMutex() {
+	static std::mutex mutex;
+	return mutex;
+}
+
+inline ScalarFunction WrapScalarFunctionWithMeosExecMutex(ScalarFunction sf) {
+	scalar_function_t orig = std::move(sf.function);
+	sf.function = [orig = std::move(orig)](DataChunk &args, ExpressionState &state, Vector &result) {
+		std::lock_guard<std::mutex> guard(MeosSerializedExecMutex());
+		orig(args, state, result);
+	};
+	return sf;
+}
+
+inline void RegisterSerializedScalarFunction(ExtensionLoader &loader, ScalarFunction sf) {
+	loader.RegisterFunction(WrapScalarFunctionWithMeosExecMutex(std::move(sf)));
+}
+
+} // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -47,6 +47,8 @@ extern "C" {
 // OpenSSL linked through vcpkg
 #include <openssl/opensslv.h>
 
+#include "mobilityduck/meos_exec_serial.hpp"
+
 namespace duckdb {
 #include "spatial_ref_sys_csv.inc"
 
@@ -217,12 +219,12 @@ static void LoadInternal(ExtensionLoader &loader) {
 	        LogicalType::VARCHAR,
 	        MobilityduckOpenSSLVersionScalarFun
 	    );
-	loader.RegisterFunction( mobilityduck_openssl_version_scalar_function);
+	duckdb::RegisterSerializedScalarFunction(loader,  mobilityduck_openssl_version_scalar_function);
 
-	loader.RegisterFunction(ScalarFunction(
+	duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
 		"mobilityduck_version", {}, LogicalType::VARCHAR,
 		MobilityduckVersionScalarFun));
-	loader.RegisterFunction(ScalarFunction(
+	duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
 		"mobilityduck_full_version", {}, LogicalType::VARCHAR,
 		MobilityduckFullVersionScalarFun));
 

--- a/src/temporal/set.cpp
+++ b/src/temporal/set.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 
 #include "time_util.hpp"
+#include "mobilityduck/meos_exec_serial.hpp"
 
 
 extern "C" {
@@ -141,658 +142,658 @@ void SetTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
 
         // Register: asText
         if (set_type == SetTypes::floatset()) {            
-            loader.RegisterFunction( // asText(floatset)
+            duckdb::RegisterSerializedScalarFunction(loader,  // asText(floatset)
                 ScalarFunction("asText", {set_type}, LogicalType::VARCHAR, SetFunctions::Set_as_text)
             );
             
-            loader.RegisterFunction( // asText(floatset, int)
+            duckdb::RegisterSerializedScalarFunction(loader,  // asText(floatset, int)
                 ScalarFunction("asText", {set_type, LogicalType::INTEGER}, LogicalType::VARCHAR, SetFunctions::Set_as_text)
             );
         } else {            
-            loader.RegisterFunction( // All other set types
+            duckdb::RegisterSerializedScalarFunction(loader,  // All other set types
                 ScalarFunction("asText", {set_type}, LogicalType::VARCHAR, SetFunctions::Set_as_text)
             );
         }
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("set", {LogicalType::LIST(base_type)}, set_type, SetFunctions::Set_constructor)                 
         );        
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("set", {base_type}, set_type, SetFunctions::Value_to_set)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("intset", {SetTypes::floatset()}, SetTypes::intset(), SetFunctions::Floatset_to_intset)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("floatset", {SetTypes::intset()}, SetTypes::floatset(), SetFunctions::Intset_to_floatset)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("dateset", {SetTypes::tstzset()}, SetTypes::dateset(), SetFunctions::Tstzset_to_dateset)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("tstzset", {SetTypes::dateset()}, SetTypes::tstzset(), SetFunctions::Dateset_to_tstzset)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("memSize",{set_type}, LogicalType::INTEGER, SetFunctions::Set_mem_size)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("set_hash", {set_type}, LogicalType::UINTEGER, SetFunctions::Set_hash)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("set_hash_extended", {set_type, LogicalType::BIGINT}, LogicalType::UBIGINT, SetFunctions::Set_hash_extended)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("numValues", {set_type}, LogicalType::INTEGER,SetFunctions::Set_num_values)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("startValue", {set_type}, base_type, SetFunctions::Set_start_value)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("endValue", {set_type}, base_type, SetFunctions::Set_end_value)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("valueN", {set_type, LogicalType::INTEGER}, base_type, SetFunctions::Set_value_n)
         );
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("getValues", {set_type}, LogicalType::LIST(base_type), SetFunctions::Set_values)
         );
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("shift", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Numset_shift)
         );
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("shift", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Numset_shift)
         );
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("shift", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Numset_shift)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("shift", {SetTypes::dateset(), LogicalType::INTEGER}, SetTypes::dateset(), SetFunctions::Numset_shift)
         );        
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("shift", {SetTypes::tstzset(), LogicalType::INTERVAL}, SetTypes::tstzset(), SetFunctions::Tstzset_shift)
         );
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("scale", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Numset_scale)
         );
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("scale", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Numset_scale)
         );
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("scale", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Numset_scale)
         );
         
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("scale", {SetTypes::dateset(), LogicalType::INTEGER}, SetTypes::dateset(), SetFunctions::Numset_scale)
         ); 
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("scale", {SetTypes::tstzset(), LogicalType::INTERVAL}, SetTypes::tstzset(), SetFunctions::Tstzset_scale)
         );
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("shiftScale", {SetTypes::intset(), LogicalType::INTEGER, LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Numset_shift_scale)
         );
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("shiftScale", {SetTypes::bigintset(), LogicalType::BIGINT, LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Numset_shift_scale)
         );
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("shiftScale", {SetTypes::floatset(), LogicalType::DOUBLE, LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Numset_shift_scale)
         );
         
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("shiftScale", {SetTypes::dateset(), LogicalType::INTEGER, LogicalType::INTEGER}, SetTypes::dateset(), SetFunctions::Numset_shift_scale)
         );
 
-        loader.RegisterFunction( 
+        duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("shiftScale", {SetTypes::tstzset(), LogicalType::INTERVAL, LogicalType::INTERVAL}, SetTypes::tstzset(), SetFunctions::Tstzset_shift_scale)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("floor", {SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Floatset_floor)                 
         );
         
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("ceil", {SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Floatset_ceil)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("round", {SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Floatset_round)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("round", {SetTypes::floatset(), LogicalType::INTEGER}, SetTypes::floatset(), SetFunctions::Floatset_round)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("degrees", {SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Floatset_degrees)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("degrees", {SetTypes::floatset(), LogicalType::BOOLEAN}, SetTypes::floatset(), SetFunctions::Floatset_degrees)
         );
         
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("radians", {SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Floatset_radians)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("lower", {SetTypes::textset()}, SetTypes::textset(), SetFunctions::Textset_lower)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("upper", {SetTypes::textset()}, SetTypes::textset(), SetFunctions::Textset_upper)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("initcap", {SetTypes::textset()}, SetTypes::textset(), SetFunctions::Textset_initcap)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("+", {set_type, set_type}, set_type, SetFunctions::Union_set_set)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("asBinary", {set_type}, LogicalType::BLOB, SetFunctions::Set_as_binary)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("asHexWKB", {set_type}, LogicalType::VARCHAR, SetFunctions::Set_as_hexwkb)
         );
     }
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("textset_cat", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(),
                        SetFunctions::Textcat_text_textset)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("textset_cat", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(),
                        SetFunctions::Textcat_textset_text)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("||", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Textcat_text_textset)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("||", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Textcat_textset_text)
     );
 
     // --- set_contains / @> ---
-    loader.RegisterFunction( ScalarFunction("set_contains", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
-    loader.RegisterFunction( ScalarFunction("set_contains", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
-    loader.RegisterFunction( ScalarFunction("set_contains", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
-    loader.RegisterFunction( ScalarFunction("set_contains", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
-    loader.RegisterFunction( ScalarFunction("set_contains", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
-    loader.RegisterFunction( ScalarFunction("set_contains", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
-    loader.RegisterFunction( ScalarFunction("set_contains", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
-    loader.RegisterFunction( ScalarFunction("set_contains", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
-    loader.RegisterFunction( ScalarFunction("set_contains", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
-    loader.RegisterFunction( ScalarFunction("set_contains", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
-    loader.RegisterFunction( ScalarFunction("set_contains", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
-    loader.RegisterFunction( ScalarFunction("set_contains", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contains", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contains", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contains", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contains", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contains", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contains", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contains", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contains", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contains", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contains", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contains", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contains", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
 
-    loader.RegisterFunction( ScalarFunction("@>", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
-    loader.RegisterFunction( ScalarFunction("@>", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
-    loader.RegisterFunction( ScalarFunction("@>", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
-    loader.RegisterFunction( ScalarFunction("@>", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
-    loader.RegisterFunction( ScalarFunction("@>", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
-    loader.RegisterFunction( ScalarFunction("@>", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
-    loader.RegisterFunction( ScalarFunction("@>", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
-    loader.RegisterFunction( ScalarFunction("@>", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
-    loader.RegisterFunction( ScalarFunction("@>", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
-    loader.RegisterFunction( ScalarFunction("@>", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
-    loader.RegisterFunction( ScalarFunction("@>", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
-    loader.RegisterFunction( ScalarFunction("@>", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("@>", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("@>", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("@>", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("@>", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("@>", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("@>", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("@>", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("@>", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("@>", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("@>", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("@>", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Contains_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("@>", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Contains_set_set));
 
     // --- set_contained / <@ ---
-    loader.RegisterFunction( ScalarFunction("set_contained", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
-    loader.RegisterFunction( ScalarFunction("set_contained", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
-    loader.RegisterFunction( ScalarFunction("set_contained", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
-    loader.RegisterFunction( ScalarFunction("set_contained", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
-    loader.RegisterFunction( ScalarFunction("set_contained", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
-    loader.RegisterFunction( ScalarFunction("set_contained", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
-    loader.RegisterFunction( ScalarFunction("set_contained", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
-    loader.RegisterFunction( ScalarFunction("set_contained", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
-    loader.RegisterFunction( ScalarFunction("set_contained", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
-    loader.RegisterFunction( ScalarFunction("set_contained", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
-    loader.RegisterFunction( ScalarFunction("set_contained", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
-    loader.RegisterFunction( ScalarFunction("set_contained", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contained", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contained", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contained", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contained", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contained", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contained", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contained", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contained", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contained", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contained", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contained", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_contained", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
 
-    loader.RegisterFunction( ScalarFunction("<@", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
-    loader.RegisterFunction( ScalarFunction("<@", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
-    loader.RegisterFunction( ScalarFunction("<@", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
-    loader.RegisterFunction( ScalarFunction("<@", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
-    loader.RegisterFunction( ScalarFunction("<@", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
-    loader.RegisterFunction( ScalarFunction("<@", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
-    loader.RegisterFunction( ScalarFunction("<@", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
-    loader.RegisterFunction( ScalarFunction("<@", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
-    loader.RegisterFunction( ScalarFunction("<@", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
-    loader.RegisterFunction( ScalarFunction("<@", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
-    loader.RegisterFunction( ScalarFunction("<@", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
-    loader.RegisterFunction( ScalarFunction("<@", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Contained_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Contained_set_set));
 
     // --- set_overlaps / && ---
-    loader.RegisterFunction( ScalarFunction("set_overlaps", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overlaps", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overlaps", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overlaps", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overlaps", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overlaps", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
-    loader.RegisterFunction( ScalarFunction("&&", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
-    loader.RegisterFunction( ScalarFunction("&&", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
-    loader.RegisterFunction( ScalarFunction("&&", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
-    loader.RegisterFunction( ScalarFunction("&&", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
-    loader.RegisterFunction( ScalarFunction("&&", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
-    loader.RegisterFunction( ScalarFunction("&&", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overlaps", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overlaps", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overlaps", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overlaps", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overlaps", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overlaps", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&&", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&&", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&&", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&&", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&&", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&&", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overlaps_set_set));
 
     // --- Position: set_left / << ---
-    loader.RegisterFunction( ScalarFunction("set_left", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
-    loader.RegisterFunction( ScalarFunction("set_left", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
-    loader.RegisterFunction( ScalarFunction("set_left", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
-    loader.RegisterFunction( ScalarFunction("set_left", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
-    loader.RegisterFunction( ScalarFunction("set_left", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
-    loader.RegisterFunction( ScalarFunction("set_left", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
-    loader.RegisterFunction( ScalarFunction("set_left", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
-    loader.RegisterFunction( ScalarFunction("set_left", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
-    loader.RegisterFunction( ScalarFunction("set_left", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
-    loader.RegisterFunction( ScalarFunction("set_left", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
-    loader.RegisterFunction( ScalarFunction("set_left", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
-    loader.RegisterFunction( ScalarFunction("set_left", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
-    loader.RegisterFunction( ScalarFunction("set_left", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
-    loader.RegisterFunction( ScalarFunction("set_left", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
-    loader.RegisterFunction( ScalarFunction("set_left", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
-    loader.RegisterFunction( ScalarFunction("set_left", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
-    loader.RegisterFunction( ScalarFunction("set_left", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
-    loader.RegisterFunction( ScalarFunction("set_left", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
-    loader.RegisterFunction( ScalarFunction("<<", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
-    loader.RegisterFunction( ScalarFunction("<<", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
-    loader.RegisterFunction( ScalarFunction("<<", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
-    loader.RegisterFunction( ScalarFunction("<<", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
-    loader.RegisterFunction( ScalarFunction("<<", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
-    loader.RegisterFunction( ScalarFunction("<<", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
-    loader.RegisterFunction( ScalarFunction("<<", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
-    loader.RegisterFunction( ScalarFunction("<<", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
-    loader.RegisterFunction( ScalarFunction("<<", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
-    loader.RegisterFunction( ScalarFunction("<<", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
-    loader.RegisterFunction( ScalarFunction("<<", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
-    loader.RegisterFunction( ScalarFunction("<<", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
-    loader.RegisterFunction( ScalarFunction("<<", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
-    loader.RegisterFunction( ScalarFunction("<<", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
-    loader.RegisterFunction( ScalarFunction("<<", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
-    loader.RegisterFunction( ScalarFunction("<<", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
-    loader.RegisterFunction( ScalarFunction("<<", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
-    loader.RegisterFunction( ScalarFunction("<<", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_left", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Left_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Left_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Left_set_set));
 
     // --- set_right / >> ---
-    loader.RegisterFunction( ScalarFunction("set_right", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
-    loader.RegisterFunction( ScalarFunction("set_right", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
-    loader.RegisterFunction( ScalarFunction("set_right", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
-    loader.RegisterFunction( ScalarFunction("set_right", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
-    loader.RegisterFunction( ScalarFunction("set_right", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
-    loader.RegisterFunction( ScalarFunction("set_right", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
-    loader.RegisterFunction( ScalarFunction("set_right", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
-    loader.RegisterFunction( ScalarFunction("set_right", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
-    loader.RegisterFunction( ScalarFunction("set_right", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
-    loader.RegisterFunction( ScalarFunction("set_right", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
-    loader.RegisterFunction( ScalarFunction("set_right", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
-    loader.RegisterFunction( ScalarFunction("set_right", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
-    loader.RegisterFunction( ScalarFunction("set_right", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
-    loader.RegisterFunction( ScalarFunction("set_right", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
-    loader.RegisterFunction( ScalarFunction("set_right", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
-    loader.RegisterFunction( ScalarFunction("set_right", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
-    loader.RegisterFunction( ScalarFunction("set_right", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
-    loader.RegisterFunction( ScalarFunction("set_right", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
-    loader.RegisterFunction( ScalarFunction(">>", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
-    loader.RegisterFunction( ScalarFunction(">>", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
-    loader.RegisterFunction( ScalarFunction(">>", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
-    loader.RegisterFunction( ScalarFunction(">>", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
-    loader.RegisterFunction( ScalarFunction(">>", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
-    loader.RegisterFunction( ScalarFunction(">>", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
-    loader.RegisterFunction( ScalarFunction(">>", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
-    loader.RegisterFunction( ScalarFunction(">>", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
-    loader.RegisterFunction( ScalarFunction(">>", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
-    loader.RegisterFunction( ScalarFunction(">>", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
-    loader.RegisterFunction( ScalarFunction(">>", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
-    loader.RegisterFunction( ScalarFunction(">>", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
-    loader.RegisterFunction( ScalarFunction(">>", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
-    loader.RegisterFunction( ScalarFunction(">>", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
-    loader.RegisterFunction( ScalarFunction(">>", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
-    loader.RegisterFunction( ScalarFunction(">>", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
-    loader.RegisterFunction( ScalarFunction(">>", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
-    loader.RegisterFunction( ScalarFunction(">>", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_right", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Right_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Right_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Right_set_set));
 
     // --- set_overleft / &< ---
-    loader.RegisterFunction( ScalarFunction("set_overleft", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
-    loader.RegisterFunction( ScalarFunction("set_overleft", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
-    loader.RegisterFunction( ScalarFunction("&<", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
-    loader.RegisterFunction( ScalarFunction("&<", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
-    loader.RegisterFunction( ScalarFunction("&<", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
-    loader.RegisterFunction( ScalarFunction("&<", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
-    loader.RegisterFunction( ScalarFunction("&<", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
-    loader.RegisterFunction( ScalarFunction("&<", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
-    loader.RegisterFunction( ScalarFunction("&<", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
-    loader.RegisterFunction( ScalarFunction("&<", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
-    loader.RegisterFunction( ScalarFunction("&<", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
-    loader.RegisterFunction( ScalarFunction("&<", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
-    loader.RegisterFunction( ScalarFunction("&<", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
-    loader.RegisterFunction( ScalarFunction("&<", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
-    loader.RegisterFunction( ScalarFunction("&<", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
-    loader.RegisterFunction( ScalarFunction("&<", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
-    loader.RegisterFunction( ScalarFunction("&<", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
-    loader.RegisterFunction( ScalarFunction("&<", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
-    loader.RegisterFunction( ScalarFunction("&<", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
-    loader.RegisterFunction( ScalarFunction("&<", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overleft", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overleft_set_set));
 
     // --- set_overright / &> ---
-    loader.RegisterFunction( ScalarFunction("set_overright", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
-    loader.RegisterFunction( ScalarFunction("set_overright", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
-    loader.RegisterFunction( ScalarFunction("set_overright", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overright", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
-    loader.RegisterFunction( ScalarFunction("set_overright", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
-    loader.RegisterFunction( ScalarFunction("set_overright", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overright", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
-    loader.RegisterFunction( ScalarFunction("set_overright", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
-    loader.RegisterFunction( ScalarFunction("set_overright", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overright", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
-    loader.RegisterFunction( ScalarFunction("set_overright", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
-    loader.RegisterFunction( ScalarFunction("set_overright", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overright", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
-    loader.RegisterFunction( ScalarFunction("set_overright", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
-    loader.RegisterFunction( ScalarFunction("set_overright", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
-    loader.RegisterFunction( ScalarFunction("set_overright", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
-    loader.RegisterFunction( ScalarFunction("set_overright", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
-    loader.RegisterFunction( ScalarFunction("set_overright", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
-    loader.RegisterFunction( ScalarFunction("&>", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
-    loader.RegisterFunction( ScalarFunction("&>", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
-    loader.RegisterFunction( ScalarFunction("&>", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
-    loader.RegisterFunction( ScalarFunction("&>", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
-    loader.RegisterFunction( ScalarFunction("&>", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
-    loader.RegisterFunction( ScalarFunction("&>", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
-    loader.RegisterFunction( ScalarFunction("&>", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
-    loader.RegisterFunction( ScalarFunction("&>", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
-    loader.RegisterFunction( ScalarFunction("&>", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
-    loader.RegisterFunction( ScalarFunction("&>", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
-    loader.RegisterFunction( ScalarFunction("&>", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
-    loader.RegisterFunction( ScalarFunction("&>", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
-    loader.RegisterFunction( ScalarFunction("&>", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
-    loader.RegisterFunction( ScalarFunction("&>", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
-    loader.RegisterFunction( ScalarFunction("&>", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
-    loader.RegisterFunction( ScalarFunction("&>", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
-    loader.RegisterFunction( ScalarFunction("&>", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
-    loader.RegisterFunction( ScalarFunction("&>", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_overright", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {LogicalType::VARCHAR, SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SetTypes::textset(), LogicalType::VARCHAR}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overright_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SetFunctions::Overright_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Overright_set_set));
 
     // --- set_union / + (value forms) ---
-    loader.RegisterFunction( ScalarFunction("set_union", {LogicalType::INTEGER, SetTypes::intset()}, SetTypes::intset(), SetFunctions::Union_value_set));
-    loader.RegisterFunction( ScalarFunction("set_union", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Union_set_value));
-    loader.RegisterFunction( ScalarFunction("set_union", {LogicalType::BIGINT, SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Union_value_set));
-    loader.RegisterFunction( ScalarFunction("set_union", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Union_set_value));
-    loader.RegisterFunction( ScalarFunction("set_union", {LogicalType::DOUBLE, SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Union_value_set));
-    loader.RegisterFunction( ScalarFunction("set_union", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Union_set_value));
-    loader.RegisterFunction( ScalarFunction("set_union", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Union_value_set));
-    loader.RegisterFunction( ScalarFunction("set_union", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Union_set_value));
-    loader.RegisterFunction( ScalarFunction("set_union", {LogicalType::DATE, SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Union_value_set));
-    loader.RegisterFunction( ScalarFunction("set_union", {SetTypes::dateset(), LogicalType::DATE}, SetTypes::dateset(), SetFunctions::Union_set_value));
-    loader.RegisterFunction( ScalarFunction("set_union", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Union_value_set));
-    loader.RegisterFunction( ScalarFunction("set_union", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, SetTypes::tstzset(), SetFunctions::Union_set_value));
-    loader.RegisterFunction( ScalarFunction("+", {LogicalType::INTEGER, SetTypes::intset()}, SetTypes::intset(), SetFunctions::Union_value_set));
-    loader.RegisterFunction( ScalarFunction("+", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Union_set_value));
-    loader.RegisterFunction( ScalarFunction("+", {LogicalType::BIGINT, SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Union_value_set));
-    loader.RegisterFunction( ScalarFunction("+", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Union_set_value));
-    loader.RegisterFunction( ScalarFunction("+", {LogicalType::DOUBLE, SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Union_value_set));
-    loader.RegisterFunction( ScalarFunction("+", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Union_set_value));
-    loader.RegisterFunction( ScalarFunction("+", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Union_value_set));
-    loader.RegisterFunction( ScalarFunction("+", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Union_set_value));
-    loader.RegisterFunction( ScalarFunction("+", {LogicalType::DATE, SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Union_value_set));
-    loader.RegisterFunction( ScalarFunction("+", {SetTypes::dateset(), LogicalType::DATE}, SetTypes::dateset(), SetFunctions::Union_set_value));
-    loader.RegisterFunction( ScalarFunction("+", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Union_value_set));
-    loader.RegisterFunction( ScalarFunction("+", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, SetTypes::tstzset(), SetFunctions::Union_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_union", {LogicalType::INTEGER, SetTypes::intset()}, SetTypes::intset(), SetFunctions::Union_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_union", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Union_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_union", {LogicalType::BIGINT, SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Union_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_union", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Union_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_union", {LogicalType::DOUBLE, SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Union_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_union", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Union_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_union", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Union_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_union", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Union_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_union", {LogicalType::DATE, SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Union_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_union", {SetTypes::dateset(), LogicalType::DATE}, SetTypes::dateset(), SetFunctions::Union_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_union", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Union_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_union", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, SetTypes::tstzset(), SetFunctions::Union_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {LogicalType::INTEGER, SetTypes::intset()}, SetTypes::intset(), SetFunctions::Union_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Union_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {LogicalType::BIGINT, SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Union_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Union_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {LogicalType::DOUBLE, SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Union_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Union_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Union_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Union_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {LogicalType::DATE, SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Union_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SetTypes::dateset(), LogicalType::DATE}, SetTypes::dateset(), SetFunctions::Union_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Union_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, SetTypes::tstzset(), SetFunctions::Union_set_value));
 
     // --- set_minus / - ---
-    loader.RegisterFunction( ScalarFunction("set_minus", {LogicalType::INTEGER, SetTypes::intset()}, SetTypes::intset(), SetFunctions::Minus_value_set));
-    loader.RegisterFunction( ScalarFunction("set_minus", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Minus_set_value));
-    loader.RegisterFunction( ScalarFunction("set_minus", {SetTypes::intset(), SetTypes::intset()}, SetTypes::intset(), SetFunctions::Minus_set_set));
-    loader.RegisterFunction( ScalarFunction("set_minus", {LogicalType::BIGINT, SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Minus_value_set));
-    loader.RegisterFunction( ScalarFunction("set_minus", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Minus_set_value));
-    loader.RegisterFunction( ScalarFunction("set_minus", {SetTypes::bigintset(), SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Minus_set_set));
-    loader.RegisterFunction( ScalarFunction("set_minus", {LogicalType::DOUBLE, SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Minus_value_set));
-    loader.RegisterFunction( ScalarFunction("set_minus", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Minus_set_value));
-    loader.RegisterFunction( ScalarFunction("set_minus", {SetTypes::floatset(), SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Minus_set_set));
-    loader.RegisterFunction( ScalarFunction("set_minus", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Minus_value_set));
-    loader.RegisterFunction( ScalarFunction("set_minus", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Minus_set_value));
-    loader.RegisterFunction( ScalarFunction("set_minus", {SetTypes::textset(), SetTypes::textset()}, SetTypes::textset(), SetFunctions::Minus_set_set));
-    loader.RegisterFunction( ScalarFunction("set_minus", {LogicalType::DATE, SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Minus_value_set));
-    loader.RegisterFunction( ScalarFunction("set_minus", {SetTypes::dateset(), LogicalType::DATE}, SetTypes::dateset(), SetFunctions::Minus_set_value));
-    loader.RegisterFunction( ScalarFunction("set_minus", {SetTypes::dateset(), SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Minus_set_set));
-    loader.RegisterFunction( ScalarFunction("set_minus", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Minus_value_set));
-    loader.RegisterFunction( ScalarFunction("set_minus", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, SetTypes::tstzset(), SetFunctions::Minus_set_value));
-    loader.RegisterFunction( ScalarFunction("set_minus", {SetTypes::tstzset(), SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Minus_set_set));
-    loader.RegisterFunction( ScalarFunction("-", {LogicalType::INTEGER, SetTypes::intset()}, SetTypes::intset(), SetFunctions::Minus_value_set));
-    loader.RegisterFunction( ScalarFunction("-", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Minus_set_value));
-    loader.RegisterFunction( ScalarFunction("-", {SetTypes::intset(), SetTypes::intset()}, SetTypes::intset(), SetFunctions::Minus_set_set));
-    loader.RegisterFunction( ScalarFunction("-", {LogicalType::BIGINT, SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Minus_value_set));
-    loader.RegisterFunction( ScalarFunction("-", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Minus_set_value));
-    loader.RegisterFunction( ScalarFunction("-", {SetTypes::bigintset(), SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Minus_set_set));
-    loader.RegisterFunction( ScalarFunction("-", {LogicalType::DOUBLE, SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Minus_value_set));
-    loader.RegisterFunction( ScalarFunction("-", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Minus_set_value));
-    loader.RegisterFunction( ScalarFunction("-", {SetTypes::floatset(), SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Minus_set_set));
-    loader.RegisterFunction( ScalarFunction("-", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Minus_value_set));
-    loader.RegisterFunction( ScalarFunction("-", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Minus_set_value));
-    loader.RegisterFunction( ScalarFunction("-", {SetTypes::textset(), SetTypes::textset()}, SetTypes::textset(), SetFunctions::Minus_set_set));
-    loader.RegisterFunction( ScalarFunction("-", {LogicalType::DATE, SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Minus_value_set));
-    loader.RegisterFunction( ScalarFunction("-", {SetTypes::dateset(), LogicalType::DATE}, SetTypes::dateset(), SetFunctions::Minus_set_value));
-    loader.RegisterFunction( ScalarFunction("-", {SetTypes::dateset(), SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Minus_set_set));
-    loader.RegisterFunction( ScalarFunction("-", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Minus_value_set));
-    loader.RegisterFunction( ScalarFunction("-", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, SetTypes::tstzset(), SetFunctions::Minus_set_value));
-    loader.RegisterFunction( ScalarFunction("-", {SetTypes::tstzset(), SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Minus_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {LogicalType::INTEGER, SetTypes::intset()}, SetTypes::intset(), SetFunctions::Minus_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Minus_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {SetTypes::intset(), SetTypes::intset()}, SetTypes::intset(), SetFunctions::Minus_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {LogicalType::BIGINT, SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Minus_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Minus_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {SetTypes::bigintset(), SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Minus_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {LogicalType::DOUBLE, SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Minus_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Minus_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {SetTypes::floatset(), SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Minus_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Minus_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Minus_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {SetTypes::textset(), SetTypes::textset()}, SetTypes::textset(), SetFunctions::Minus_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {LogicalType::DATE, SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Minus_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {SetTypes::dateset(), LogicalType::DATE}, SetTypes::dateset(), SetFunctions::Minus_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {SetTypes::dateset(), SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Minus_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Minus_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, SetTypes::tstzset(), SetFunctions::Minus_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_minus", {SetTypes::tstzset(), SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Minus_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {LogicalType::INTEGER, SetTypes::intset()}, SetTypes::intset(), SetFunctions::Minus_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Minus_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SetTypes::intset(), SetTypes::intset()}, SetTypes::intset(), SetFunctions::Minus_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {LogicalType::BIGINT, SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Minus_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Minus_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SetTypes::bigintset(), SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Minus_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {LogicalType::DOUBLE, SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Minus_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Minus_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SetTypes::floatset(), SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Minus_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Minus_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Minus_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SetTypes::textset(), SetTypes::textset()}, SetTypes::textset(), SetFunctions::Minus_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {LogicalType::DATE, SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Minus_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SetTypes::dateset(), LogicalType::DATE}, SetTypes::dateset(), SetFunctions::Minus_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SetTypes::dateset(), SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Minus_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Minus_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, SetTypes::tstzset(), SetFunctions::Minus_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SetTypes::tstzset(), SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Minus_set_set));
 
     // --- set_intersection / * ---
-    loader.RegisterFunction( ScalarFunction("set_intersection", {LogicalType::INTEGER, SetTypes::intset()}, SetTypes::intset(), SetFunctions::Intersect_value_set));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Intersect_set_value));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {SetTypes::intset(), SetTypes::intset()}, SetTypes::intset(), SetFunctions::Intersect_set_set));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {LogicalType::BIGINT, SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Intersect_value_set));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Intersect_set_value));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {SetTypes::bigintset(), SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Intersect_set_set));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {LogicalType::DOUBLE, SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Intersect_value_set));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Intersect_set_value));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {SetTypes::floatset(), SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Intersect_set_set));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Intersect_value_set));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Intersect_set_value));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {SetTypes::textset(), SetTypes::textset()}, SetTypes::textset(), SetFunctions::Intersect_set_set));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {LogicalType::DATE, SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Intersect_value_set));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {SetTypes::dateset(), LogicalType::DATE}, SetTypes::dateset(), SetFunctions::Intersect_set_value));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {SetTypes::dateset(), SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Intersect_set_set));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Intersect_value_set));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, SetTypes::tstzset(), SetFunctions::Intersect_set_value));
-    loader.RegisterFunction( ScalarFunction("set_intersection", {SetTypes::tstzset(), SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Intersect_set_set));
-    loader.RegisterFunction( ScalarFunction("*", {LogicalType::INTEGER, SetTypes::intset()}, SetTypes::intset(), SetFunctions::Intersect_value_set));
-    loader.RegisterFunction( ScalarFunction("*", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Intersect_set_value));
-    loader.RegisterFunction( ScalarFunction("*", {SetTypes::intset(), SetTypes::intset()}, SetTypes::intset(), SetFunctions::Intersect_set_set));
-    loader.RegisterFunction( ScalarFunction("*", {LogicalType::BIGINT, SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Intersect_value_set));
-    loader.RegisterFunction( ScalarFunction("*", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Intersect_set_value));
-    loader.RegisterFunction( ScalarFunction("*", {SetTypes::bigintset(), SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Intersect_set_set));
-    loader.RegisterFunction( ScalarFunction("*", {LogicalType::DOUBLE, SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Intersect_value_set));
-    loader.RegisterFunction( ScalarFunction("*", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Intersect_set_value));
-    loader.RegisterFunction( ScalarFunction("*", {SetTypes::floatset(), SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Intersect_set_set));
-    loader.RegisterFunction( ScalarFunction("*", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Intersect_value_set));
-    loader.RegisterFunction( ScalarFunction("*", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Intersect_set_value));
-    loader.RegisterFunction( ScalarFunction("*", {SetTypes::textset(), SetTypes::textset()}, SetTypes::textset(), SetFunctions::Intersect_set_set));
-    loader.RegisterFunction( ScalarFunction("*", {LogicalType::DATE, SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Intersect_value_set));
-    loader.RegisterFunction( ScalarFunction("*", {SetTypes::dateset(), LogicalType::DATE}, SetTypes::dateset(), SetFunctions::Intersect_set_value));
-    loader.RegisterFunction( ScalarFunction("*", {SetTypes::dateset(), SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Intersect_set_set));
-    loader.RegisterFunction( ScalarFunction("*", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Intersect_value_set));
-    loader.RegisterFunction( ScalarFunction("*", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, SetTypes::tstzset(), SetFunctions::Intersect_set_value));
-    loader.RegisterFunction( ScalarFunction("*", {SetTypes::tstzset(), SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Intersect_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {LogicalType::INTEGER, SetTypes::intset()}, SetTypes::intset(), SetFunctions::Intersect_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Intersect_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {SetTypes::intset(), SetTypes::intset()}, SetTypes::intset(), SetFunctions::Intersect_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {LogicalType::BIGINT, SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Intersect_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Intersect_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {SetTypes::bigintset(), SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Intersect_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {LogicalType::DOUBLE, SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Intersect_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Intersect_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {SetTypes::floatset(), SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Intersect_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Intersect_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Intersect_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {SetTypes::textset(), SetTypes::textset()}, SetTypes::textset(), SetFunctions::Intersect_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {LogicalType::DATE, SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Intersect_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {SetTypes::dateset(), LogicalType::DATE}, SetTypes::dateset(), SetFunctions::Intersect_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {SetTypes::dateset(), SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Intersect_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Intersect_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, SetTypes::tstzset(), SetFunctions::Intersect_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_intersection", {SetTypes::tstzset(), SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Intersect_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {LogicalType::INTEGER, SetTypes::intset()}, SetTypes::intset(), SetFunctions::Intersect_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Intersect_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SetTypes::intset(), SetTypes::intset()}, SetTypes::intset(), SetFunctions::Intersect_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {LogicalType::BIGINT, SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Intersect_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SetTypes::bigintset(), LogicalType::BIGINT}, SetTypes::bigintset(), SetFunctions::Intersect_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SetTypes::bigintset(), SetTypes::bigintset()}, SetTypes::bigintset(), SetFunctions::Intersect_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {LogicalType::DOUBLE, SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Intersect_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SetTypes::floatset(), LogicalType::DOUBLE}, SetTypes::floatset(), SetFunctions::Intersect_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SetTypes::floatset(), SetTypes::floatset()}, SetTypes::floatset(), SetFunctions::Intersect_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {LogicalType::VARCHAR, SetTypes::textset()}, SetTypes::textset(), SetFunctions::Intersect_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SetTypes::textset(), LogicalType::VARCHAR}, SetTypes::textset(), SetFunctions::Intersect_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SetTypes::textset(), SetTypes::textset()}, SetTypes::textset(), SetFunctions::Intersect_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {LogicalType::DATE, SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Intersect_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SetTypes::dateset(), LogicalType::DATE}, SetTypes::dateset(), SetFunctions::Intersect_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SetTypes::dateset(), SetTypes::dateset()}, SetTypes::dateset(), SetFunctions::Intersect_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Intersect_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, SetTypes::tstzset(), SetFunctions::Intersect_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SetTypes::tstzset(), SetTypes::tstzset()}, SetTypes::tstzset(), SetFunctions::Intersect_set_set));
 
     // --- set_distance / <-> ---
-    loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, SetFunctions::Distance_value_value));
-    loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::BIGINT, SetFunctions::Distance_value_value));
-    loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, SetFunctions::Distance_value_value));
-    loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::DATE, LogicalType::DATE}, LogicalType::INTEGER, SetFunctions::Distance_value_value));
-    loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::TIMESTAMP_TZ, LogicalType::TIMESTAMP_TZ}, LogicalType::DOUBLE, SetFunctions::Distance_value_value));
-    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::INTEGER, SetFunctions::Distance_set_value));
-    loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::INTEGER, SetFunctions::Distance_value_set));
-    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::intset(), SetTypes::intset()}, LogicalType::INTEGER, SetFunctions::Distance_set_set));
-    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BIGINT, SetFunctions::Distance_set_value));
-    loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BIGINT, SetFunctions::Distance_value_set));
-    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BIGINT, SetFunctions::Distance_set_set));
-    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::DOUBLE, SetFunctions::Distance_set_value));
-    loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::DOUBLE, SetFunctions::Distance_value_set));
-    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::DOUBLE, SetFunctions::Distance_set_set));
-    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::INTEGER, SetFunctions::Distance_set_value));
-    loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Distance_value_set));
-    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Distance_set_set));
-    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::DOUBLE, SetFunctions::Distance_set_value));
-    loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::DOUBLE, SetFunctions::Distance_value_set));
-    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::DOUBLE, SetFunctions::Distance_set_set));
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, SetFunctions::Distance_value_value));
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::BIGINT, SetFunctions::Distance_value_value));
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, SetFunctions::Distance_value_value));
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::DATE, LogicalType::DATE}, LogicalType::INTEGER, SetFunctions::Distance_value_value));
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::TIMESTAMP_TZ, LogicalType::TIMESTAMP_TZ}, LogicalType::DOUBLE, SetFunctions::Distance_value_value));
-    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::INTEGER, SetFunctions::Distance_set_value));
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::INTEGER, SetFunctions::Distance_value_set));
-    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::intset(), SetTypes::intset()}, LogicalType::INTEGER, SetFunctions::Distance_set_set));
-    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BIGINT, SetFunctions::Distance_set_value));
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BIGINT, SetFunctions::Distance_value_set));
-    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BIGINT, SetFunctions::Distance_set_set));
-    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::DOUBLE, SetFunctions::Distance_set_value));
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::DOUBLE, SetFunctions::Distance_value_set));
-    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::DOUBLE, SetFunctions::Distance_set_set));
-    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::INTEGER, SetFunctions::Distance_set_value));
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Distance_value_set));
-    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Distance_set_set));
-    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::DOUBLE, SetFunctions::Distance_set_value));
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::DOUBLE, SetFunctions::Distance_value_set));
-    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::DOUBLE, SetFunctions::Distance_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, SetFunctions::Distance_value_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::BIGINT, SetFunctions::Distance_value_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, SetFunctions::Distance_value_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {LogicalType::DATE, LogicalType::DATE}, LogicalType::INTEGER, SetFunctions::Distance_value_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {LogicalType::TIMESTAMP_TZ, LogicalType::TIMESTAMP_TZ}, LogicalType::DOUBLE, SetFunctions::Distance_value_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::INTEGER, SetFunctions::Distance_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::INTEGER, SetFunctions::Distance_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {SetTypes::intset(), SetTypes::intset()}, LogicalType::INTEGER, SetFunctions::Distance_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BIGINT, SetFunctions::Distance_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BIGINT, SetFunctions::Distance_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BIGINT, SetFunctions::Distance_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::DOUBLE, SetFunctions::Distance_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::DOUBLE, SetFunctions::Distance_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::DOUBLE, SetFunctions::Distance_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::INTEGER, SetFunctions::Distance_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Distance_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Distance_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::DOUBLE, SetFunctions::Distance_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::DOUBLE, SetFunctions::Distance_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_distance", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::DOUBLE, SetFunctions::Distance_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, SetFunctions::Distance_value_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::BIGINT, SetFunctions::Distance_value_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, SetFunctions::Distance_value_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::DATE, LogicalType::DATE}, LogicalType::INTEGER, SetFunctions::Distance_value_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::TIMESTAMP_TZ, LogicalType::TIMESTAMP_TZ}, LogicalType::DOUBLE, SetFunctions::Distance_value_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SetTypes::intset(), LogicalType::INTEGER}, LogicalType::INTEGER, SetFunctions::Distance_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::INTEGER, SetTypes::intset()}, LogicalType::INTEGER, SetFunctions::Distance_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SetTypes::intset(), SetTypes::intset()}, LogicalType::INTEGER, SetFunctions::Distance_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SetTypes::bigintset(), LogicalType::BIGINT}, LogicalType::BIGINT, SetFunctions::Distance_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::BIGINT, SetTypes::bigintset()}, LogicalType::BIGINT, SetFunctions::Distance_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BIGINT, SetFunctions::Distance_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SetTypes::floatset(), LogicalType::DOUBLE}, LogicalType::DOUBLE, SetFunctions::Distance_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::DOUBLE, SetTypes::floatset()}, LogicalType::DOUBLE, SetFunctions::Distance_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::DOUBLE, SetFunctions::Distance_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::INTEGER, SetFunctions::Distance_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Distance_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Distance_set_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::DOUBLE, SetFunctions::Distance_set_value));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::DOUBLE, SetFunctions::Distance_value_set));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::DOUBLE, SetFunctions::Distance_set_set));
 
     // --- set_eq / = ---
-    loader.RegisterFunction( ScalarFunction("set_eq", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
-    loader.RegisterFunction( ScalarFunction("set_eq", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
-    loader.RegisterFunction( ScalarFunction("set_eq", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
-    loader.RegisterFunction( ScalarFunction("set_eq", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
-    loader.RegisterFunction( ScalarFunction("set_eq", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
-    loader.RegisterFunction( ScalarFunction("set_eq", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_eq", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_eq", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_eq", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_eq", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_eq", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_eq", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
 
-    loader.RegisterFunction( ScalarFunction("=", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
-    loader.RegisterFunction( ScalarFunction("=", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
-    loader.RegisterFunction( ScalarFunction("=", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
-    loader.RegisterFunction( ScalarFunction("=", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
-    loader.RegisterFunction( ScalarFunction("=", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
-    loader.RegisterFunction( ScalarFunction("=", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("=", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("=", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("=", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("=", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("=", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("=", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));
 
-    loader.RegisterFunction( ScalarFunction("set_ne", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
-    loader.RegisterFunction( ScalarFunction("set_ne", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
-    loader.RegisterFunction( ScalarFunction("set_ne", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
-    loader.RegisterFunction( ScalarFunction("set_ne", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
-    loader.RegisterFunction( ScalarFunction("set_ne", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
-    loader.RegisterFunction( ScalarFunction("set_ne", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_ne", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_ne", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_ne", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_ne", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_ne", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_ne", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
 
-    loader.RegisterFunction( ScalarFunction("<>", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
-    loader.RegisterFunction( ScalarFunction("<>", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
-    loader.RegisterFunction( ScalarFunction("<>", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
-    loader.RegisterFunction( ScalarFunction("<>", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
-    loader.RegisterFunction( ScalarFunction("<>", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
-    loader.RegisterFunction( ScalarFunction("<>", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<>", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<>", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<>", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<>", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<>", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<>", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_ne));
 
 
-    loader.RegisterFunction( ScalarFunction("set_lt", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
-    loader.RegisterFunction( ScalarFunction("set_lt", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
-    loader.RegisterFunction( ScalarFunction("set_lt", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
-    loader.RegisterFunction( ScalarFunction("set_lt", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
-    loader.RegisterFunction( ScalarFunction("set_lt", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
-    loader.RegisterFunction( ScalarFunction("set_lt", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_lt", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_lt", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_lt", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_lt", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_lt", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_lt", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
 
-    loader.RegisterFunction( ScalarFunction("<", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
-    loader.RegisterFunction( ScalarFunction("<", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
-    loader.RegisterFunction( ScalarFunction("<", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
-    loader.RegisterFunction( ScalarFunction("<", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
-    loader.RegisterFunction( ScalarFunction("<", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
-    loader.RegisterFunction( ScalarFunction("<", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_lt));
 
-    loader.RegisterFunction( ScalarFunction("set_le", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
-    loader.RegisterFunction( ScalarFunction("set_le", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
-    loader.RegisterFunction( ScalarFunction("set_le", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
-    loader.RegisterFunction( ScalarFunction("set_le", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
-    loader.RegisterFunction( ScalarFunction("set_le", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
-    loader.RegisterFunction( ScalarFunction("set_le", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_le", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_le", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_le", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_le", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_le", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_le", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
 
-    loader.RegisterFunction( ScalarFunction("<=", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
-    loader.RegisterFunction( ScalarFunction("<=", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
-    loader.RegisterFunction( ScalarFunction("<=", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
-    loader.RegisterFunction( ScalarFunction("<=", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
-    loader.RegisterFunction( ScalarFunction("<=", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
-    loader.RegisterFunction( ScalarFunction("<=", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<=", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<=", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<=", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<=", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<=", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<=", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_le));
 
-    loader.RegisterFunction( ScalarFunction("set_gt", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
-    loader.RegisterFunction( ScalarFunction("set_gt", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
-    loader.RegisterFunction( ScalarFunction("set_gt", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
-    loader.RegisterFunction( ScalarFunction("set_gt", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
-    loader.RegisterFunction( ScalarFunction("set_gt", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
-    loader.RegisterFunction( ScalarFunction("set_gt", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_gt", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_gt", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_gt", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_gt", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_gt", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_gt", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
 
-    loader.RegisterFunction( ScalarFunction(">", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
-    loader.RegisterFunction( ScalarFunction(">", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
-    loader.RegisterFunction( ScalarFunction(">", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
-    loader.RegisterFunction( ScalarFunction(">", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
-    loader.RegisterFunction( ScalarFunction(">", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
-    loader.RegisterFunction( ScalarFunction(">", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_gt));
 
-    loader.RegisterFunction( ScalarFunction("set_ge", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
-    loader.RegisterFunction( ScalarFunction("set_ge", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
-    loader.RegisterFunction( ScalarFunction("set_ge", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
-    loader.RegisterFunction( ScalarFunction("set_ge", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
-    loader.RegisterFunction( ScalarFunction("set_ge", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
-    loader.RegisterFunction( ScalarFunction("set_ge", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_ge", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_ge", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_ge", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_ge", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_ge", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_ge", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
 
-    loader.RegisterFunction( ScalarFunction(">=", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
-    loader.RegisterFunction( ScalarFunction(">=", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
-    loader.RegisterFunction( ScalarFunction(">=", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
-    loader.RegisterFunction( ScalarFunction(">=", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
-    loader.RegisterFunction( ScalarFunction(">=", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
-    loader.RegisterFunction( ScalarFunction(">=", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">=", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">=", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">=", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">=", {SetTypes::textset(), SetTypes::textset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">=", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">=", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::BOOLEAN, SetFunctions::Set_ge));
 
-    loader.RegisterFunction( ScalarFunction("set_cmp", {SetTypes::intset(), SetTypes::intset()}, LogicalType::INTEGER, SetFunctions::Set_cmp));
-    loader.RegisterFunction( ScalarFunction("set_cmp", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::INTEGER, SetFunctions::Set_cmp));
-    loader.RegisterFunction( ScalarFunction("set_cmp", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::INTEGER, SetFunctions::Set_cmp));
-    loader.RegisterFunction( ScalarFunction("set_cmp", {SetTypes::textset(), SetTypes::textset()}, LogicalType::INTEGER, SetFunctions::Set_cmp));
-    loader.RegisterFunction( ScalarFunction("set_cmp", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Set_cmp));
-    loader.RegisterFunction( ScalarFunction("set_cmp", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::INTEGER, SetFunctions::Set_cmp));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_cmp", {SetTypes::intset(), SetTypes::intset()}, LogicalType::INTEGER, SetFunctions::Set_cmp));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_cmp", {SetTypes::bigintset(), SetTypes::bigintset()}, LogicalType::INTEGER, SetFunctions::Set_cmp));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_cmp", {SetTypes::floatset(), SetTypes::floatset()}, LogicalType::INTEGER, SetFunctions::Set_cmp));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_cmp", {SetTypes::textset(), SetTypes::textset()}, LogicalType::INTEGER, SetFunctions::Set_cmp));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_cmp", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Set_cmp));
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("set_cmp", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::INTEGER, SetFunctions::Set_cmp));
 }
 
 // --- Unnest ---
@@ -905,7 +906,7 @@ void SetTypes::RegisterSetUnnest(ExtensionLoader &loader) {
                          SetUnnestExec,
                          SetUnnestBind,
                          SetUnnestInit);
-        loader.RegisterFunction( fn);
+        loader.RegisterFunction(fn);
     }
 }
 

--- a/src/temporal/span.cpp
+++ b/src/temporal/span.cpp
@@ -14,6 +14,7 @@
 
 #include <regex>
 #include <string>
+#include "mobilityduck/meos_exec_serial.hpp"
 
 extern "C" {
     #include <meos.h>
@@ -159,1000 +160,1000 @@ void SpanTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
 
         // Register: asText
         if (span_type == SpanTypes::FLOATSPAN()) {            
-            loader.RegisterFunction( // asText(floatspan)
+            duckdb::RegisterSerializedScalarFunction(loader,  // asText(floatspan)
                 ScalarFunction("asText", {span_type}, LogicalType::VARCHAR, SpanFunctions::Span_as_text)
             );
             
-            loader.RegisterFunction( // asText(floatspan, int)
+            duckdb::RegisterSerializedScalarFunction(loader,  // asText(floatspan, int)
                 ScalarFunction("asText", {span_type, LogicalType::INTEGER}, LogicalType::VARCHAR, SpanFunctions::Span_as_text)
             );
         } else {            
-            loader.RegisterFunction( // All other span types
+            duckdb::RegisterSerializedScalarFunction(loader,  // All other span types
                 ScalarFunction("asText", {span_type}, LogicalType::VARCHAR, SpanFunctions::Span_as_text)
             );
         }
 
         // Register span constructor functions
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(span_type.ToString(), {LogicalType::VARCHAR}, span_type, SpanFunctions::Span_constructor)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("span", {base_type, base_type}, span_type, SpanFunctions::Span_binary_constructor)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("span", {base_type, base_type, LogicalType::BOOLEAN, LogicalType::BOOLEAN}, span_type,
                            SpanFunctions::Span_binary_constructor)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("span", {base_type}, span_type, SpanFunctions::Value_to_span)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("intspan", {SpanTypes::FLOATSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Floatspan_to_intspan)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("floatspan", {SpanTypes::INTSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Intspan_to_floatspan)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("datespan", {SpanTypes::TSTZSPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Tstzspan_to_datespan)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("tstzspan", {SpanTypes::DATESPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Datespan_to_tstzspan)                 
         );
 
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("span", {SetTypes::intset()},SpanTypes::INTSPAN(), SpanFunctions::Set_to_span)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("span", {SetTypes::bigintset()},SpanTypes::BIGINTSPAN(), SpanFunctions::Set_to_span)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("span", {SetTypes::floatset()},SpanTypes::FLOATSPAN(), SpanFunctions::Set_to_span)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("span", {SetTypes::tstzset()},SpanTypes::TSTZSPAN(), SpanFunctions::Set_to_span) 
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("span", {SetTypes::dateset()},SpanTypes::DATESPAN(), SpanFunctions::Set_to_span) 
         );
 
         if (span_type == SpanTypes::INTSPAN() ||span_type == SpanTypes::DATESPAN()){
 
-            loader.RegisterFunction( ScalarFunction("shift", {span_type, LogicalType::INTEGER}, span_type, SpanFunctions::Numspan_shift)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("shift", {span_type, LogicalType::INTEGER}, span_type, SpanFunctions::Numspan_shift)
             ); 
             
-            loader.RegisterFunction( ScalarFunction("scale", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Numspan_scale)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("scale", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Numspan_scale)
             );
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction("shiftScale", {span_type, LogicalType::INTEGER, LogicalType::INTEGER}, span_type,
                                SpanFunctions::Numspan_shift_scale));
 
         }
         else if( span_type == SpanTypes::BIGINTSPAN() ){
-            loader.RegisterFunction( ScalarFunction("shift", {span_type, LogicalType::BIGINT}, span_type, SpanFunctions::Numspan_shift)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("shift", {span_type, LogicalType::BIGINT}, span_type, SpanFunctions::Numspan_shift)
             ); 
-            loader.RegisterFunction( ScalarFunction("expand", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Numspan_expand)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("expand", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Numspan_expand)
             );
-            loader.RegisterFunction( ScalarFunction("scale", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Numspan_scale)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("scale", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Numspan_scale)
             );
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction("shiftScale", {span_type, LogicalType::BIGINT, LogicalType::BIGINT}, span_type, SpanFunctions::Numspan_shift_scale)
             );    
         }
         else if( span_type == SpanTypes::FLOATSPAN() ){
-            loader.RegisterFunction( ScalarFunction("shift", {span_type, LogicalType::DOUBLE}, span_type, SpanFunctions::Numspan_shift)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("shift", {span_type, LogicalType::DOUBLE}, span_type, SpanFunctions::Numspan_shift)
             ); 
-            loader.RegisterFunction( ScalarFunction("expand", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Numspan_expand)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("expand", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Numspan_expand)
             );
-            loader.RegisterFunction( ScalarFunction("scale", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Numspan_scale)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("scale", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Numspan_scale)
             );
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction("shiftScale", {span_type, LogicalType::DOUBLE, LogicalType::DOUBLE}, span_type, SpanFunctions::Numspan_shift_scale)
             );
 
         }
         else if( span_type == SpanTypes::TSTZSPAN() ){
-            loader.RegisterFunction( ScalarFunction("shift", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Tstzspan_shift)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("shift", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Tstzspan_shift)
             ); 
 
-            loader.RegisterFunction( ScalarFunction("expand", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Tstzspan_expand)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("expand", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Tstzspan_expand)
             );
 
-            loader.RegisterFunction( ScalarFunction("scale", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Tstzspan_scale)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("scale", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Tstzspan_scale)
             );
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction("shiftScale", {span_type, LogicalType::INTERVAL, LogicalType::INTERVAL}, span_type, SpanFunctions::Tstzspan_shift_scale)
             );
 
         }      
         
-        loader.RegisterFunction( ScalarFunction("lower", {span_type}, base_type, SpanFunctions::Span_lower));
-        loader.RegisterFunction( ScalarFunction("upper", {span_type}, base_type, SpanFunctions::Span_upper));
+        duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("lower", {span_type}, base_type, SpanFunctions::Span_lower));
+        duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("upper", {span_type}, base_type, SpanFunctions::Span_upper));
 
-        loader.RegisterFunction( ScalarFunction("lowerInc",{span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_lower_inc));
-        loader.RegisterFunction( ScalarFunction("upperInc",{span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_upper_inc));
+        duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("lowerInc",{span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_lower_inc));
+        duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("upperInc",{span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_upper_inc));
 
-        loader.RegisterFunction( ScalarFunction("span_hash", {span_type}, LogicalType::UINTEGER, SpanFunctions::Span_hash));
-        loader.RegisterFunction( ScalarFunction("span_hash_extended", {span_type, LogicalType::BIGINT}, LogicalType::UBIGINT, SpanFunctions::Span_hash_extended));
+        duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_hash", {span_type}, LogicalType::UINTEGER, SpanFunctions::Span_hash));
+        duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_hash_extended", {span_type, LogicalType::BIGINT}, LogicalType::UBIGINT, SpanFunctions::Span_hash_extended));
         }
     
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("expand", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpanTypes::INTSPAN(), SpanFunctions::Numspan_expand)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("expand", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpanTypes::BIGINTSPAN(), SpanFunctions::Numspan_expand)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("expand", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpanTypes::FLOATSPAN(), SpanFunctions::Numspan_expand)
     );  
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("expand", {SpanTypes::DATESPAN(), LogicalType::INTEGER}, SpanTypes::DATESPAN(), SpanFunctions::Numspan_expand)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
             ScalarFunction("expand", {SpanTypes::TSTZSPAN(), LogicalType::INTERVAL}, SpanTypes::TSTZSPAN(), SpanFunctions::Tstzspan_expand)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("width", {SpanTypes::INTSPAN()}, LogicalType::INTEGER, SpanFunctions::Numspan_width)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("width", {SpanTypes::BIGINTSPAN()}, LogicalType::BIGINT, SpanFunctions::Numspan_width)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("width", {SpanTypes::FLOATSPAN()}, LogicalType::DOUBLE, SpanFunctions::Numspan_width)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("duration", {SpanTypes::DATESPAN()}, LogicalType::INTERVAL, SpanFunctions::Datespan_duration)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("duration", {SpanTypes::TSTZSPAN()}, LogicalType::INTERVAL, SpanFunctions::Tstzspan_duration)
     );
 
 
 
     // spans(<set_type>) — list of unit spans, one per set element
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("spans", {SetTypes::intset()},
                        LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("spans", {SetTypes::bigintset()},
                        LogicalType::LIST(SpanTypes::BIGINTSPAN()), SpanFunctions::Set_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("spans", {SetTypes::floatset()},
                        LogicalType::LIST(SpanTypes::FLOATSPAN()), SpanFunctions::Set_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("spans", {SetTypes::dateset()},
                        LogicalType::LIST(SpanTypes::DATESPAN()), SpanFunctions::Set_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("spans", {SetTypes::tstzset()},
                        LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_spans));
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitNSpans", {SetTypes::intset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_split_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitNSpans", {SetTypes::bigintset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::BIGINTSPAN()), SpanFunctions::Set_split_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitNSpans", {SetTypes::floatset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::FLOATSPAN()), SpanFunctions::Set_split_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitNSpans", {SetTypes::dateset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::DATESPAN()), SpanFunctions::Set_split_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitNSpans", {SetTypes::tstzset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_split_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitEachNSpans", {SetTypes::intset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_split_each_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitEachNSpans", {SetTypes::bigintset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::BIGINTSPAN()), SpanFunctions::Set_split_each_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitEachNSpans", {SetTypes::floatset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::FLOATSPAN()), SpanFunctions::Set_split_each_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitEachNSpans", {SetTypes::dateset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::DATESPAN()), SpanFunctions::Set_split_each_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitEachNSpans", {SetTypes::tstzset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_split_each_n_spans));
 
     // Lowercase-"spans" aliases matching MobilityDB's SQL surface
     // (`splitNspans` / `splitEachNspans`). The camelCase forms above
     // stay registered for back-compat with existing MobilityDuck callers.
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitNspans", {SetTypes::intset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_split_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitNspans", {SetTypes::bigintset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::BIGINTSPAN()), SpanFunctions::Set_split_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitNspans", {SetTypes::floatset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::FLOATSPAN()), SpanFunctions::Set_split_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitNspans", {SetTypes::dateset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::DATESPAN()), SpanFunctions::Set_split_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitNspans", {SetTypes::tstzset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_split_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitEachNspans", {SetTypes::intset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::INTSPAN()), SpanFunctions::Set_split_each_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitEachNspans", {SetTypes::bigintset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::BIGINTSPAN()), SpanFunctions::Set_split_each_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitEachNspans", {SetTypes::floatset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::FLOATSPAN()), SpanFunctions::Set_split_each_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitEachNspans", {SetTypes::dateset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::DATESPAN()), SpanFunctions::Set_split_each_n_spans));
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("splitEachNspans", {SetTypes::tstzset(), LogicalType::INTEGER},
                        LogicalType::LIST(SpanTypes::TSTZSPAN()), SpanFunctions::Set_split_each_n_spans));
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("floor", {SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Floatspan_floor)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("ceil", {SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Floatspan_ceil)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("round", {LogicalType::DOUBLE}, LogicalType::DOUBLE, SpanFunctions::Float_round)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("round", {LogicalType::DOUBLE, LogicalType::INTEGER}, LogicalType::DOUBLE, SpanFunctions::Float_round)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("round", {SpanTypes::FLOATSPAN(), LogicalType::INTEGER}, SpanTypes::FLOATSPAN(), SpanFunctions::Floatspan_round)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("round", {SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Floatspan_round)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("degrees", {SpanTypes::FLOATSPAN(), LogicalType::BOOLEAN}, SpanTypes::FLOATSPAN(), SpanFunctions::Floatspan_degrees)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("degrees", {SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Floatspan_degrees)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("radians", {SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Floatspan_radians)
     );
 
     for (const auto &span_type : SpanTypes::AllTypes()) {
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("span_eq", {span_type, span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_eq)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("span_ne", {span_type, span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_ne)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("span_lt", {span_type, span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_lt)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("span_le", {span_type, span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_le)
     );
     
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("span_ge", {span_type, span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_ge)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("span_gt", {span_type, span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_gt)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("span_cmp", {span_type, span_type}, LogicalType::INTEGER, SpanFunctions::Span_cmp)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("=", {span_type, span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_eq)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("<>", {span_type, span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_ne)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("<", {span_type, span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_lt)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("<=", {span_type, span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_le)
     );
     
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(">=", {span_type, span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_ge)
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(">", {span_type, span_type}, LogicalType::BOOLEAN, SpanFunctions::Span_gt)
     );
     }
 
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("span_contains", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_value)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("@>", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_value)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("span_contains", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_span)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("@>", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_span)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("span_contains", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_value)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("@>", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_value)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("span_contains", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_span)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("@>", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_span)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("span_contains", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_value)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("@>", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_value)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("span_contains", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_span)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("@>", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_span)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("span_contains", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_value)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("@>", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_value)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("span_contains", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_span)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("@>", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_span)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("span_contains", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_value)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("@>", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_value)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("span_contains", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_span)
     );
-    loader.RegisterFunction( 
+    duckdb::RegisterSerializedScalarFunction(loader,  
         ScalarFunction("@>", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contains_span_span)
     );
 
-    loader.RegisterFunction( ScalarFunction("span_contained", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_contained", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("<@", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_contained", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_contained", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("<@", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_contained", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_contained", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("<@", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_contained", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_contained", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("<@", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_contained", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_contained", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("<@", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_contained", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_contained", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("<@", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_contained", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_contained", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("<@", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_contained", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_contained", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("<@", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_contained", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)     
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_contained", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)     
     );
-    loader.RegisterFunction( ScalarFunction("<@", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)     
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_value_span)     
     );
-    loader.RegisterFunction( ScalarFunction("span_contained", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_contained", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("<@", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<@", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Contained_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overlaps", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overlaps", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&&", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&&", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overlaps", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overlaps", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&&", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&&", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
     );              
-    loader.RegisterFunction( ScalarFunction("span_overlaps", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overlaps", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&&", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&&", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overlaps", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overlaps", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&&", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&&", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overlaps", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overlaps", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&&", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&&", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overlaps_span_span)
     );      
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {LogicalType::BIGINT,SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {LogicalType::BIGINT,SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {LogicalType::BIGINT,SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {LogicalType::BIGINT,SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)   
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)   
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)   
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_value_span)   
     );
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)    
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)    
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)    
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_span)    
     );  
-    loader.RegisterFunction( ScalarFunction("span_adjacent", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)    
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_adjacent", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)    
     );
-    loader.RegisterFunction( ScalarFunction("-|-", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)    
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-|-", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Adjacent_span_value)    
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("<<", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("<<", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("<<", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("<<", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("<<", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("<<", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
     );  
-    loader.RegisterFunction( ScalarFunction("span_left", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("<<", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("<<", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("<<", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("<<#", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<#", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("<<#", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<#", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("<<#", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<#", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("<<#", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<#", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Left_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("<<#", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<#", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_left", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_left", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("<<#", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<<#", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Left_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
     );
-    loader.RegisterFunction( ScalarFunction(">>", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
     );
-    loader.RegisterFunction( ScalarFunction(">>", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
     );
-    loader.RegisterFunction( ScalarFunction(">>", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
     );
-    loader.RegisterFunction( ScalarFunction(">>", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
     );
-    loader.RegisterFunction( ScalarFunction(">>", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
     );
-    loader.RegisterFunction( ScalarFunction(">>", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
     );      
-    loader.RegisterFunction( ScalarFunction("span_right", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
     );
-    loader.RegisterFunction( ScalarFunction(">>", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
     );
-    loader.RegisterFunction( ScalarFunction(">>", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
     );
-    loader.RegisterFunction( ScalarFunction(">>", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction(">>", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("#>>", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("#>>", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("#>>", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("#>>", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("#>>", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("#>>", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("#>>", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("#>>", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Right_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("#>>", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("#>>", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_right", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_right", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("#>>", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("#>>", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Right_span_span)
     );  
-    loader.RegisterFunction( ScalarFunction("span_overleft", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("&<", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("&<", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&<", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("&<", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("&<", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&<", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
     );  
-    loader.RegisterFunction( ScalarFunction("span_overleft", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("&<", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("&<", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&<", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("&<#", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<#", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("&<#", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<#", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&<#", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<#", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("&<", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
     );  
-    loader.RegisterFunction( ScalarFunction("&<", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overleft", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overleft", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&<#", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&<#", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overleft_span_span)
     );
     
-    loader.RegisterFunction( ScalarFunction("span_overright", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("&>", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("&>", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&>", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("&>", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&>", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
     );      
-    loader.RegisterFunction( ScalarFunction("span_overright", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("&>", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("&>", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("&>", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("&>", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("#&>", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("#&>", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("#&>", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("#&>", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("#&>", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("#&>", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("#&>", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("#&>", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("#&>", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("#&>", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_overright", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_overright", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("#&>", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("#&>", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, SpanFunctions::Overright_span_span)
     );  
 
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpansetTypes::intspanset(), SpanFunctions::Union_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpansetTypes::intspanset(), SpanFunctions::Union_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Union_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Union_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Union_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpansetTypes::intspanset(), SpanFunctions::Union_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpansetTypes::intspanset(), SpanFunctions::Union_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("+", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Union_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Union_span_span)
-    );
-
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpansetTypes::bigintspanset(), SpanFunctions::Union_span_value)
-    );
-    loader.RegisterFunction( ScalarFunction("span_union", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Union_value_span)
-    );
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Union_span_span)
-    );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpansetTypes::bigintspanset(), SpanFunctions::Union_span_value)
-    );
-    loader.RegisterFunction( ScalarFunction("+", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Union_value_span)
-    );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Union_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Union_span_span)
     );
 
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpansetTypes::floatspanset(), SpanFunctions::Union_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpansetTypes::bigintspanset(), SpanFunctions::Union_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Union_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Union_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Union_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpansetTypes::floatspanset(), SpanFunctions::Union_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpansetTypes::bigintspanset(), SpanFunctions::Union_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("+", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Union_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Union_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Union_span_span)
     );
 
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpansetTypes::datespanset(), SpanFunctions::Union_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpansetTypes::floatspanset(), SpanFunctions::Union_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Union_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Union_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Union_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpansetTypes::datespanset(), SpanFunctions::Union_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpansetTypes::floatspanset(), SpanFunctions::Union_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("+", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Union_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Union_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Union_span_span)
+    );
+
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpansetTypes::datespanset(), SpanFunctions::Union_span_value)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Union_value_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Union_span_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpansetTypes::datespanset(), SpanFunctions::Union_span_value)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Union_value_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Union_span_span)
     );  
 
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpansetTypes::tstzspanset(), SpanFunctions::Union_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpansetTypes::tstzspanset(), SpanFunctions::Union_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Union_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_union", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Union_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_union", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Union_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpansetTypes::tstzspanset(), SpanFunctions::Union_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpansetTypes::tstzspanset(), SpanFunctions::Union_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("+", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Union_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Union_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("+", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Union_span_span)  
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("+", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Union_span_span)  
     );  
 
-    loader.RegisterFunction( ScalarFunction("span_intersection", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_intersection", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_intersection", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("*", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("*", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("*", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_span_span)
-    );
-
-    loader.RegisterFunction( ScalarFunction("span_intersection", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpanTypes::BIGINTSPAN(), SpanFunctions::Intersection_span_value)
-    );
-    loader.RegisterFunction( ScalarFunction("span_intersection", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Intersection_value_span)
-    );
-    loader.RegisterFunction( ScalarFunction("span_intersection", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Intersection_span_span) 
-    );
-    loader.RegisterFunction( ScalarFunction("*", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpanTypes::BIGINTSPAN(), SpanFunctions::Intersection_span_value)
-    );
-    loader.RegisterFunction( ScalarFunction("*", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Intersection_value_span)
-    );
-    loader.RegisterFunction( ScalarFunction("*", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Intersection_span_span) 
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpanTypes::INTSPAN(), SpanFunctions::Intersection_span_span)
     );
 
-    loader.RegisterFunction( ScalarFunction("span_intersection", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpanTypes::FLOATSPAN(), SpanFunctions::Intersection_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpanTypes::BIGINTSPAN(), SpanFunctions::Intersection_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_intersection", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Intersection_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Intersection_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_intersection", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Intersection_span_span) 
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Intersection_span_span) 
     );
-    loader.RegisterFunction( ScalarFunction("*", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpanTypes::FLOATSPAN(), SpanFunctions::Intersection_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpanTypes::BIGINTSPAN(), SpanFunctions::Intersection_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("*", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Intersection_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Intersection_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("*", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Intersection_span_span) 
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpanTypes::BIGINTSPAN(), SpanFunctions::Intersection_span_span) 
+    );
+
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpanTypes::FLOATSPAN(), SpanFunctions::Intersection_span_value)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Intersection_value_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Intersection_span_span) 
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpanTypes::FLOATSPAN(), SpanFunctions::Intersection_span_value)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Intersection_value_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpanTypes::FLOATSPAN(), SpanFunctions::Intersection_span_span) 
     );  
 
-    loader.RegisterFunction( ScalarFunction("span_intersection", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpanTypes::DATESPAN(), SpanFunctions::Intersection_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpanTypes::DATESPAN(), SpanFunctions::Intersection_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_intersection", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Intersection_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Intersection_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_intersection", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Intersection_span_span) 
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Intersection_span_span) 
     );
-    loader.RegisterFunction( ScalarFunction("*", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpanTypes::DATESPAN(), SpanFunctions::Intersection_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpanTypes::DATESPAN(), SpanFunctions::Intersection_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("*", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Intersection_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Intersection_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("*", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Intersection_span_span) 
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpanTypes::DATESPAN(), SpanFunctions::Intersection_span_span) 
     );  
-    loader.RegisterFunction( ScalarFunction("span_intersection", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpanTypes::TSTZSPAN(), SpanFunctions::Intersection_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpanTypes::TSTZSPAN(), SpanFunctions::Intersection_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_intersection", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Intersection_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Intersection_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_intersection", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Intersection_span_span) 
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_intersection", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Intersection_span_span) 
     );
-    loader.RegisterFunction( ScalarFunction("*", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpanTypes::TSTZSPAN(), SpanFunctions::Intersection_span_value)  
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpanTypes::TSTZSPAN(), SpanFunctions::Intersection_span_value)  
     );
-    loader.RegisterFunction( ScalarFunction("*", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Intersection_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Intersection_value_span)
     );  
-    loader.RegisterFunction( ScalarFunction("*", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Intersection_span_span) 
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("*", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpanTypes::TSTZSPAN(), SpanFunctions::Intersection_span_span) 
     );
     
-    loader.RegisterFunction( ScalarFunction("span_minus", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpansetTypes::intspanset(), SpanFunctions::Minus_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpansetTypes::intspanset(), SpanFunctions::Minus_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_minus", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Minus_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Minus_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_minus", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Minus_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Minus_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("-", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpansetTypes::intspanset(), SpanFunctions::Minus_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, SpansetTypes::intspanset(), SpanFunctions::Minus_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("-", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Minus_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Minus_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("-", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Minus_span_span)
-    );
-
-    loader.RegisterFunction( ScalarFunction("span_minus", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpansetTypes::bigintspanset(), SpanFunctions::Minus_span_value)
-    );
-    loader.RegisterFunction( ScalarFunction("span_minus", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Minus_value_span)    
-    );
-    loader.RegisterFunction( ScalarFunction("span_minus", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Minus_span_span) 
-    );
-    loader.RegisterFunction( ScalarFunction("-", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpansetTypes::bigintspanset(), SpanFunctions::Minus_span_value)
-    );
-    loader.RegisterFunction( ScalarFunction("-", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Minus_value_span)    
-    );
-    loader.RegisterFunction( ScalarFunction("-", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Minus_span_span) 
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, SpansetTypes::intspanset(), SpanFunctions::Minus_span_span)
     );
 
-    loader.RegisterFunction( ScalarFunction("span_minus", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpansetTypes::floatspanset(), SpanFunctions::Minus_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpansetTypes::bigintspanset(), SpanFunctions::Minus_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_minus", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Minus_value_span)    
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Minus_value_span)    
     );
-    loader.RegisterFunction( ScalarFunction("span_minus", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Minus_span_span) 
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Minus_span_span) 
     );
-    loader.RegisterFunction( ScalarFunction("-", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpansetTypes::floatspanset(), SpanFunctions::Minus_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, SpansetTypes::bigintspanset(), SpanFunctions::Minus_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("-", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Minus_value_span)    
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Minus_value_span)    
     );
-    loader.RegisterFunction( ScalarFunction("-", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Minus_span_span) 
-    );
-
-    loader.RegisterFunction( ScalarFunction("span_minus", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpansetTypes::datespanset(), SpanFunctions::Minus_span_value)
-    );
-    loader.RegisterFunction( ScalarFunction("span_minus", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Minus_value_span)    
-    );
-    loader.RegisterFunction( ScalarFunction("span_minus", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Minus_span_span) 
-    );
-    loader.RegisterFunction( ScalarFunction("-", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpansetTypes::datespanset(), SpanFunctions::Minus_span_value)
-    );
-    loader.RegisterFunction( ScalarFunction("-", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Minus_value_span)    
-    );
-    loader.RegisterFunction( ScalarFunction("-", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Minus_span_span) 
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, SpansetTypes::bigintspanset(), SpanFunctions::Minus_span_span) 
     );
 
-    loader.RegisterFunction( ScalarFunction("span_minus", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpansetTypes::tstzspanset(), SpanFunctions::Minus_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpansetTypes::floatspanset(), SpanFunctions::Minus_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_minus", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Minus_value_span)    
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Minus_value_span)    
     );
-    loader.RegisterFunction( ScalarFunction("span_minus", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Minus_span_span) 
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Minus_span_span) 
     );
-    loader.RegisterFunction( ScalarFunction("-", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpansetTypes::tstzspanset(), SpanFunctions::Minus_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, SpansetTypes::floatspanset(), SpanFunctions::Minus_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("-", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Minus_value_span)    
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Minus_value_span)    
     );
-    loader.RegisterFunction( ScalarFunction("-", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Minus_span_span) 
-    );
-
-    loader.RegisterFunction( ScalarFunction("span_distance", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::INTEGER, SpanFunctions::Distance_span_value)
-    );
-    loader.RegisterFunction( ScalarFunction("span_distance", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_value_span)
-    );
-    loader.RegisterFunction( ScalarFunction("span_distance", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_span_span)
-    );
-    loader.RegisterFunction( ScalarFunction("<->", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::INTEGER, SpanFunctions::Distance_span_value)
-    );
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_value_span)
-    );
-    loader.RegisterFunction( ScalarFunction("<->", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, SpansetTypes::floatspanset(), SpanFunctions::Minus_span_span) 
     );
 
-    loader.RegisterFunction( ScalarFunction("span_distance", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BIGINT, SpanFunctions::Distance_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpansetTypes::datespanset(), SpanFunctions::Minus_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_distance", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BIGINT, SpanFunctions::Distance_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Minus_value_span)    
     );
-    loader.RegisterFunction( ScalarFunction("span_distance", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BIGINT, SpanFunctions::Distance_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Minus_span_span) 
     );
-    loader.RegisterFunction( ScalarFunction("<->", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BIGINT, SpanFunctions::Distance_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SpanTypes::DATESPAN(), LogicalType::DATE}, SpansetTypes::datespanset(), SpanFunctions::Minus_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BIGINT, SpanFunctions::Distance_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {LogicalType::DATE, SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Minus_value_span)    
     );
-    loader.RegisterFunction( ScalarFunction("<->", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BIGINT, SpanFunctions::Distance_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, SpansetTypes::datespanset(), SpanFunctions::Minus_span_span) 
     );
 
-    loader.RegisterFunction( ScalarFunction("span_distance", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::DOUBLE, SpanFunctions::Distance_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpansetTypes::tstzspanset(), SpanFunctions::Minus_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_distance", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::DOUBLE, SpanFunctions::Distance_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Minus_value_span)    
     );
-    loader.RegisterFunction( ScalarFunction("span_distance", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::DOUBLE, SpanFunctions::Distance_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_minus", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Minus_span_span) 
     );
-    loader.RegisterFunction( ScalarFunction("<->", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::DOUBLE, SpanFunctions::Distance_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, SpansetTypes::tstzspanset(), SpanFunctions::Minus_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::DOUBLE, SpanFunctions::Distance_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Minus_value_span)    
     );
-    loader.RegisterFunction( ScalarFunction("<->", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::DOUBLE, SpanFunctions::Distance_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("-", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, SpansetTypes::tstzspanset(), SpanFunctions::Minus_span_span) 
+    );
+
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::INTEGER, SpanFunctions::Distance_span_value)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_value_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_span_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SpanTypes::INTSPAN(), LogicalType::INTEGER}, LogicalType::INTEGER, SpanFunctions::Distance_span_value)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::INTEGER, SpanTypes::INTSPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_value_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SpanTypes::INTSPAN(), SpanTypes::INTSPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_span_span)
+    );
+
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BIGINT, SpanFunctions::Distance_span_value)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BIGINT, SpanFunctions::Distance_value_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BIGINT, SpanFunctions::Distance_span_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SpanTypes::BIGINTSPAN(), LogicalType::BIGINT}, LogicalType::BIGINT, SpanFunctions::Distance_span_value)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::BIGINT, SpanTypes::BIGINTSPAN()}, LogicalType::BIGINT, SpanFunctions::Distance_value_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()}, LogicalType::BIGINT, SpanFunctions::Distance_span_span)
+    );
+
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::DOUBLE, SpanFunctions::Distance_span_value)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::DOUBLE, SpanFunctions::Distance_value_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::DOUBLE, SpanFunctions::Distance_span_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SpanTypes::FLOATSPAN(), LogicalType::DOUBLE}, LogicalType::DOUBLE, SpanFunctions::Distance_span_value)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::DOUBLE, SpanTypes::FLOATSPAN()}, LogicalType::DOUBLE, SpanFunctions::Distance_value_span)
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()}, LogicalType::DOUBLE, SpanFunctions::Distance_span_span)
     );  
 
-    loader.RegisterFunction( ScalarFunction("span_distance", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::INTEGER, SpanFunctions::Distance_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::INTEGER, SpanFunctions::Distance_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_distance", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_distance", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("<->", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::INTEGER, SpanFunctions::Distance_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SpanTypes::DATESPAN(), LogicalType::DATE}, LogicalType::INTEGER, SpanFunctions::Distance_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::DATE, SpanTypes::DATESPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("<->", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SpanTypes::DATESPAN(), SpanTypes::DATESPAN()}, LogicalType::INTEGER, SpanFunctions::Distance_span_span)
     );
 
-    loader.RegisterFunction( ScalarFunction("span_distance", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::INTERVAL, SpanFunctions::Distance_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::INTERVAL, SpanFunctions::Distance_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("span_distance", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::INTERVAL, SpanFunctions::Distance_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::INTERVAL, SpanFunctions::Distance_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("span_distance", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::INTERVAL, SpanFunctions::Distance_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("span_distance", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::INTERVAL, SpanFunctions::Distance_span_span)
     );
-    loader.RegisterFunction( ScalarFunction("<->", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::INTERVAL, SpanFunctions::Distance_span_value)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SpanTypes::TSTZSPAN(), LogicalType::TIMESTAMP_TZ}, LogicalType::INTERVAL, SpanFunctions::Distance_span_value)
     );
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::INTERVAL, SpanFunctions::Distance_value_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()}, LogicalType::INTERVAL, SpanFunctions::Distance_value_span)
     );
-    loader.RegisterFunction( ScalarFunction("<->", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::INTERVAL, SpanFunctions::Distance_span_span)
+    duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("<->", {SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()}, LogicalType::INTERVAL, SpanFunctions::Distance_span_span)
     );
 }
 

--- a/src/temporal/spanset.cpp
+++ b/src/temporal/spanset.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 
 #include "time_util.hpp"
+#include "mobilityduck/meos_exec_serial.hpp"
 
 
 extern "C" {     
@@ -173,281 +174,281 @@ void SpansetTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         auto set_type = SpansetTypeMapping::GetSetType(spanset_type);       // set
         // Register: asText
         if (spanset_type == SpansetTypes::floatspanset()) {            
-            loader.RegisterFunction( // asText(floatset)
+            duckdb::RegisterSerializedScalarFunction(loader,  // asText(floatset)
                 ScalarFunction("asText", {spanset_type}, LogicalType::VARCHAR, SpansetFunctions::Spanset_as_text)
             );
             
-            loader.RegisterFunction( // asText(floatset, int)
+            duckdb::RegisterSerializedScalarFunction(loader,  // asText(floatset, int)
                 ScalarFunction("asText", {spanset_type, LogicalType::INTEGER}, LogicalType::VARCHAR, SpansetFunctions::Spanset_as_text)
             );
         } else {            
-            loader.RegisterFunction( // All other set types
+            duckdb::RegisterSerializedScalarFunction(loader,  // All other set types
                 ScalarFunction("asText", {spanset_type}, LogicalType::VARCHAR, SpansetFunctions::Spanset_as_text)
             );
         }
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset", {LogicalType::LIST(child_type)}, spanset_type, SpansetFunctions::Spanset_constructor)                 
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset", {base_type}, spanset_type, SpansetFunctions::Value_to_spanset)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset", {SpansetTypeMapping::GetSetType(spanset_type)}, spanset_type, SpansetFunctions::Set_to_spanset)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset", {child_type}, spanset_type, SpansetFunctions::Span_to_spanset)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("span", {spanset_type}, child_type, SpansetFunctions::Spanset_to_span)
         );
         
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("intspanset", {SpansetTypes::floatspanset()}, SpansetTypes::intspanset(), SpansetFunctions::Floatspanset_to_intspanset)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("floatspanset", {SpansetTypes::intspanset()}, SpansetTypes::floatspanset(), SpansetFunctions::Intspanset_to_floatspanset)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("datespanset", {SpansetTypes::tstzspanset()}, SpansetTypes::datespanset(), SpansetFunctions::Tstzspanset_to_datespanset)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("tstzspanset", {SpansetTypes::datespanset()}, SpansetTypes::tstzspanset(), SpansetFunctions::Datespanset_to_tstzspanset)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("memSize", {spanset_type}, LogicalType::INTEGER, SpansetFunctions::Spanset_mem_size)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("lower", {spanset_type}, base_type, SpansetFunctions::Spanset_lower)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("upper", {spanset_type}, base_type, SpansetFunctions::Spanset_upper)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("lowerInc", {spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_lower_inc)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("upperInc", {spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_upper_inc)
         );
 
         if (spanset_type == SpansetTypes::intspanset() || spanset_type == SpansetTypes::floatspanset() || spanset_type == SpansetTypes::bigintspanset()) {
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction("width", {spanset_type}, base_type, SpansetFunctions::Numspanset_width)
             );
 
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction("width", {spanset_type, LogicalType::BOOLEAN}, base_type, SpansetFunctions::Numspanset_width)
             );
         }
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("numSpans", {spanset_type}, LogicalType::INTEGER, SpansetFunctions::Spanset_num_spans)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("startSpan", {spanset_type}, child_type, SpansetFunctions::Spanset_start_span)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("endSpan", {spanset_type}, child_type, SpansetFunctions::Spanset_end_span)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanN", {spanset_type, LogicalType::INTEGER}, child_type, SpansetFunctions::Spanset_span_n)
         );
 
         if (spanset_type == SpansetTypes::intspanset() ||spanset_type == SpansetTypes::datespanset()){
 
-            loader.RegisterFunction( ScalarFunction("shift", {spanset_type, LogicalType::INTEGER}, spanset_type, SpansetFunctions::Numspanset_shift)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("shift", {spanset_type, LogicalType::INTEGER}, spanset_type, SpansetFunctions::Numspanset_shift)
             ); 
             
-            loader.RegisterFunction( ScalarFunction("scale", {spanset_type, LogicalType::INTERVAL}, spanset_type, SpansetFunctions::Numspanset_scale)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("scale", {spanset_type, LogicalType::INTERVAL}, spanset_type, SpansetFunctions::Numspanset_scale)
             );
 
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction("shiftScale", {spanset_type, LogicalType::INTEGER, LogicalType::INTEGER}, spanset_type,
                                SpansetFunctions::Numspanset_shift_scale));
 
         }
         else if( spanset_type == SpansetTypes::bigintspanset() ){
-            loader.RegisterFunction( ScalarFunction("shift", {spanset_type, LogicalType::BIGINT}, spanset_type, SpansetFunctions::Numspanset_shift)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("shift", {spanset_type, LogicalType::BIGINT}, spanset_type, SpansetFunctions::Numspanset_shift)
             ); 
 
-            loader.RegisterFunction( ScalarFunction("scale", {spanset_type, LogicalType::INTERVAL}, spanset_type, SpansetFunctions::Numspanset_scale)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("scale", {spanset_type, LogicalType::INTERVAL}, spanset_type, SpansetFunctions::Numspanset_scale)
             );
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction("shiftScale", {spanset_type, LogicalType::BIGINT, LogicalType::BIGINT}, spanset_type, SpansetFunctions::Numspanset_shift_scale)
             );    
         }
         else if( spanset_type == SpansetTypes::floatspanset() ){
-            loader.RegisterFunction( ScalarFunction("shift", {spanset_type, LogicalType::DOUBLE}, spanset_type, SpansetFunctions::Numspanset_shift)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("shift", {spanset_type, LogicalType::DOUBLE}, spanset_type, SpansetFunctions::Numspanset_shift)
             ); 
-            loader.RegisterFunction( ScalarFunction("scale", {spanset_type, LogicalType::INTERVAL}, spanset_type, SpansetFunctions::Numspanset_scale)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("scale", {spanset_type, LogicalType::INTERVAL}, spanset_type, SpansetFunctions::Numspanset_scale)
             );
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction("shiftScale", {spanset_type, LogicalType::DOUBLE, LogicalType::DOUBLE}, spanset_type, SpansetFunctions::Numspanset_shift_scale)
             );
 
-            loader.RegisterFunction( ScalarFunction("floor", {spanset_type}, spanset_type, SpansetFunctions::Floatspanset_floor)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("floor", {spanset_type}, spanset_type, SpansetFunctions::Floatspanset_floor)
             );
-            loader.RegisterFunction( ScalarFunction("ceil", {spanset_type}, spanset_type, SpansetFunctions::Floatspanset_ceil)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("ceil", {spanset_type}, spanset_type, SpansetFunctions::Floatspanset_ceil)
             );
-            loader.RegisterFunction( ScalarFunction("round", {spanset_type}, spanset_type, SpansetFunctions::Floatspanset_round)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("round", {spanset_type}, spanset_type, SpansetFunctions::Floatspanset_round)
             );
 
-            loader.RegisterFunction( ScalarFunction("round", {spanset_type, LogicalType::INTEGER}, spanset_type, SpansetFunctions::Floatspanset_round)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("round", {spanset_type, LogicalType::INTEGER}, spanset_type, SpansetFunctions::Floatspanset_round)
             );
-            loader.RegisterFunction( ScalarFunction("degrees", {spanset_type}, spanset_type, SpansetFunctions::Floatspanset_degrees)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("degrees", {spanset_type}, spanset_type, SpansetFunctions::Floatspanset_degrees)
             );
-            loader.RegisterFunction( ScalarFunction("radians", {spanset_type}, spanset_type, SpansetFunctions::Floatspanset_radians)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("radians", {spanset_type}, spanset_type, SpansetFunctions::Floatspanset_radians)
             );
 
         }
         else if( spanset_type == SpansetTypes::tstzspanset() ){
-            loader.RegisterFunction( ScalarFunction("shift", {spanset_type, LogicalType::INTERVAL}, spanset_type, SpansetFunctions::Tstzspanset_shift)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("shift", {spanset_type, LogicalType::INTERVAL}, spanset_type, SpansetFunctions::Tstzspanset_shift)
             ); 
 
-            loader.RegisterFunction( ScalarFunction("scale", {spanset_type, LogicalType::INTERVAL}, spanset_type, SpansetFunctions::Tstzspanset_scale)
+            duckdb::RegisterSerializedScalarFunction(loader,  ScalarFunction("scale", {spanset_type, LogicalType::INTERVAL}, spanset_type, SpansetFunctions::Tstzspanset_scale)
             );
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction("shiftScale", {spanset_type, LogicalType::INTERVAL, LogicalType::INTERVAL}, spanset_type, SpansetFunctions::Tstzspanset_shift_scale)
             );
 
         } 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spans", {spanset_type}, LogicalType::LIST(child_type), SpansetFunctions::Spanset_spans)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("splitNSpans", {spanset_type, LogicalType::INTEGER}, LogicalType::LIST(child_type), SpansetFunctions::Spanset_split_n_spans)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("splitEachNSpans", {spanset_type, LogicalType::INTEGER}, LogicalType::LIST(child_type), SpansetFunctions::Spanset_split_each_n_spans)
         );
 
         // Lowercase aliases matching MobilityDB's SQL surface
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("splitNspans", {spanset_type, LogicalType::INTEGER}, LogicalType::LIST(child_type), SpansetFunctions::Spanset_split_n_spans)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("splitEachNspans", {spanset_type, LogicalType::INTEGER}, LogicalType::LIST(child_type), SpansetFunctions::Spanset_split_each_n_spans)
         );
 
         // Hash
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset_hash", {spanset_type}, LogicalType::UINTEGER, SpansetFunctions::Spanset_hash)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset_hash_extended", {spanset_type, LogicalType::BIGINT}, LogicalType::UBIGINT, SpansetFunctions::Spanset_hash_extended)
         );
 
         // comparison operators
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset_eq", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_eq)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("=", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_eq)
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset_ne", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_ne)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("<>", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_ne)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset_le", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_le)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("<=", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_le)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset_lt", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_lt)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("<", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_lt)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset_ge", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_ge)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(">=", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_ge)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset_gt", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_gt)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(">", {spanset_type, spanset_type}, LogicalType::BOOLEAN, SpansetFunctions::Spanset_gt)
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction("spanset_cmp", {spanset_type, spanset_type}, LogicalType::INTEGER, SpansetFunctions::Spanset_cmp)
         );
     }
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("duration", {SpansetTypes::datespanset()}, LogicalType::INTERVAL, SpansetFunctions::Datespanset_duration)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("duration", {SpansetTypes::tstzspanset()}, LogicalType::INTERVAL, SpansetFunctions::Tstzspanset_duration)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("duration", {SpansetTypes::datespanset(), LogicalType::BOOLEAN}, LogicalType::INTERVAL, SpansetFunctions::Datespanset_duration)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("duration", {SpansetTypes::tstzspanset(), LogicalType::BOOLEAN}, LogicalType::INTERVAL, SpansetFunctions::Tstzspanset_duration)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("numDates", {SpansetTypes::datespanset()}, LogicalType::INTEGER, SpansetFunctions::Datespanset_num_dates)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("startDate", {SpansetTypes::datespanset()}, LogicalType::DATE, SpansetFunctions::Datespanset_start_date)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("endDate", {SpansetTypes::datespanset()}, LogicalType::DATE, SpansetFunctions::Datespanset_end_date)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("dateN", {SpansetTypes::datespanset(), LogicalType::INTEGER}, LogicalType::DATE, SpansetFunctions::Datespanset_date_n)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("dates", {SpansetTypes::datespanset()}, SetTypes::dateset(), SpansetFunctions::Datespanset_dates)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("numTimestamps", {SpansetTypes::tstzspanset()}, LogicalType::INTEGER, SpansetFunctions::Tstzspanset_num_timestamps)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("startTimestamp", {SpansetTypes::tstzspanset()}, LogicalType::TIMESTAMP_TZ, SpansetFunctions::Tstzspanset_start_timestamptz)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("endTimestamp", {SpansetTypes::tstzspanset()}, LogicalType::TIMESTAMP_TZ, SpansetFunctions::Tstzspanset_end_timestamptz)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("timestampN", {SpansetTypes::tstzspanset(), LogicalType::INTEGER}, LogicalType::TIMESTAMP_TZ, SpansetFunctions::Tstzspanset_timestamptz_n)
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction("timestamps", {SpansetTypes::tstzspanset()}, SetTypes::tstzset(), SpansetFunctions::Tstzspanset_timestamps)
     );
 

--- a/src/temporal/tbox.cpp
+++ b/src/temporal/tbox.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
+#include "mobilityduck/meos_exec_serial.hpp"
 // #include "duckdb/common/extension_type_info.hpp"
 
 namespace duckdb {
@@ -130,7 +131,7 @@ void TboxType::RegisterCastFunctions(ExtensionLoader &loader) {
 }
 
 void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {LogicalType::INTEGER, LogicalType::TIMESTAMP_TZ},
@@ -139,7 +140,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {LogicalType::DOUBLE, LogicalType::TIMESTAMP_TZ},
@@ -148,7 +149,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SpanTypes::INTSPAN(), LogicalType::TIMESTAMP_TZ},
@@ -157,7 +158,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SpanTypes::FLOATSPAN(), LogicalType::TIMESTAMP_TZ},
@@ -166,7 +167,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {LogicalType::INTEGER, SpanTypes::TSTZSPAN()},
@@ -175,7 +176,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {LogicalType::DOUBLE, SpanTypes::TSTZSPAN()},
@@ -184,7 +185,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SpanTypes::INTSPAN(), SpanTypes::TSTZSPAN()},
@@ -193,7 +194,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SpanTypes::FLOATSPAN(), SpanTypes::TSTZSPAN()},
@@ -202,7 +203,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {LogicalType::INTEGER},
@@ -211,7 +212,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {LogicalType::DOUBLE},
@@ -220,7 +221,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {LogicalType::TIMESTAMP_TZ},
@@ -229,7 +230,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SetTypes::intset()},
@@ -238,7 +239,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SetTypes::floatset()},
@@ -247,7 +248,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SetTypes::tstzset()},
@@ -256,7 +257,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SpanTypes::INTSPAN()},
@@ -265,7 +266,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SpanTypes::FLOATSPAN()},
@@ -274,7 +275,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SpanTypes::TSTZSPAN()},
@@ -283,7 +284,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "intspan",
             {TBOX()},
@@ -292,7 +293,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "floatspan",
             {TBOX()},
@@ -301,7 +302,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "timeSpan",
             {TBOX()},
@@ -310,7 +311,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SpansetTypes::intspanset()},
@@ -319,7 +320,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SpansetTypes::floatspanset()},
@@ -328,7 +329,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {SpansetTypes::tstzspanset()},
@@ -337,7 +338,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "hasX",
             {TBOX()},
@@ -346,7 +347,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "hasT",
             {TBOX()},
@@ -355,7 +356,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "Xmin",
             {TBOX()},
@@ -364,7 +365,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "XminInc",
             {TBOX()},
@@ -373,7 +374,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "Xmax",
             {TBOX()},
@@ -382,7 +383,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "XmaxInc",
             {TBOX()},
@@ -391,7 +392,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "Tmin",
             {TBOX()},
@@ -400,7 +401,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "TminInc",
             {TBOX()},
@@ -409,7 +410,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "Tmax",
             {TBOX()},
@@ -418,7 +419,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "TmaxInc",
             {TBOX()},
@@ -427,7 +428,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "shiftValue",
             {TBOX(), LogicalType::INTEGER},
@@ -436,7 +437,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "shiftValue",
             {TBOX(), LogicalType::DOUBLE},
@@ -445,7 +446,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "shiftTime",
             {TBOX(), LogicalType::INTERVAL},
@@ -454,7 +455,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "scaleValue",
             {TBOX(), LogicalType::INTEGER},
@@ -463,7 +464,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "scaleValue",
             {TBOX(), LogicalType::DOUBLE},
@@ -472,7 +473,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "scaleTime",
             {TBOX(), LogicalType::INTERVAL},
@@ -481,7 +482,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "shiftScaleValue",
             {TBOX(), LogicalType::INTEGER, LogicalType::INTEGER},
@@ -490,7 +491,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "shiftScaleValue",
             {TBOX(), LogicalType::DOUBLE, LogicalType::DOUBLE},
@@ -499,7 +500,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "shiftScaleTime",
             {TBOX(), LogicalType::INTERVAL, LogicalType::INTERVAL},
@@ -508,7 +509,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "expandValue",
             {TBOX(), LogicalType::INTEGER},
@@ -517,7 +518,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "expandValue",
             {TBOX(), LogicalType::DOUBLE},
@@ -526,7 +527,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "expandTime",
             {TBOX(), LogicalType::INTERVAL},
@@ -535,7 +536,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "round",
             {TBOX()},
@@ -544,7 +545,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "round",
             {TBOX(), LogicalType::INTEGER},
@@ -553,7 +554,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_contains",
             {TBOX(), TBOX()},
@@ -562,7 +563,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "@>",
             {TBOX(), TBOX()},
@@ -571,7 +572,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_contained",
             {TBOX(), TBOX()},
@@ -580,7 +581,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<@",
             {TBOX(), TBOX()},
@@ -589,7 +590,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_overlaps",
             {TBOX(), TBOX()},
@@ -598,7 +599,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "&&",
             {TBOX(), TBOX()},
@@ -607,7 +608,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_same",
             {TBOX(), TBOX()},
@@ -616,7 +617,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "~=",
             {TBOX(), TBOX()},
@@ -625,7 +626,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_adjacent",
             {TBOX(), TBOX()},
@@ -634,7 +635,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "-|-",
             {TBOX(), TBOX()},
@@ -643,7 +644,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_left",
             {TBOX(), TBOX()},
@@ -652,7 +653,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<<",
             {TBOX(), TBOX()},
@@ -661,7 +662,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_overleft",
             {TBOX(), TBOX()},
@@ -670,7 +671,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "&<",
             {TBOX(), TBOX()},
@@ -679,7 +680,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_right",
             {TBOX(), TBOX()},
@@ -688,7 +689,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             ">>",
             {TBOX(), TBOX()},
@@ -697,7 +698,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_overright",
             {TBOX(), TBOX()},
@@ -706,7 +707,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "&>",
             {TBOX(), TBOX()},
@@ -715,7 +716,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_before",
             {TBOX(), TBOX()},
@@ -724,7 +725,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<<#",
             {TBOX(), TBOX()},
@@ -733,7 +734,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_overbefore",
             {TBOX(), TBOX()},
@@ -744,7 +745,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
 
     // Error with #, DuckDB's lexer defines op_chars without #
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "&<#",
             {TBOX(), TBOX()},
@@ -753,7 +754,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_after",
             {TBOX(), TBOX()},
@@ -762,7 +763,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "#>>",
             {TBOX(), TBOX()},
@@ -771,7 +772,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_overafter",
             {TBOX(), TBOX()},
@@ -780,7 +781,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "#&>",
             {TBOX(), TBOX()},
@@ -789,7 +790,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_union",
             {TBOX(), TBOX()},
@@ -798,7 +799,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_intersection",
             {TBOX(), TBOX()},
@@ -807,7 +808,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "+",
             {TBOX(), TBOX()},
@@ -816,7 +817,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "*",
             {TBOX(), TBOX()},
@@ -825,7 +826,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_eq",
             {TBOX(), TBOX()},
@@ -834,7 +835,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_ne",
             {TBOX(), TBOX()},
@@ -843,7 +844,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_lt",
             {TBOX(), TBOX()},
@@ -852,7 +853,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_le",
             {TBOX(), TBOX()},
@@ -861,7 +862,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_ge",
             {TBOX(), TBOX()},
@@ -869,7 +870,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TboxFunctions::Tbox_ge
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_gt",
             {TBOX(), TBOX()},
@@ -878,7 +879,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox_cmp",
             {TBOX(), TBOX()},
@@ -887,7 +888,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "=",
             {TBOX(), TBOX()},
@@ -896,7 +897,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<>",
             {TBOX(), TBOX()},
@@ -905,7 +906,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<",
             {TBOX(), TBOX()},
@@ -914,7 +915,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "<=",
             {TBOX(), TBOX()},
@@ -923,7 +924,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             ">=",
             {TBOX(), TBOX()},
@@ -931,7 +932,7 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TboxFunctions::Tbox_ge
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             ">",
             {TBOX(), TBOX()},

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 
 #include "mobilityduck/bindings.hpp"
+#include "mobilityduck/meos_exec_serial.hpp"
 
 namespace duckdb {
 
@@ -128,7 +129,7 @@ void TemporalTypes::RegisterCastFunctions(ExtensionLoader &loader) {
 
 void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     for (auto &type : TemporalTypes::AllTypes()) {
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()),
                 {TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str()), LogicalType::TIMESTAMP_TZ},
@@ -136,7 +137,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Tinstant_constructor
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()),
                 {type, LogicalType::INTEGER},
@@ -145,7 +146,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()),
                 {TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str()), SetTypes::tstzset()},
@@ -154,7 +155,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()),
                 {TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str()), SpanTypes::TSTZSPAN()},
@@ -162,7 +163,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Tsequence_from_base_tstzspan
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()),
                 {TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str()), SpanTypes::TSTZSPAN(), LogicalType::VARCHAR},
@@ -170,7 +171,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Tsequence_from_base_tstzspan
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()),
                 {TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str()), SpansetTypes::tstzspanset()},
@@ -178,7 +179,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Tsequenceset_from_base_tstzspanset
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()),
                 {TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str()), SpansetTypes::tstzspanset(), LogicalType::VARCHAR},
@@ -187,7 +188,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "tempSubtype",
                 {type},
@@ -196,7 +197,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "interp",
                 {type},
@@ -214,7 +215,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         // fixes.
 
         if (type.GetAlias() != "TBOOL") {
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "minInstant",
                     {type},
@@ -223,7 +224,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 )
             );
     
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "maxInstant",
                     {type},
@@ -232,7 +233,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 )
             );
 
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "atMin",
                     {type},
@@ -241,7 +242,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 )
             );
 
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "minusMin",
                     {type},
@@ -250,7 +251,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 )
             );
 
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "atMax",
                     {type},
@@ -259,7 +260,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 )
             );
 
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "minusMax",
                     {type},
@@ -269,7 +270,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             );
         }
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "valueN",
                 {type, LogicalType::BIGINT},
@@ -278,7 +279,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "getTimestamp",
                 {type},
@@ -287,7 +288,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "getTime",
                 {type},
@@ -295,7 +296,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_time
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "duration",
                 {type},
@@ -304,7 +305,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "duration",
                 {type, LogicalType::BOOLEAN},
@@ -313,7 +314,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()) + "Seq",
                 {LogicalType::LIST(type)},
@@ -322,7 +323,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()) + "Seq",
                 {LogicalType::LIST(type), LogicalType::VARCHAR},
@@ -331,7 +332,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()) + "Seq",
                 {LogicalType::LIST(type), LogicalType::VARCHAR, LogicalType::BOOLEAN},
@@ -340,7 +341,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()) + "Inst",
                 {type},
@@ -349,7 +350,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()) + "Seq",
                 {LogicalType::LIST(type), LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN},
@@ -358,7 +359,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
         
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()) + "Seq",
                 {type, LogicalType::VARCHAR},
@@ -367,7 +368,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()) + "Seq",
                 {type},
@@ -376,7 +377,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()) + "SeqSet",
                 {LogicalType::LIST(type)},
@@ -385,7 +386,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 StringUtil::Lower(type.GetAlias()) + "SeqSet",
                 {type},
@@ -395,7 +396,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         );
 
         if (type.GetAlias() == "TFLOAT") {
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     StringUtil::Lower(type.GetAlias()) + "SeqSet",
                     {type, LogicalType::VARCHAR},
@@ -405,7 +406,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             );
         }
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "setInterp",
                 {type, LogicalType::VARCHAR},
@@ -414,7 +415,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "appendInstant",
                 {type, type},
@@ -423,7 +424,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "appendInstant",
                 {type, type, LogicalType::VARCHAR},
@@ -432,7 +433,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "appendSequence",
                 {type, type},
@@ -441,7 +442,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "merge",
                 {type, type},
@@ -450,7 +451,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "merge",
                 {LogicalType::LIST(type)},
@@ -459,7 +460,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "timeSpan",
                 {type},
@@ -469,7 +470,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         );
 
         if (type.GetAlias() == "TINT") {
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "valueSpan",
                     {type},
@@ -478,7 +479,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 )
             );
 
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "valueSet",
                     {type},
@@ -487,7 +488,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 )
             );
         } else if (type.GetAlias() == "TFLOAT") {
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "valueSpan",
                     {type},
@@ -496,7 +497,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 )
             );
 
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "valueSet",
                     {type},
@@ -506,7 +507,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             );
         }
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "sequences",
                 {type},
@@ -515,7 +516,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "segments",
                 {type},
@@ -524,7 +525,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "startTimestamp",
                 {type},
@@ -533,7 +534,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "endTimestamp",
                 {type},
@@ -542,7 +543,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "timestamps",
                 {type},
@@ -551,7 +552,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "instants",
                 {type},
@@ -560,7 +561,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "atTime",
                 {type, LogicalType::TIMESTAMP_TZ},
@@ -569,7 +570,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "atTime",
                 {type, SpanTypes::TSTZSPAN()},
@@ -578,7 +579,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "atTime",
                 {type, SpansetTypes::tstzspanset()},
@@ -587,7 +588,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "minusTime",
                 {type, LogicalType::TIMESTAMP_TZ},
@@ -596,7 +597,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "atTime",
                 {type, SetTypes::tstzset()},
@@ -605,7 +606,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "minusTime",
                 {type, SetTypes::tstzset()},
@@ -614,7 +615,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "minusTime",
                 {type, SpanTypes::TSTZSPAN()},
@@ -623,7 +624,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "minusTime",
                 {type, SpansetTypes::tstzspanset()},
@@ -632,7 +633,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "valueAtTimestamp",
                 {type, LogicalType::TIMESTAMP_TZ},
@@ -642,7 +643,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         );
 
         if (type.GetAlias() == "TINT" || type.GetAlias() == "TFLOAT") {
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "shiftValue",
                     {type, LogicalType::BIGINT},
@@ -651,7 +652,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 )
             );
 
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "scaleValue",
                     {type, LogicalType::BIGINT},
@@ -660,7 +661,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 )
             );
 
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "shiftScaleValue",
                     {type, LogicalType::BIGINT, LogicalType::BIGINT},
@@ -669,7 +670,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 )
             );
 
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "integral",
                     {type},
@@ -678,7 +679,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 )
             );
 
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "twAvg",
                     {type},
@@ -688,7 +689,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             );
         }
         if (type.GetAlias() != "TBOOL") {
-            loader.RegisterFunction(
+            duckdb::RegisterSerializedScalarFunction(loader, 
                 ScalarFunction(
                     "tempDump",
                     {type},
@@ -703,7 +704,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             );
         }
         
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "atValues",
                 {type, TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str())},
@@ -711,7 +712,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_at_value
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "minusValues",
                 {type, TemporalTypes::GetBaseTypeFromAlias(type.GetAlias().c_str())},
@@ -720,7 +721,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "beforeTimestamp",
                 {type, LogicalType::TIMESTAMP_TZ},
@@ -728,7 +729,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_before_timestamptz
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "beforeTimestamp",
                 {type, LogicalType::TIMESTAMP_TZ, LogicalType::BOOLEAN},
@@ -737,7 +738,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "afterTimestamp",
                 {type, LogicalType::TIMESTAMP_TZ},
@@ -745,7 +746,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_after_timestamptz
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "afterTimestamp",
                 {type, LogicalType::TIMESTAMP_TZ, LogicalType::BOOLEAN},
@@ -754,7 +755,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "insert",
                 {type, type},
@@ -762,7 +763,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_insert
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "insert",
                 {type, type, LogicalType::BOOLEAN},
@@ -771,7 +772,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "update",
                 {type, type},
@@ -779,7 +780,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_update
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "update",
                 {type, type, LogicalType::BOOLEAN},
@@ -788,7 +789,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
         
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "deleteTime",
                 {type, LogicalType::TIMESTAMP_TZ},
@@ -796,7 +797,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_delete_timestamptz
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "deleteTime",
                 {type, LogicalType::TIMESTAMP_TZ, LogicalType::BOOLEAN},
@@ -805,7 +806,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "deleteTime",
                 {type, SetTypes::tstzset()},
@@ -813,7 +814,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_delete_tstzset
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "deleteTime",
                 {type, SetTypes::tstzset(), LogicalType::BOOLEAN},
@@ -822,7 +823,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "deleteTime",
                 {type, SpanTypes::TSTZSPAN()},
@@ -830,7 +831,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_delete_tstzspan
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "deleteTime",
                 {type, SpanTypes::TSTZSPAN(), LogicalType::BOOLEAN},
@@ -839,7 +840,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "deleteTime",
                 {type, SpansetTypes::tstzspanset()},
@@ -847,7 +848,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_delete_tstzspanset
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "deleteTime",
                 {type, SpansetTypes::tstzspanset(), LogicalType::BOOLEAN},
@@ -855,7 +856,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_delete_tstzspanset
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "segmentMinDuration",
                 {type, LogicalType::INTERVAL},
@@ -863,7 +864,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_segm_min_duration
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "segmentMinDuration",
                 {type, LogicalType::INTERVAL, LogicalType::BOOLEAN},
@@ -872,7 +873,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "segmentMaxDuration",
                 {type, LogicalType::INTERVAL},
@@ -880,7 +881,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_segm_max_duration
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "segmentMaxDuration",
                 {type, LogicalType::INTERVAL, LogicalType::BOOLEAN},
@@ -889,7 +890,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "temporal_eq",
                 {type, type},
@@ -897,7 +898,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_eq
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "=",
                 {type, type},
@@ -905,7 +906,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_eq
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "temporal_ne",
                 {type, type},
@@ -913,7 +914,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_ne
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "<>",
                 {type, type},
@@ -921,7 +922,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_ne
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "temporal_le",
                 {type, type},
@@ -929,7 +930,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_le
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "<=",
                 {type, type},
@@ -937,7 +938,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_le
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "temporal_lt",
                 {type, type},
@@ -945,7 +946,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_lt
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "<",
                 {type, type},
@@ -953,7 +954,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_lt
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "temporal_ge",
                 {type, type},
@@ -961,7 +962,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_ge
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 ">=",
                 {type, type},
@@ -969,7 +970,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_ge
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "temporal_gt",
                 {type, type},
@@ -977,7 +978,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
                 TemporalFunctions::Temporal_gt
             )
         );
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 ">",
                 {type, type},
@@ -986,7 +987,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             )
         );
 
-        loader.RegisterFunction(
+        duckdb::RegisterSerializedScalarFunction(loader, 
             ScalarFunction(
                 "temporal_cmp",
                 {type, type},
@@ -1041,7 +1042,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     mobilityduck::RegisterTemporalDatumAccessor<double>(
         loader, "maxValue", TemporalTypes::TFLOAT(), LogicalType::DOUBLE, temporal_max_value);
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atValues",
             {TemporalTypes::TINT(), SetTypes::intset()},
@@ -1049,7 +1050,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             TemporalFunctions::Temporal_at_values
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atValues",
             {TemporalTypes::TFLOAT(), SetTypes::floatset()},
@@ -1057,7 +1058,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             TemporalFunctions::Temporal_at_values
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atValues",
             {TemporalTypes::TTEXT(), SetTypes::textset()},
@@ -1066,7 +1067,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusValues",
             {TemporalTypes::TINT(), SetTypes::intset()},
@@ -1074,7 +1075,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             TemporalFunctions::Temporal_minus_value
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusValues",
             {TemporalTypes::TFLOAT(), SetTypes::floatset()},
@@ -1082,7 +1083,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             TemporalFunctions::Temporal_minus_value
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusValues",
             {TemporalTypes::TTEXT(), SetTypes::textset()},
@@ -1090,7 +1091,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             TemporalFunctions::Temporal_minus_value
         )
     );
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "whenTrue",
             {TemporalTypes::TBOOL()},
@@ -1099,7 +1100,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atValues",
             {TemporalTypes::TINT(), SpanTypes::INTSPAN()},
@@ -1108,7 +1109,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atValues",
             {TemporalTypes::TFLOAT(), SpanTypes::FLOATSPAN()},
@@ -1117,7 +1118,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusValues",
             {TemporalTypes::TINT(), SpanTypes::INTSPAN()},
@@ -1126,7 +1127,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusValues",
             {TemporalTypes::TFLOAT(), SpanTypes::FLOATSPAN()},
@@ -1135,7 +1136,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atValues",
             {TemporalTypes::TINT(), SpansetTypes::intspanset()},
@@ -1144,7 +1145,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atValues",
             {TemporalTypes::TFLOAT(), SpansetTypes::floatspanset()},
@@ -1153,7 +1154,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusValues",
             {TemporalTypes::TINT(), SpansetTypes::intspanset()},
@@ -1162,7 +1163,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusValues",
             {TemporalTypes::TFLOAT(), SpansetTypes::floatspanset()},
@@ -1171,7 +1172,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atTbox",
             {TemporalTypes::TINT(), TboxType::TBOX()},
@@ -1180,7 +1181,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "atTbox",
             {TemporalTypes::TFLOAT(), TboxType::TBOX()},
@@ -1189,7 +1190,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusTbox",
             {TemporalTypes::TINT(), TboxType::TBOX()},
@@ -1198,7 +1199,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "minusTbox",
             {TemporalTypes::TFLOAT(), TboxType::TBOX()},
@@ -1207,7 +1208,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "round",
             {TemporalTypes::TFLOAT()},
@@ -1216,7 +1217,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "round",
             {TemporalTypes::TFLOAT(), LogicalType::INTEGER},
@@ -1225,7 +1226,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tint",
             {TemporalTypes::TBOOL()},
@@ -1234,7 +1235,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tfloat",
             {TemporalTypes::TINT()},
@@ -1243,7 +1244,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tint",
             {TemporalTypes::TFLOAT()},
@@ -1252,7 +1253,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {TemporalTypes::TINT()},
@@ -1261,7 +1262,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "tbox",
             {TemporalTypes::TFLOAT()},
@@ -1270,7 +1271,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "getValues",
             {TemporalTypes::TINT()},
@@ -1279,7 +1280,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "getValues",
             {TemporalTypes::TFLOAT()},
@@ -1288,7 +1289,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "avgValue",
             {TemporalTypes::TINT()},
@@ -1297,7 +1298,7 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    loader.RegisterFunction(
+    duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
             "avgValue",
             {TemporalTypes::TFLOAT()},
@@ -1307,50 +1308,50 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     );
 
     // tbool boolean operators
-    loader.RegisterFunction(ScalarFunction("&", {TemporalTypes::TBOOL(), LogicalType::BOOLEAN}, TemporalTypes::TBOOL(), TemporalFunctions::Tand_tbool_bool));
-    loader.RegisterFunction(ScalarFunction("&", {LogicalType::BOOLEAN, TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tand_bool_tbool));
-    loader.RegisterFunction(ScalarFunction("&", {TemporalTypes::TBOOL(), TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tand_tbool_tbool));
-    loader.RegisterFunction(ScalarFunction("|", {TemporalTypes::TBOOL(), LogicalType::BOOLEAN}, TemporalTypes::TBOOL(), TemporalFunctions::Tor_tbool_bool));
-    loader.RegisterFunction(ScalarFunction("|", {LogicalType::BOOLEAN, TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tor_bool_tbool));
-    loader.RegisterFunction(ScalarFunction("|", {TemporalTypes::TBOOL(), TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tor_tbool_tbool));
-    loader.RegisterFunction(ScalarFunction("~", {TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tnot_tbool));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&", {TemporalTypes::TBOOL(), LogicalType::BOOLEAN}, TemporalTypes::TBOOL(), TemporalFunctions::Tand_tbool_bool));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&", {LogicalType::BOOLEAN, TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tand_bool_tbool));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&", {TemporalTypes::TBOOL(), TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tand_tbool_tbool));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("|", {TemporalTypes::TBOOL(), LogicalType::BOOLEAN}, TemporalTypes::TBOOL(), TemporalFunctions::Tor_tbool_bool));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("|", {LogicalType::BOOLEAN, TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tor_bool_tbool));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("|", {TemporalTypes::TBOOL(), TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tor_tbool_tbool));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("~", {TemporalTypes::TBOOL()}, TemporalTypes::TBOOL(), TemporalFunctions::Tnot_tbool));
 
     // tnumber arithmetic operators
-    loader.RegisterFunction(ScalarFunction("+", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Add_int_tint));
-    loader.RegisterFunction(ScalarFunction("+", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Add_tint_int));
-    loader.RegisterFunction(ScalarFunction("+", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_float_tfloat));
-    loader.RegisterFunction(ScalarFunction("+", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_tfloat_float));
-    loader.RegisterFunction(ScalarFunction("+", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Add_tnumber_tnumber));
-    loader.RegisterFunction(ScalarFunction("+", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_tnumber_tnumber));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("+", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Add_int_tint));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("+", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Add_tint_int));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("+", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_float_tfloat));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("+", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_tfloat_float));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("+", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Add_tnumber_tnumber));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("+", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_tnumber_tnumber));
 
-    loader.RegisterFunction(ScalarFunction("-", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Sub_int_tint));
-    loader.RegisterFunction(ScalarFunction("-", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Sub_tint_int));
-    loader.RegisterFunction(ScalarFunction("-", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_float_tfloat));
-    loader.RegisterFunction(ScalarFunction("-", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_tfloat_float));
-    loader.RegisterFunction(ScalarFunction("-", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Sub_tnumber_tnumber));
-    loader.RegisterFunction(ScalarFunction("-", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_tnumber_tnumber));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Sub_int_tint));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Sub_tint_int));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_float_tfloat));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_tfloat_float));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Sub_tnumber_tnumber));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_tnumber_tnumber));
 
-    loader.RegisterFunction(ScalarFunction("*", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Mult_int_tint));
-    loader.RegisterFunction(ScalarFunction("*", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Mult_tint_int));
-    loader.RegisterFunction(ScalarFunction("*", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_float_tfloat));
-    loader.RegisterFunction(ScalarFunction("*", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_tfloat_float));
-    loader.RegisterFunction(ScalarFunction("*", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Mult_tnumber_tnumber));
-    loader.RegisterFunction(ScalarFunction("*", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_tnumber_tnumber));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("*", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Mult_int_tint));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("*", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Mult_tint_int));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("*", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_float_tfloat));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("*", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_tfloat_float));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("*", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Mult_tnumber_tnumber));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("*", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_tnumber_tnumber));
 
-    loader.RegisterFunction(ScalarFunction("/", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Div_int_tint));
-    loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Div_tint_int));
-    loader.RegisterFunction(ScalarFunction("/", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_float_tfloat));
-    loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_tfloat_float));
-    loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Div_tnumber_tnumber));
-    loader.RegisterFunction(ScalarFunction("/", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_tnumber_tnumber));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("/", {LogicalType::INTEGER, TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Div_int_tint));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("/", {TemporalTypes::TINT(), LogicalType::INTEGER}, TemporalTypes::TINT(), TemporalFunctions::Div_tint_int));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("/", {LogicalType::DOUBLE, TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_float_tfloat));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("/", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_tfloat_float));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("/", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Div_tnumber_tnumber));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("/", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_tnumber_tnumber));
 
     // Unary tnumber functions
-    loader.RegisterFunction(ScalarFunction("abs", {TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Tnumber_abs));
-    loader.RegisterFunction(ScalarFunction("abs", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tnumber_abs));
-    loader.RegisterFunction(ScalarFunction("derivative", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Temporal_derivative));
-    loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
-    loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT(), LogicalType::BOOLEAN}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
-    loader.RegisterFunction(ScalarFunction("radians", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_radians));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("abs", {TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Tnumber_abs));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("abs", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tnumber_abs));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("derivative", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Temporal_derivative));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("degrees", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("degrees", {TemporalTypes::TFLOAT(), LogicalType::BOOLEAN}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("radians", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_radians));
 
     // tnumber distance and nearest-approach-distance.
     //
@@ -1363,38 +1364,38 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     //   SELECT 100.0::DOUBLE <-> tfloat '2.5@2000-01-01'; -- returns 2.5, expected 97.5
     // The temporal-temporal variant DOES work correctly, and so does nad_*.
     // Restore the value-distance registrations once the MEOS issue is resolved.
-    loader.RegisterFunction(ScalarFunction("<->", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Tdistance_tnumber_tnumber));
-    loader.RegisterFunction(ScalarFunction("<->", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tdistance_tnumber_tnumber));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<->", {TemporalTypes::TINT(), TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Tdistance_tnumber_tnumber));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<->", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tdistance_tnumber_tnumber));
 
     // nearestApproachDistance / nad — scalar return
-    loader.RegisterFunction(ScalarFunction("nad", {TemporalTypes::TINT(), LogicalType::INTEGER}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_int));
-    loader.RegisterFunction(ScalarFunction("nad", {TemporalTypes::TINT(), TemporalTypes::TINT()}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_tint));
-    loader.RegisterFunction(ScalarFunction("nad", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
-    loader.RegisterFunction(ScalarFunction("nad", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
-    loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TINT(), LogicalType::INTEGER}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_int));
-    loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TINT(), TemporalTypes::TINT()}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_tint));
-    loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
-    loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("nad", {TemporalTypes::TINT(), LogicalType::INTEGER}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_int));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("nad", {TemporalTypes::TINT(), TemporalTypes::TINT()}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_tint));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("nad", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("nad", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("nearestApproachDistance", {TemporalTypes::TINT(), LogicalType::INTEGER}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_int));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("nearestApproachDistance", {TemporalTypes::TINT(), TemporalTypes::TINT()}, LogicalType::INTEGER, TemporalFunctions::Nad_tint_tint));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
 
     // Temporal topological predicates: temporal × temporal (4 ops × 4 type pairs)
     for (auto &t1 : TemporalTypes::AllTypes()) {
         for (auto &t2 : TemporalTypes::AllTypes()) {
-            loader.RegisterFunction(ScalarFunction("@>", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_temporal));
-            loader.RegisterFunction(ScalarFunction("<@", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_temporal));
-            loader.RegisterFunction(ScalarFunction("&&", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_temporal));
-            loader.RegisterFunction(ScalarFunction("-|-", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_temporal));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("@>", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_temporal));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<@", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_temporal));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&&", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_temporal));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-|-", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_temporal));
         }
     }
     // Temporal × tstzspan (and the reverse direction)
     for (auto &t : TemporalTypes::AllTypes()) {
-        loader.RegisterFunction(ScalarFunction("@>", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("<@", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("&&", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("-|-", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("@>", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tstzspan_temporal));
-        loader.RegisterFunction(ScalarFunction("<@", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tstzspan_temporal));
-        loader.RegisterFunction(ScalarFunction("&&", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tstzspan_temporal));
-        loader.RegisterFunction(ScalarFunction("-|-", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tstzspan_temporal));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("@>", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_tstzspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<@", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_tstzspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&&", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_tstzspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-|-", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_tstzspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("@>", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tstzspan_temporal));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<@", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tstzspan_temporal));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&&", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tstzspan_temporal));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-|-", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tstzspan_temporal));
     }
 
     // Temporal time-position predicates registered as named functions:
@@ -1404,35 +1405,35 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     // `after`, `overbefore`, `overafter` provide equivalent behaviour.
     for (auto &t1 : TemporalTypes::AllTypes()) {
         for (auto &t2 : TemporalTypes::AllTypes()) {
-            loader.RegisterFunction(ScalarFunction("before",     {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_temporal));
-            loader.RegisterFunction(ScalarFunction("after",      {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_temporal));
-            loader.RegisterFunction(ScalarFunction("overbefore", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_temporal));
-            loader.RegisterFunction(ScalarFunction("overafter",  {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_temporal));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("before",     {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_temporal));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("after",      {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_temporal));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overbefore", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_temporal));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overafter",  {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_temporal));
         }
     }
     for (auto &t : TemporalTypes::AllTypes()) {
-        loader.RegisterFunction(ScalarFunction("before",     {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("after",      {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("overbefore", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("overafter",  {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("before",     {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Before_tstzspan_temporal));
-        loader.RegisterFunction(ScalarFunction("after",      {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::After_tstzspan_temporal));
-        loader.RegisterFunction(ScalarFunction("overbefore", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_tstzspan_temporal));
-        loader.RegisterFunction(ScalarFunction("overafter",  {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_tstzspan_temporal));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("before",     {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_tstzspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("after",      {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_tstzspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overbefore", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_tstzspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overafter",  {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_tstzspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("before",     {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Before_tstzspan_temporal));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("after",      {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::After_tstzspan_temporal));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overbefore", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_tstzspan_temporal));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overafter",  {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_tstzspan_temporal));
     }
 
     // Ever / always equality and inequality (named functions; DuckDB
     // parser does not accept ?= / #= operator names).
 #define REG_EA(NAME, FN)                                                                                                                                                          \
-    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::BOOLEAN,        TemporalTypes::TBOOL()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_bool_tbool));             \
-    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TBOOL(),      LogicalType::BOOLEAN},     LogicalType::BOOLEAN, TemporalFunctions::FN##_tbool_bool));             \
-    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::INTEGER,        TemporalTypes::TINT()},    LogicalType::BOOLEAN, TemporalFunctions::FN##_int_tint));               \
-    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),       LogicalType::INTEGER},     LogicalType::BOOLEAN, TemporalFunctions::FN##_tint_int));               \
-    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::DOUBLE,         TemporalTypes::TFLOAT()},  LogicalType::BOOLEAN, TemporalFunctions::FN##_float_tfloat));           \
-    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(),     LogicalType::DOUBLE},      LogicalType::BOOLEAN, TemporalFunctions::FN##_tfloat_float));           \
-    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),       TemporalTypes::TINT()},    LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));      \
-    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(),     TemporalTypes::TFLOAT()},  LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));      \
-    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TBOOL(),      TemporalTypes::TBOOL()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {LogicalType::BOOLEAN,        TemporalTypes::TBOOL()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_bool_tbool));             \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {TemporalTypes::TBOOL(),      LogicalType::BOOLEAN},     LogicalType::BOOLEAN, TemporalFunctions::FN##_tbool_bool));             \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {LogicalType::INTEGER,        TemporalTypes::TINT()},    LogicalType::BOOLEAN, TemporalFunctions::FN##_int_tint));               \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {TemporalTypes::TINT(),       LogicalType::INTEGER},     LogicalType::BOOLEAN, TemporalFunctions::FN##_tint_int));               \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {LogicalType::DOUBLE,         TemporalTypes::TFLOAT()},  LogicalType::BOOLEAN, TemporalFunctions::FN##_float_tfloat));           \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {TemporalTypes::TFLOAT(),     LogicalType::DOUBLE},      LogicalType::BOOLEAN, TemporalFunctions::FN##_tfloat_float));           \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {TemporalTypes::TINT(),       TemporalTypes::TINT()},    LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));      \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {TemporalTypes::TFLOAT(),     TemporalTypes::TFLOAT()},  LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));      \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {TemporalTypes::TBOOL(),      TemporalTypes::TBOOL()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));
 
     REG_EA("ever_eq",   Ever_eq)
     REG_EA("always_eq", Always_eq)
@@ -1442,12 +1443,12 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
 
     // Ordering ever/always — no tbool variant (booleans have no ordering)
 #define REG_EA_ORD(NAME, FN)                                                                                                                                          \
-    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::INTEGER,    TemporalTypes::TINT()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_int_tint));        \
-    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),   LogicalType::INTEGER},    LogicalType::BOOLEAN, TemporalFunctions::FN##_tint_int));        \
-    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, LogicalType::BOOLEAN, TemporalFunctions::FN##_float_tfloat));    \
-    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     LogicalType::BOOLEAN, TemporalFunctions::FN##_tfloat_float));    \
-    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),   TemporalTypes::TINT()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal)); \
-    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {LogicalType::INTEGER,    TemporalTypes::TINT()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_int_tint));        \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {TemporalTypes::TINT(),   LogicalType::INTEGER},    LogicalType::BOOLEAN, TemporalFunctions::FN##_tint_int));        \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, LogicalType::BOOLEAN, TemporalFunctions::FN##_float_tfloat));    \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     LogicalType::BOOLEAN, TemporalFunctions::FN##_tfloat_float));    \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {TemporalTypes::TINT(),   TemporalTypes::TINT()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal)); \
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(NAME, {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));
 
     REG_EA_ORD("ever_lt",   Ever_lt)
     REG_EA_ORD("always_lt", Always_lt)
@@ -1461,10 +1462,10 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
 
     // Similarity measures (tnumber × tnumber)
     for (auto &t : {TemporalTypes::TINT(), TemporalTypes::TFLOAT()}) {
-        loader.RegisterFunction(ScalarFunction("frechetDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_frechet_distance));
-        loader.RegisterFunction(ScalarFunction("discreteFrechet", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_frechet_distance));
-        loader.RegisterFunction(ScalarFunction("dynTimeWarp",     {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_dyntimewarp_distance));
-        loader.RegisterFunction(ScalarFunction("hausdorffDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_hausdorff_distance));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("frechetDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_frechet_distance));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("discreteFrechet", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_frechet_distance));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("dynTimeWarp",     {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_dyntimewarp_distance));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("hausdorffDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_hausdorff_distance));
     }
 
     // tnumber × {numspan, tbox} topological predicates (4 ops × 8 shape pairs)
@@ -1476,71 +1477,71 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         auto tbox  = TboxType::TBOX();
 
         // tnumber × numspan
-        loader.RegisterFunction(ScalarFunction("@>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("<@",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&&",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("-|-", {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("@>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("<@",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&&",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("-|-", {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("@>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<@",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&&",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-|-", {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("@>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<@",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&&",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-|-", {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
         // numspan × tnumber
-        loader.RegisterFunction(ScalarFunction("@>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("<@",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&&",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("-|-", {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("@>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("<@",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&&",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("-|-", {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("@>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<@",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&&",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-|-", {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("@>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<@",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&&",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-|-", {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
         // tnumber × tbox
         for (auto &t : {tint, tflt}) {
-            loader.RegisterFunction(ScalarFunction("@>",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("<@",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("&&",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("-|-", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("@>",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("<@",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("&&",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("-|-", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tbox_tnumber));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("@>",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_tbox));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<@",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_tbox));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&&",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_tbox));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-|-", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_tbox));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("@>",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tbox_tnumber));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<@",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tbox_tnumber));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&&",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tbox_tnumber));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("-|-", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tbox_tnumber));
         }
 
         // Position ops (<<, >>, &<, &>) — same surface
-        loader.RegisterFunction(ScalarFunction("<<",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction(">>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&<",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("<<",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction(">>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&<",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("<<",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Left_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction(">>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Right_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&<",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overright_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("<<",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Left_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction(">>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Right_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&<",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<<",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(">>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&<",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<<",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(">>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&<",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_numspan));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<<",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Left_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(">>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Right_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&<",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overright_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<<",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Left_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(">>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Right_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&<",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_numspan_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_numspan_tnumber));
         for (auto &t : {tint, tflt}) {
-            loader.RegisterFunction(ScalarFunction("<<", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction(">>", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("&<", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("&>", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("<<", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Left_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction(">>", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Right_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("&<", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("&>", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tbox_tnumber));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<<", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tbox));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(">>", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tbox));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&<", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tbox));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&>", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tbox));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<<", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Left_tbox_tnumber));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(">>", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Right_tbox_tnumber));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&<", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tbox_tnumber));
+            duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&>", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tbox_tnumber));
         }
         // tnumber × tnumber (same base type)
-        loader.RegisterFunction(ScalarFunction("<<", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction(">>", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction("&<", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction("&>", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction("<<", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction(">>", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction("&<", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction("&>", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<<", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(">>", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&<", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&>", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<<", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(">>", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&<", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tnumber));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&>", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
     }
 
     // tspatial × {stbox, tspatial} position predicates
@@ -1549,53 +1550,53 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         auto stbox = StboxType::STBOX();
 
         // L/R operators (DuckDB parser-friendly)
-        loader.RegisterFunction(ScalarFunction("<<", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Left_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction(">>", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Right_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("&<", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("&>", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("<<", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Left_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction(">>", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Right_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("&<", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("&>", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overright_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("<<", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Left_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction(">>", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Right_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("&<", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overleft_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("&>", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overright_tspatial_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<<", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Left_tspatial_stbox));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(">>", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Right_tspatial_stbox));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&<", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tspatial_stbox));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&>", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tspatial_stbox));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<<", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Left_stbox_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(">>", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Right_stbox_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&<", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_stbox_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&>", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overright_stbox_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("<<", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Left_tspatial_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(">>", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Right_tspatial_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&<", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overleft_tspatial_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("&>", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overright_tspatial_tspatial));
 
         // Above/below/front/back as named functions (DuckDB parser rejects |>>, <<|, etc.)
-        loader.RegisterFunction(ScalarFunction("below",     {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Below_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("above",     {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Above_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("front",     {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Front_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("back",      {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Back_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("overbelow", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overbelow_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("overabove", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overabove_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("overfront", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overfront_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("overback",  {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overback_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("below",     {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Below_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("above",     {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Above_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("front",     {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Front_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("back",      {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Back_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("overbelow", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overbelow_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("overabove", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overabove_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("overfront", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overfront_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("overback",  {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overback_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("below",     {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Below_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("above",     {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Above_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("front",     {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Front_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("back",      {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Back_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("overbelow", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overbelow_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("overabove", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overabove_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("overfront", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overfront_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("overback",  {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overback_tspatial_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("below",     {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Below_tspatial_stbox));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("above",     {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Above_tspatial_stbox));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("front",     {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Front_tspatial_stbox));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("back",      {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Back_tspatial_stbox));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overbelow", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overbelow_tspatial_stbox));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overabove", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overabove_tspatial_stbox));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overfront", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overfront_tspatial_stbox));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overback",  {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overback_tspatial_stbox));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("below",     {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Below_stbox_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("above",     {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Above_stbox_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("front",     {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Front_stbox_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("back",      {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Back_stbox_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overbelow", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overbelow_stbox_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overabove", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overabove_stbox_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overfront", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overfront_stbox_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overback",  {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overback_stbox_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("below",     {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Below_tspatial_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("above",     {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Above_tspatial_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("front",     {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Front_tspatial_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("back",      {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Back_tspatial_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overbelow", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overbelow_tspatial_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overabove", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overabove_tspatial_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overfront", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overfront_tspatial_tspatial));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("overback",  {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overback_tspatial_tspatial));
     }
 
     // ttext text functions
-    loader.RegisterFunction(ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
-    loader.RegisterFunction(ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));
-    loader.RegisterFunction(ScalarFunction("initcap", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_initcap));
-    loader.RegisterFunction(ScalarFunction("||", {LogicalType::VARCHAR, TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_text_ttext));
-    loader.RegisterFunction(ScalarFunction("||", {TemporalTypes::TTEXT(), LogicalType::VARCHAR}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_ttext_text));
-    loader.RegisterFunction(ScalarFunction("||", {TemporalTypes::TTEXT(), TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_ttext_ttext));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("lower", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_lower));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("upper", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_upper));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("initcap", {TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Ttext_initcap));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("||", {LogicalType::VARCHAR, TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_text_ttext));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("||", {TemporalTypes::TTEXT(), LogicalType::VARCHAR}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_ttext_text));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("||", {TemporalTypes::TTEXT(), TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_ttext_ttext));
 }
 
 struct TemporalUnnestBindData : public TableFunctionData {
@@ -1717,7 +1718,7 @@ void TemporalTypes::RegisterTemporalUnnestFunction(ExtensionLoader &loader) {
                             TemporalUnnestExec,
                             TemporalUnnestBind,
                             TemporalUnnestInit);
-            loader.RegisterFunction( fn);
+            loader.RegisterFunction(fn);
         }
     }
 }


### PR DESCRIPTION
Mutex serialization for MobilityDuck scalar function bodies that ultimately call MEOS / liblwgeom. MEOS uses GEOS's legacy global API (`initGEOS` / `finishGEOS`) internally from worker threads; concurrent legacy GEOS init/teardown from DuckDB's parallelism triggers intermittent GEOS errors and allocator corruption when spatial and MobilityDuck coexist.
Wrapping each MEOS-backed ScalarFunction execution prevents overlapping MEOS/GEOS legacy pairs across concurrent pipelines while preserving parallelism elsewhere.