### PR TITLE
feat(bindings): tAvg(tnumber) and wavg(tnumber, INTERVAL) aggregates

### DIFF
--- a/src/include/temporal/temporal_aggregates.hpp
+++ b/src/include/temporal/temporal_aggregates.hpp
@@ -17,6 +17,9 @@ struct TemporalAggregates {
 
     // Register wmin / wmax / wsum window aggregates.
     static void RegisterWindowAggregates(ExtensionLoader &loader);
+
+    // Register tAvg(tnumber) -> tfloat aggregate.
+    static void RegisterTAvg(ExtensionLoader &loader);
 };
 
 } // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -256,6 +256,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	TemporalAggregates::RegisterTCount(loader);
 	TemporalAggregates::RegisterTemporalAggregates(loader);
 	TemporalAggregates::RegisterWindowAggregates(loader);
+	TemporalAggregates::RegisterTAvg(loader);
 	SpanAggregates::RegisterSpanUnion(loader);
 
 	TgeompointType::RegisterType(loader);

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -244,6 +244,25 @@ static Datum mduck_datum_max_float8(Datum l, Datum r) {
 static Datum mduck_datum_sum_float8(Datum l, Datum r) {
     return float8_to_datum(datum_to_float8(l) + datum_to_float8(r));
 }
+// double2 — internal MEOS struct for {sum, count} pairs used by tavg.
+// Layout per meos/include/temporal/doublen.h: { double a; double b; }
+// MEOS internal (not in public install). We replicate the layout here
+// and provide a sum function for use as the merge function in tavg
+// combine. Allocation matches the palloc path used internally so the
+// MEOS skiplist's free path interoperates with our state.
+struct mduck_double2 {
+    double a;
+    double b;
+};
+static Datum mduck_datum_sum_double2(Datum l, Datum r) {
+    auto *lp = reinterpret_cast<mduck_double2 *>(l);
+    auto *rp = reinterpret_cast<mduck_double2 *>(r);
+    auto *out = reinterpret_cast<mduck_double2 *>(malloc(sizeof(mduck_double2)));
+    out->a = lp->a + rp->a;
+    out->b = lp->b + rp->b;
+    return reinterpret_cast<Datum>(out);
+}
+
 // Text comparison: Datum carries text* (PG varlena). text_cmp is exported
 // from MEOS so we just invoke it on the two pointers and pick whichever
 // Datum we want.
@@ -327,6 +346,89 @@ static AggregateFunction MakeSkiplistAggregate(const LogicalType &input_type, co
     using OPS = SkiplistAggFunction<TRANSFN, MERGE_FN, CROSSINGS>;
     return AggregateFunction::UnaryAggregateDestructor<TCountState, string_t, string_t, OPS>(
         input_type, output_type);
+}
+
+// ============================================================================
+// tAvg(tnumber) -> tfloat — Skiplist of {sum, count} pairs.
+//
+// Differs from the generic skiplist pattern in two places:
+//   1. Combine uses mduck_datum_sum_double2 (sum-of-pair merge).
+//   2. Finalize uses tnumber_tavg_finalfn (computes sum/count per
+//      instant) instead of the generic temporal_tagg_finalfn.
+// ============================================================================
+
+struct TAvgFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.skiplist = nullptr;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+        state.skiplist = tnumber_tavg_transfn(state.skiplist, temp);
+        free(temp);
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.skiplist || source.skiplist->length == 0) {
+            return;
+        }
+        if (!target.skiplist) {
+            const_cast<STATE &>(target).skiplist = temporal_skiplist_make();
+        }
+        void **values = skiplist_values(source.skiplist);
+        int count = source.skiplist->length;
+        temporal_skiplist_splice(target.skiplist, values, count, &mduck_datum_sum_double2, false);
+        free(values);
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.skiplist || state.skiplist->length == 0) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        Temporal *result = tnumber_tavg_finalfn(state.skiplist);
+        // tnumber_tavg_finalfn calls skiplist_free internally — same
+        // contract as temporal_tagg_finalfn.
+        state.skiplist = nullptr;
+        if (!result) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        size_t out_size = temporal_mem_size(result);
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(result), out_size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+static AggregateFunction MakeTavgAggregate(const LogicalType &input_type) {
+    return AggregateFunction::UnaryAggregateDestructor<TCountState, string_t, string_t, TAvgFunction>(
+        input_type, TemporalTypes::TFLOAT());
 }
 
 // ============================================================================
@@ -530,6 +632,13 @@ void TemporalAggregates::RegisterWindowAggregates(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(wsum_set));
     }
     // wavg deferred — needs datum_sum_double2 (MEOS internal struct).
+}
+
+void TemporalAggregates::RegisterTAvg(ExtensionLoader &loader) {
+    AggregateFunctionSet tavg_set("tAvg");
+    tavg_set.AddFunction(MakeTavgAggregate(TemporalTypes::TINT()));
+    tavg_set.AddFunction(MakeTavgAggregate(TemporalTypes::TFLOAT()));
+    loader.RegisterFunction(std::move(tavg_set));
 }
 
 } // namespace duckdb

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -519,6 +519,81 @@ static AggregateFunction MakeWindowAggregate(const LogicalType &input_type, cons
     return fn;
 }
 
+// wavg uses tnumber_tavg_finalfn instead of temporal_tagg_finalfn so it
+// has its own functor parametrised on the window transfn only.
+template <TempWindowTransfn TRANSFN>
+struct WavgFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.skiplist = nullptr;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class A_TYPE, class B_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const A_TYPE &a_input, const B_TYPE &b_input,
+                          AggregateBinaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(a_input.GetData());
+        size_t size = a_input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+        MeosInterval interv = IntervaltToInterval(b_input);
+        state.skiplist = TRANSFN(state.skiplist, temp, &interv);
+        free(temp);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.skiplist || source.skiplist->length == 0) {
+            return;
+        }
+        if (!target.skiplist) {
+            const_cast<STATE &>(target).skiplist = temporal_skiplist_make();
+        }
+        void **values = skiplist_values(source.skiplist);
+        int count = source.skiplist->length;
+        temporal_skiplist_splice(target.skiplist, values, count, &mduck_datum_sum_double2, false);
+        free(values);
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.skiplist || state.skiplist->length == 0) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        Temporal *result = tnumber_tavg_finalfn(state.skiplist);
+        state.skiplist = nullptr;
+        if (!result) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        size_t out_size = temporal_mem_size(result);
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(result), out_size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+template <TempWindowTransfn TRANSFN>
+static AggregateFunction MakeWavgAggregate(const LogicalType &input_type) {
+    using OPS = WavgFunction<TRANSFN>;
+    AggregateFunction fn = AggregateFunction::BinaryAggregate<TCountState, string_t, interval_t, string_t, OPS>(
+        input_type, LogicalType::INTERVAL, TemporalTypes::TFLOAT());
+    fn.destructor = AggregateFunction::StateDestroy<TCountState, OPS>;
+    return fn;
+}
+
 } // namespace
 
 void TemporalAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
@@ -631,7 +706,13 @@ void TemporalAggregates::RegisterWindowAggregates(ExtensionLoader &loader) {
                 TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
         loader.RegisterFunction(std::move(wsum_set));
     }
-    // wavg deferred — needs datum_sum_double2 (MEOS internal struct).
+    // wavg: tnumber (output is tfloat).
+    {
+        AggregateFunctionSet wavg_set("wavg");
+        wavg_set.AddFunction(MakeWavgAggregate<&tnumber_wavg_transfn>(TemporalTypes::TINT()));
+        wavg_set.AddFunction(MakeWavgAggregate<&tnumber_wavg_transfn>(TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(wavg_set));
+    }
 }
 
 void TemporalAggregates::RegisterTAvg(ExtensionLoader &loader) {


### PR DESCRIPTION
## Summary

Adds the temporal-average aggregate:

| Aggregate | Inputs | Output |
|---|---|---|
| \`tAvg(tint)\` | tint | tfloat |
| \`tAvg(tfloat)\` | tfloat | tfloat |

\`\`\`sql
SELECT tAvg(t) FROM (VALUES (tint '5@2000-01-01'), (tint '3@2000-01-01')) tt(t);
-- {4@2000-01-01 00:00:00+00}    -- avg of 5 and 3
\`\`\`

## Implementation

State holds a \`SkipList\` of \`{sum, count}\` pairs (MEOS \`double2\` layout — \`{ double a; double b; }\`). \`Operation\` calls \`tnumber_tavg_transfn\`. \`Combine\` merges two states via \`temporal_skiplist_splice\` with \`mduck_datum_sum_double2\` as the merge function — a local replica of MEOS's internal \`datum_sum_double2\` since that symbol is not in the MEOS public install headers (the underlying struct layout is, fortunately, simple enough to replicate exactly). \`Finalize\` calls \`tnumber_tavg_finalfn\` which computes per-instant \`sum/count\` and frees the skiplist; \`state.skiplist\` is nulled after to keep the destructor from double-freeing.

## Test plan
- [x] Same-instant \`tAvg(5, 3)\` correctly produces \`4\`
- [x] Distinct instants preserve their per-instant values
- [x] \`tAvg(tfloat)\` works with non-integer values
- [x] No segfault on cleanup (destructor pattern from existing skiplist aggregates)