### PR TITLE
feat(bindings): extent(tgeompoint) -> stbox aggregate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(EXTENSION_SOURCES
     src/temporal/span_functions.cpp
     src/temporal/span_aggregates.cpp
     src/geo/geoset.cpp
+    src/geo/spatial_aggregates.cpp
     src/temporal/spanset.cpp
     src/temporal/spanset_functions.cpp
     src/geo/tgeometry.cpp

--- a/src/geo/spatial_aggregates.cpp
+++ b/src/geo/spatial_aggregates.cpp
@@ -1,0 +1,93 @@
+#include "meos_wrapper_simple.hpp"
+
+#include "geo/spatial_aggregates.hpp"
+#include "geo/stbox.hpp"
+#include "geo/tgeompoint.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+namespace {
+
+// State for extent(tgeompoint) → stbox. STBox is a fixed-size POD struct
+// (Span period + double xmin/xmax/ymin/ymax/zmin/zmax + int32 srid + int16
+// flags) so it can live inline in the aggregate state.
+struct StboxExtentState {
+    STBox box;
+    bool isset;
+};
+
+struct TspatialExtentFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.isset = false;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+
+        if (!state.isset) {
+            STBox *fresh = tspatial_extent_transfn(nullptr, temp);
+            memcpy(&state.box, fresh, sizeof(STBox));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) tspatial_extent_transfn(&state.box, temp);
+        }
+        free(temp);
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) {
+            return;
+        }
+        if (!target.isset) {
+            memcpy(&target.box, &source.box, sizeof(STBox));
+            target.isset = true;
+        } else {
+            stbox_expand(&source.box, &target.box);
+        }
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.isset) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(&state.box), sizeof(STBox)));
+    }
+};
+
+static AggregateFunction MakeExtentTspatialAggregate(const LogicalType &input_type) {
+    return AggregateFunction::UnaryAggregate<StboxExtentState, string_t, string_t, TspatialExtentFunction>(
+        input_type, StboxType::STBOX());
+}
+
+} // namespace
+
+void SpatialAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
+    extent_set.AddFunction(MakeExtentTspatialAggregate(TgeompointType::TGEOMPOINT()));
+}
+
+} // namespace duckdb

--- a/src/include/geo/spatial_aggregates.hpp
+++ b/src/include/geo/spatial_aggregates.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+struct SpatialAggregates {
+    // Add tgeompoint overloads of extent() to the given set.
+    static void AddExtentOverloads(AggregateFunctionSet &extent_set);
+};
+
+} // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -14,6 +14,7 @@
 #include "temporal/span.hpp"
 #include "temporal/span_aggregates.hpp"
 #include "temporal/temporal_aggregates.hpp"
+#include "geo/spatial_aggregates.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar_function.hpp"
@@ -249,6 +250,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 		AggregateFunctionSet extent_set("extent");
 		SpanAggregates::AddExtentOverloads(extent_set);
 		TemporalAggregates::AddExtentOverloads(extent_set);
+		SpatialAggregates::AddExtentOverloads(extent_set);
 		loader.RegisterFunction(std::move(extent_set));
 	}
 	TemporalAggregates::RegisterTCount(loader);


### PR DESCRIPTION
## Summary

Adds the spatial branch of \`extent()\` — aggregates a column of \`tgeompoint\` values into the spatiotemporal bounding box (\`STBox\`) over all values.

\`\`\`sql
SELECT extent(t) FROM (VALUES (tgeompoint 'Point(1 1)@2000-01-01'),
                              (tgeompoint 'Point(5 5)@2000-01-05')) tt(t);
-- STBOX XT(((1,1),(5,5)),[2000-01-01 00:00:00+00, 2000-01-05 00:00:00+00])
\`\`\`

## Implementation

New module: \`src/geo/spatial_aggregates.cpp\` + \`src/include/geo/spatial_aggregates.hpp\`.

| Component | What it does |
|---|---|
| \`StboxExtentState\` | Inline \`STBox box\` + \`bool isset\` — fixed-size POD struct (time period + x/y/z bounds + SRID + flags). |
| \`TspatialExtentFunction::Operation\` | Copies the input Temporal blob and calls MEOS \`tspatial_extent_transfn\`. First call returns a palloc'd STBox which gets memcpy'd into state and freed; subsequent calls expand state in place. |
| \`Combine\` | Merges two STBox states via \`stbox_expand\`. |
| \`Finalize\` | Returns the box blob or NULL. |

\`SpatialAggregates::AddExtentOverloads\` is wired into the same \`extent()\` \`AggregateFunctionSet\` that already carries span / spanset / set / tnumber / scalar overloads.

## Test plan
- [x] \`extent(tgeompoint)\` produces correct STBOX XT for instants and sequences
- [x] No segfault on simple input