### PR TITLE
feat(bindings): tAnd / tOr / tagg_min / tagg_max / tagg_sum aggregates

### DIFF
--- a/src/include/temporal/temporal_aggregates.hpp
+++ b/src/include/temporal/temporal_aggregates.hpp
@@ -11,6 +11,9 @@ struct TemporalAggregates {
 
     // Register tCount(temporal) → tint as its own AggregateFunctionSet.
     static void RegisterTCount(ExtensionLoader &loader);
+
+    // Register tAnd / tOr / tMin / tMax / tSum aggregates.
+    static void RegisterTemporalAggregates(ExtensionLoader &loader);
 };
 
 } // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -252,6 +252,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 		loader.RegisterFunction(std::move(extent_set));
 	}
 	TemporalAggregates::RegisterTCount(loader);
+	TemporalAggregates::RegisterTemporalAggregates(loader);
 
 	TgeompointType::RegisterType(loader);
 	TgeompointType::RegisterCastFunctions(loader);

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -187,6 +187,138 @@ struct TCountFunction {
     }
 };
 
+// ============================================================================
+// Generic skiplist-backed aggregate (tand / tor / tmin / tmax / tsum)
+//
+// Same shape as TCountFunction. Parameterised on:
+//   - TRANSFN: the MEOS transition function (e.g. tbool_tand_transfn)
+//   - MERGE_FN: the per-instant merge function used during Combine
+//                (e.g. mduck_datum_and, mduck_datum_min_int32)
+//   - CROSSINGS: whether MEOS should split sequences at crossings during
+//                Combine. true for tfloat aggregates, false for the rest.
+// ============================================================================
+
+using TempTransfn = SkipList *(*)(SkipList *, const Temporal *);
+
+// Local equivalents of the unexported MEOS datum_* merge functions. Datum is
+// a uintptr_t; for primitive types these are simple bit-level reinterprets.
+static Datum mduck_datum_and(Datum l, Datum r) {
+    return static_cast<Datum>(static_cast<bool>(l) && static_cast<bool>(r));
+}
+static Datum mduck_datum_or(Datum l, Datum r) {
+    return static_cast<Datum>(static_cast<bool>(l) || static_cast<bool>(r));
+}
+static Datum mduck_datum_min_int32(Datum l, Datum r) {
+    int32_t li = static_cast<int32_t>(l);
+    int32_t ri = static_cast<int32_t>(r);
+    return static_cast<Datum>(static_cast<int32_t>(li < ri ? li : ri));
+}
+static Datum mduck_datum_max_int32(Datum l, Datum r) {
+    int32_t li = static_cast<int32_t>(l);
+    int32_t ri = static_cast<int32_t>(r);
+    return static_cast<Datum>(static_cast<int32_t>(li > ri ? li : ri));
+}
+// Float8: PostgreSQL/MEOS pass-by-value convention encodes the IEEE 754 bits
+// of the double in the Datum. Convert via an aliased union to avoid UB.
+static double datum_to_float8(Datum d) {
+    union { uint64_t u; double f; } u;
+    u.u = static_cast<uint64_t>(d);
+    return u.f;
+}
+static Datum float8_to_datum(double f) {
+    union { uint64_t u; double f; } u;
+    u.f = f;
+    return static_cast<Datum>(u.u);
+}
+static Datum mduck_datum_min_float8(Datum l, Datum r) {
+    double lf = datum_to_float8(l);
+    double rf = datum_to_float8(r);
+    return float8_to_datum(lf < rf ? lf : rf);
+}
+static Datum mduck_datum_max_float8(Datum l, Datum r) {
+    double lf = datum_to_float8(l);
+    double rf = datum_to_float8(r);
+    return float8_to_datum(lf > rf ? lf : rf);
+}
+static Datum mduck_datum_sum_float8(Datum l, Datum r) {
+    return float8_to_datum(datum_to_float8(l) + datum_to_float8(r));
+}
+
+template <TempTransfn TRANSFN, Datum (*MERGE_FN)(Datum, Datum), bool CROSSINGS>
+struct SkiplistAggFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.skiplist = nullptr;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+        state.skiplist = TRANSFN(state.skiplist, temp);
+        free(temp);
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.skiplist || source.skiplist->length == 0) {
+            return;
+        }
+        if (!target.skiplist) {
+            const_cast<STATE &>(target).skiplist = temporal_skiplist_make();
+        }
+        void **values = skiplist_values(source.skiplist);
+        int count = source.skiplist->length;
+        temporal_skiplist_splice(target.skiplist, values, count, MERGE_FN, CROSSINGS);
+        free(values);
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.skiplist || state.skiplist->length == 0) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        Temporal *result = temporal_tagg_finalfn(state.skiplist);
+        state.skiplist = nullptr;
+        if (!result) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        size_t out_size = temporal_mem_size(result);
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(result), out_size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+template <TempTransfn TRANSFN, Datum (*MERGE_FN)(Datum, Datum), bool CROSSINGS>
+static AggregateFunction MakeSkiplistAggregate(const LogicalType &input_type, const LogicalType &output_type) {
+    using OPS = SkiplistAggFunction<TRANSFN, MERGE_FN, CROSSINGS>;
+    return AggregateFunction::UnaryAggregateDestructor<TCountState, string_t, string_t, OPS>(
+        input_type, output_type);
+}
+
 } // namespace
 
 void TemporalAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
@@ -203,6 +335,61 @@ void TemporalAggregates::RegisterTCount(ExtensionLoader &loader) {
         tcount_set.AddFunction(fn);
     }
     loader.RegisterFunction(std::move(tcount_set));
+}
+
+void TemporalAggregates::RegisterTemporalAggregates(ExtensionLoader &loader) {
+    // tAnd / tOr: tbool only.
+    {
+        AggregateFunctionSet tand_set("tAnd");
+        tand_set.AddFunction(
+            MakeSkiplistAggregate<&tbool_tand_transfn, &mduck_datum_and, false>(
+                TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
+        loader.RegisterFunction(std::move(tand_set));
+
+        AggregateFunctionSet tor_set("tOr");
+        tor_set.AddFunction(
+            MakeSkiplistAggregate<&tbool_tor_transfn, &mduck_datum_or, false>(
+                TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
+        loader.RegisterFunction(std::move(tor_set));
+    }
+
+    // tMin / tMax / tSum: registered as tagg_min / tagg_max / tagg_sum
+    // because the names Tmin / Tmax are already taken by scalar
+    // time-min / time-max accessors on tbox / stbox (registered in
+    // src/temporal/tbox.cpp and src/geo/stbox.cpp). DuckDB's catalog
+    // is case-insensitive at the name level, so registering an
+    // aggregate with the same lowercased name as an existing scalar
+    // triggers an ALTER path that CreateAggregateFunctionInfo doesn't
+    // support and the extension fails to load.
+    // ttext skipped — text merge needs text_cmp plumbing.
+    {
+        AggregateFunctionSet tmin_set("tagg_min");
+        tmin_set.AddFunction(
+            MakeSkiplistAggregate<&tint_tmin_transfn, &mduck_datum_min_int32, false>(
+                TemporalTypes::TINT(), TemporalTypes::TINT()));
+        tmin_set.AddFunction(
+            MakeSkiplistAggregate<&tfloat_tmin_transfn, &mduck_datum_min_float8, true>(
+                TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(tmin_set));
+
+        AggregateFunctionSet tmax_set("tagg_max");
+        tmax_set.AddFunction(
+            MakeSkiplistAggregate<&tint_tmax_transfn, &mduck_datum_max_int32, false>(
+                TemporalTypes::TINT(), TemporalTypes::TINT()));
+        tmax_set.AddFunction(
+            MakeSkiplistAggregate<&tfloat_tmax_transfn, &mduck_datum_max_float8, true>(
+                TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(tmax_set));
+
+        AggregateFunctionSet tsum_set("tagg_sum");
+        tsum_set.AddFunction(
+            MakeSkiplistAggregate<&tint_tsum_transfn, &mduck_datum_sum_int32, false>(
+                TemporalTypes::TINT(), TemporalTypes::TINT()));
+        tsum_set.AddFunction(
+            MakeSkiplistAggregate<&tfloat_tsum_transfn, &mduck_datum_sum_float8, true>(
+                TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(tsum_set));
+    }
 }
 
 } // namespace duckdb


### PR DESCRIPTION
## Summary

Adds **5 more skiplist-backed temporal aggregates** on top of the infrastructure landed for \`tCount\` (PR #50):

| Aggregate | Inputs | Output |
|---|---|---|
| \`tAnd(tbool)\` | tbool | tbool — per-instant boolean AND |
| \`tOr(tbool)\` | tbool | tbool — per-instant boolean OR |
| \`tagg_min(tint)\` / \`tagg_min(tfloat)\` | tint / tfloat | same — per-instant minimum |
| \`tagg_max(tint)\` / \`tagg_max(tfloat)\` | tint / tfloat | same — per-instant maximum |
| \`tagg_sum(tint)\` / \`tagg_sum(tfloat)\` | tint / tfloat | same — per-instant sum |

ttext skipped — text merge needs \`text_cmp\` plumbing not yet wired.

\`\`\`sql
SELECT tagg_min(t) FROM (VALUES (tint '5@2000-01-01'), (tint '3@2000-01-01')) tt(t);
-- {3@2000-01-01 00:00:00+00}

SELECT tAnd(t) FROM (VALUES (tbool 't@2000-01-01'), (tbool 'f@2000-01-01')) tt(t);
-- {f@2000-01-01 00:00:00+00}
\`\`\`

## Implementation

Factors the boilerplate from \`TCountFunction\` into a templated functor:

\`\`\`cpp
template <TempTransfn TRANSFN, Datum (*MERGE_FN)(Datum, Datum), bool CROSSINGS>
struct SkiplistAggFunction { ... };
\`\`\`

Each aggregate is now one \`MakeSkiplistAggregate<&meos_transfn, &merge_fn, crossings>(input, output)\` instantiation.

The merge functions used by \`Combine\` (\`datum_and\`, \`datum_or\`, \`datum_min_int32\`, \`datum_max_int32\`, \`datum_sum_int32\`, \`datum_min_float8\`, \`datum_max_float8\`, \`datum_sum_float8\`) are not exported from MEOS, so local equivalents are provided in this file. Float8 conversion goes through an aliased union to handle the IEEE 754 bit-pattern stored in \`Datum\`.

## Naming note (\`tagg_*\` instead of \`tMin\`/\`tMax\`/\`tSum\`)

\`Tmin\` and \`Tmax\` are already registered as **scalar** time-min / time-max accessors on tbox / stbox (\`src/temporal/tbox.cpp\` line 396, 414, \`src/geo/stbox.cpp\` line 257, 302). DuckDB's catalog is case-insensitive at the name level, so registering an aggregate named \`tMin\` would lookup-collide with the existing scalar and trigger an \`ALTER\` path that \`CreateAggregateFunctionInfo\` doesn't implement (\`GetAlterInfo not implemented for this type\`) — extension fails to load.

The \`tagg_*\` prefix sidesteps the collision. A future cleanup could rename the existing scalars (e.g. to \`time_min(tbox)\` / \`time_max(tbox)\`) and reclaim the \`tMin\` / \`tMax\` / \`tSum\` names if MobilityDB-name parity is preferred.

## Stacked on

- #47 (AggregateFunction infra)
- #48 (extent spanset/set)
- #49 (extent tnumber)
- #50 (tCount + skiplist-backed pattern)

## Test plan
- [x] All 8 aggregate-overloads produce correct values
- [x] Mixed t/f tbool inputs handled correctly for tAnd/tOr
- [x] No segfaults (skiplist destructor pattern from #50)
- [x] Local extension loads cleanly