### PR TITLE
feat(bindings): tagg_min(ttext) / tagg_max(ttext) overloads

### DIFF
--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -243,6 +243,15 @@ static Datum mduck_datum_max_float8(Datum l, Datum r) {
 static Datum mduck_datum_sum_float8(Datum l, Datum r) {
     return float8_to_datum(datum_to_float8(l) + datum_to_float8(r));
 }
+// Text comparison: Datum carries text* (PG varlena). text_cmp is exported
+// from MEOS so we just invoke it on the two pointers and pick whichever
+// Datum we want.
+static Datum mduck_datum_min_text(Datum l, Datum r) {
+    return text_cmp(reinterpret_cast<text *>(l), reinterpret_cast<text *>(r)) < 0 ? l : r;
+}
+static Datum mduck_datum_max_text(Datum l, Datum r) {
+    return text_cmp(reinterpret_cast<text *>(l), reinterpret_cast<text *>(r)) > 0 ? l : r;
+}
 
 template <TempTransfn TRANSFN, Datum (*MERGE_FN)(Datum, Datum), bool CROSSINGS>
 struct SkiplistAggFunction {
@@ -361,7 +370,6 @@ void TemporalAggregates::RegisterTemporalAggregates(ExtensionLoader &loader) {
     // aggregate with the same lowercased name as an existing scalar
     // triggers an ALTER path that CreateAggregateFunctionInfo doesn't
     // support and the extension fails to load.
-    // ttext skipped — text merge needs text_cmp plumbing.
     {
         AggregateFunctionSet tmin_set("tagg_min");
         tmin_set.AddFunction(
@@ -370,6 +378,9 @@ void TemporalAggregates::RegisterTemporalAggregates(ExtensionLoader &loader) {
         tmin_set.AddFunction(
             MakeSkiplistAggregate<&tfloat_tmin_transfn, &mduck_datum_min_float8, true>(
                 TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        tmin_set.AddFunction(
+            MakeSkiplistAggregate<&ttext_tmin_transfn, &mduck_datum_min_text, false>(
+                TemporalTypes::TTEXT(), TemporalTypes::TTEXT()));
         loader.RegisterFunction(std::move(tmin_set));
 
         AggregateFunctionSet tmax_set("tagg_max");
@@ -379,6 +390,9 @@ void TemporalAggregates::RegisterTemporalAggregates(ExtensionLoader &loader) {
         tmax_set.AddFunction(
             MakeSkiplistAggregate<&tfloat_tmax_transfn, &mduck_datum_max_float8, true>(
                 TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        tmax_set.AddFunction(
+            MakeSkiplistAggregate<&ttext_tmax_transfn, &mduck_datum_max_text, false>(
+                TemporalTypes::TTEXT(), TemporalTypes::TTEXT()));
         loader.RegisterFunction(std::move(tmax_set));
 
         AggregateFunctionSet tsum_set("tagg_sum");


### PR DESCRIPTION
## Summary

Adds the ttext branch of the temporal min/max aggregates that PR #52 explicitly skipped (\"ttext skipped — text merge needs text_cmp plumbing\"). MEOS exports \`text_cmp\` as a public API, so the wrapper datum-merge functions are 2-liners:

\`\`\`cpp
static Datum mduck_datum_min_text(Datum l, Datum r) {
    return text_cmp((text*)l, (text*)r) < 0 ? l : r;
}
\`\`\`

Each merge fn casts both Datums to \`text*\` (PG varlena), invokes \`text_cmp\`, and returns whichever Datum the comparison selects.

## Coverage

| Aggregate | Inputs | Output |
|---|---|---|
| \`tagg_min(ttext)\` | ttext | ttext — per-instant minimum (lexicographic) |
| \`tagg_max(ttext)\` | ttext | ttext — per-instant maximum (lexicographic) |

\`\`\`sql
SELECT tagg_min(t) FROM (VALUES (ttext '"hello"@2000-01-01'), (ttext '"alpha"@2000-01-01')) tt(t);
-- {"alpha"@2000-01-01 00:00:00+00}

SELECT tagg_max(t) FROM (VALUES (ttext '"hello"@2000-01-01'), (ttext '"zebra"@2000-01-01')) tt(t);
-- {"zebra"@2000-01-01 00:00:00+00}
\`\`\`

## Stacked on

- #47 → #48 → #49 → #50 → #52 → #53 (aggregate stack)

## Test plan
- [x] tagg_min(ttext) / tagg_max(ttext) produce correct lexicographic results
- [x] Existing int/float overloads still work (regression check)