### PR TITLE
feat(bindings): spanUnion(span | spanset) → spanset aggregate

### DIFF
--- a/src/include/temporal/span_aggregates.hpp
+++ b/src/include/temporal/span_aggregates.hpp
@@ -8,6 +8,9 @@ namespace duckdb {
 struct SpanAggregates {
     // Add span / spanset / set overloads of extent() to the given set.
     static void AddExtentOverloads(AggregateFunctionSet &extent_set);
+
+    // Register spanUnion(span | spanset) → spanset.
+    static void RegisterSpanUnion(ExtensionLoader &loader);
 };
 
 } // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -253,6 +253,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	}
 	TemporalAggregates::RegisterTCount(loader);
 	TemporalAggregates::RegisterTemporalAggregates(loader);
+	SpanAggregates::RegisterSpanUnion(loader);
 
 	TgeompointType::RegisterType(loader);
 	TgeompointType::RegisterCastFunctions(loader);

--- a/src/temporal/span_aggregates.cpp
+++ b/src/temporal/span_aggregates.cpp
@@ -129,6 +129,104 @@ static AggregateFunction MakeExtentAggregate(const LogicalType &input_type, cons
         input_type, output_span_type);
 }
 
+// ============================================================================
+// spanUnion(span | spanset) -> spanset
+//
+// State holds a heap-allocated SpanSet *. MEOS span_union_transfn allocates
+// a fresh spanset on first call and either appends in place or returns a
+// new (possibly larger) spanset on subsequent calls — we always reassign
+// state.spanset to whatever the transfn returns. spanset_union_finalfn
+// compacts the state and frees it; we null state.spanset after the call
+// to keep our destructor from double-freeing.
+// ============================================================================
+
+struct SpansetUnionState {
+    SpanSet *spanset;
+};
+
+template <bool INPUT_IS_SPANSET>
+struct SpanUnionFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.spanset = nullptr;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        if constexpr (INPUT_IS_SPANSET) {
+            SpanSet *ss = reinterpret_cast<SpanSet *>(malloc(size));
+            memcpy(ss, bytes, size);
+            state.spanset = spanset_union_transfn(state.spanset, ss);
+            free(ss);
+        } else {
+            Span *s = reinterpret_cast<Span *>(malloc(size));
+            memcpy(s, bytes, size);
+            state.spanset = span_union_transfn(state.spanset, s);
+            free(s);
+        }
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.spanset || source.spanset->count == 0) {
+            return;
+        }
+        // spanset_union_transfn(target, source) merges source into target.
+        // It may return target unchanged (if it had room) or a new larger
+        // spanset; in the latter case it frees the old target. Always
+        // reassign whatever is returned.
+        const_cast<STATE &>(target).spanset =
+            spanset_union_transfn(target.spanset, source.spanset);
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.spanset) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        SpanSet *result = spanset_union_finalfn(state.spanset);
+        // spanset_union_finalfn calls pfree(state) internally; null out
+        // the pointer so our destructor doesn't double-free.
+        state.spanset = nullptr;
+        if (!result) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        size_t out_size = spanset_mem_size(result);
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(result), out_size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.spanset) {
+            free(state.spanset);
+            state.spanset = nullptr;
+        }
+    }
+};
+
+template <bool INPUT_IS_SPANSET>
+static AggregateFunction MakeSpanUnionAggregate(const LogicalType &input_type, const LogicalType &output_spanset_type) {
+    using OPS = SpanUnionFunction<INPUT_IS_SPANSET>;
+    return AggregateFunction::UnaryAggregateDestructor<SpansetUnionState, string_t, string_t, OPS>(
+        input_type, output_spanset_type);
+}
+
 } // namespace
 
 void SpanAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
@@ -152,6 +250,26 @@ void SpanAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
     extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::floatset(), SpanTypes::FLOATSPAN()));
     extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::dateset(), SpanTypes::DATESPAN()));
     extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::tstzset(), SpanTypes::TSTZSPAN()));
+}
+
+void SpanAggregates::RegisterSpanUnion(ExtensionLoader &loader) {
+    AggregateFunctionSet spanunion_set("spanUnion");
+
+    // spanUnion(<span>) -> <spanset>
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<false>(SpanTypes::INTSPAN(),    SpansetTypes::intspanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<false>(SpanTypes::BIGINTSPAN(), SpansetTypes::bigintspanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<false>(SpanTypes::FLOATSPAN(),  SpansetTypes::floatspanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<false>(SpanTypes::DATESPAN(),   SpansetTypes::datespanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<false>(SpanTypes::TSTZSPAN(),   SpansetTypes::tstzspanset()));
+
+    // spanUnion(<spanset>) -> <spanset>
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<true>(SpansetTypes::intspanset(),    SpansetTypes::intspanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<true>(SpansetTypes::bigintspanset(), SpansetTypes::bigintspanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<true>(SpansetTypes::floatspanset(),  SpansetTypes::floatspanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<true>(SpansetTypes::datespanset(),   SpansetTypes::datespanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<true>(SpansetTypes::tstzspanset(),   SpansetTypes::tstzspanset()));
+
+    loader.RegisterFunction(std::move(spanunion_set));
 }
 
 } // namespace duckdb


### PR DESCRIPTION
## Summary

Adds \`spanUnion\` aggregate — merges a column of spans (or spansets) into a single canonical spanset. **10 overloads**:

| Input | Output |
|---|---|
| \`spanUnion(<span>)\` | \`<spanset>\` for \`{int, bigint, float, date, tstz}span\` (5) |
| \`spanUnion(<spanset>)\` | \`<spanset>\` same 5 types |

Closes the architectural gap documented in the parity manifest at \`test/sql/parity/015_span_aggfuncs.test\` (PR #21).

\`\`\`sql
SELECT spanUnion(s) FROM (VALUES (intspan '[1, 5)'), (intspan '[3, 8)')) tt(s);
-- {[1, 8)}    -- overlap merged

SELECT spanUnion(s) FROM (VALUES (intspan '[1, 3)'), (intspan '[3, 5)')) tt(s);
-- {[1, 5)}    -- adjacent merged

SELECT spanUnion(s) FROM (VALUES (intspan '[1, 5)'), (intspan '[10, 12)')) tt(s);
-- {[1, 5), [10, 12)}    -- disjoint preserved
\`\`\`

## Implementation

New \`SpansetUnionState\` holds a heap-allocated \`SpanSet *\`. Same destructor pattern as the skiplist-backed aggregates (PR #50, PR #52).

| Step | What it does |
|---|---|
| \`Operation\` | Copies input blob, calls MEOS \`span_union_transfn\` (or \`spanset_union_transfn\` when \`INPUT_IS_SPANSET=true\`), reassigns \`state.spanset\` to whatever the transfn returns — the transfn may return a new larger spanset and free the old state when it grows. |
| \`Combine\` | Calls \`spanset_union_transfn(target, source)\` to merge two states. |
| \`Finalize\` | Calls \`spanset_union_finalfn\` which compacts and frees the state. We null \`state.spanset\` after to keep the destructor from double-freeing. |

The transfn dispatch is templated on \`bool INPUT_IS_SPANSET\` so the same \`SpanUnionFunction\` handles both Span and SpanSet inputs.

## Stacked on
- #47 → #48 → #49 → #50 → #52 (aggregate stack)

## Test plan
- [x] Distinct spans → preserved as multiple elements
- [x] Overlapping spans → merged
- [x] Adjacent spans → merged
- [x] Spanset inputs (multiple element merges)
- [x] All 5 base types (int / bigint / float / date / tstz)
- [x] NULL handling: mixed NULL + value → returns the spanset; all-NULL → returns NULL
- [x] No segfaults (destructor + finalfn double-free guard)