### PR TITLE
feat(bindings): scalar extent overloads (integer/bigint/float/date/timestamptz)

### DIFF
--- a/src/temporal/span_aggregates.cpp
+++ b/src/temporal/span_aggregates.cpp
@@ -4,6 +4,7 @@
 #include "temporal/span.hpp"
 #include "temporal/span_aggregates.hpp"
 #include "temporal/spanset.hpp"
+#include "time_util.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
@@ -94,6 +95,111 @@ struct SpansetExtentFunction : SpanExtentBase {
         }
     }
 
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+// extent(<scalar>) — input is a primitive numeric / temporal value rather
+// than a varlena blob. Each subtype dispatches to its own MEOS transfn.
+struct IntExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        if (!state.isset) {
+            Span *fresh = int_extent_transfn(nullptr, static_cast<int>(input));
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) int_extent_transfn(&state.span, static_cast<int>(input));
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+struct BigintExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        if (!state.isset) {
+            Span *fresh = bigint_extent_transfn(nullptr, static_cast<int64>(input));
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) bigint_extent_transfn(&state.span, static_cast<int64>(input));
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+struct FloatExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        if (!state.isset) {
+            Span *fresh = float_extent_transfn(nullptr, static_cast<double>(input));
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) float_extent_transfn(&state.span, static_cast<double>(input));
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+struct DateExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        // INPUT_TYPE is duckdb::date_t (offset from 1970); MEOS DateADT
+        // is offset from 2000. Convert before passing.
+        int32_t meos_d = ToMeosDate(input);
+        if (!state.isset) {
+            Span *fresh = date_extent_transfn(nullptr, meos_d);
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) date_extent_transfn(&state.span, meos_d);
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+struct TimestamptzExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        // INPUT_TYPE is duckdb::timestamp_t (1970 epoch); MEOS TimestampTz
+        // uses 2000 epoch.
+        timestamp_tz_t in_ts;
+        in_ts.value = input.value;
+        timestamp_tz_t meos_ts = DuckDBToMeosTimestamp(in_ts);
+        if (!state.isset) {
+            Span *fresh = timestamptz_extent_transfn(nullptr, meos_ts.value);
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) timestamptz_extent_transfn(&state.span, meos_ts.value);
+        }
+    }
     template <class INPUT_TYPE, class STATE, class OP>
     static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
                                   idx_t /*count*/) {
@@ -250,6 +356,25 @@ void SpanAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
     extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::floatset(), SpanTypes::FLOATSPAN()));
     extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::dateset(), SpanTypes::DATESPAN()));
     extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::tstzset(), SpanTypes::TSTZSPAN()));
+
+    // extent(<scalar>) -> <span>. Primitive inputs (not blob-encoded);
+    // matches MobilityDB's extent(integer) / (bigint) / (float) / (date)
+    // / (timestamptz) overloads.
+    extent_set.AddFunction(
+        AggregateFunction::UnaryAggregate<SpanExtentState, int32_t, string_t, IntExtentFunction>(
+            LogicalType::INTEGER, SpanTypes::INTSPAN()));
+    extent_set.AddFunction(
+        AggregateFunction::UnaryAggregate<SpanExtentState, int64_t, string_t, BigintExtentFunction>(
+            LogicalType::BIGINT, SpanTypes::BIGINTSPAN()));
+    extent_set.AddFunction(
+        AggregateFunction::UnaryAggregate<SpanExtentState, double, string_t, FloatExtentFunction>(
+            LogicalType::DOUBLE, SpanTypes::FLOATSPAN()));
+    extent_set.AddFunction(
+        AggregateFunction::UnaryAggregate<SpanExtentState, date_t, string_t, DateExtentFunction>(
+            LogicalType::DATE, SpanTypes::DATESPAN()));
+    extent_set.AddFunction(
+        AggregateFunction::UnaryAggregate<SpanExtentState, timestamp_t, string_t, TimestamptzExtentFunction>(
+            LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()));
 }
 
 void SpanAggregates::RegisterSpanUnion(ExtensionLoader &loader) {


### PR DESCRIPTION
## Summary

Adds **5 scalar overloads** to the \`extent()\` \`AggregateFunctionSet\`, matching MobilityDB's \`CREATE AGGREGATE extent(integer)\` / \`(bigint)\` / \`(float)\` / \`(date)\` / \`(timestamptz)\` registrations from \`015_span_aggfuncs.in.sql\`:

| Overload | Returns |
|---|---|
| \`extent(integer)\` | \`intspan\` |
| \`extent(bigint)\` | \`bigintspan\` |
| \`extent(float)\` | \`floatspan\` (DuckDB \`DOUBLE\`) |
| \`extent(date)\` | \`datespan\` |
| \`extent(timestamptz)\` | \`tstzspan\` |

\`\`\`sql
SELECT extent(v) FROM (VALUES (1), (5), (3)) tt(v);
-- [1, 6)

SELECT extent(v) FROM (VALUES (DATE '2000-01-01'), (DATE '2000-01-05')) tt(v);
-- [2000-01-01, 2000-01-06)
\`\`\`

## Implementation

Each subtype gets its own functor (\`IntExtentFunction\`, \`BigintExtentFunction\`, \`FloatExtentFunction\`, \`DateExtentFunction\`, \`TimestamptzExtentFunction\`) that bridges to the matching MEOS \`*_extent_transfn\` (\`int_extent_transfn\`, \`bigint_extent_transfn\`, etc.). All share the existing \`SpanExtentState\` and \`SpanExtentBase\` (Initialize / Combine / Finalize) from PR #47.

**Epoch conversion**: \`date\` and \`timestamptz\` inputs use DuckDB's 1970 epoch; MEOS uses PostgreSQL's 2000 epoch. The functors convert via the existing \`time_util.hpp\` helpers (\`ToMeosDate\` / \`DuckDBToMeosTimestamp\`). The output Span is stored in MEOS-native epoch form, which round-trips correctly through the existing span in/out functions.

## Stacked on

- #47 → #48 → #49 → #50 → #52 → #53 → #54 (aggregate stack)

## Test plan
- [x] All 5 scalar input types produce correct extent
- [x] NULL handling (mid-run NULL ignored)
- [x] Date / timestamptz round-trip correctly across the epoch boundary
- [x] Existing span/spanset/set/tnumber overloads still work (regression)