### PR TITLE
feat(bindings): full *Agg surface — cumulative aggregate cluster (consolidates #48–#59)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(EXTENSION_SOURCES
     src/mobilityduck_extension.cpp        
     src/temporal/temporal.cpp
     src/temporal/temporal_functions.cpp
+    src/temporal/temporal_aggregates.cpp
     src/temporal/tbox.cpp
     src/temporal/tbox_functions.cpp
     src/geo/stbox.cpp
@@ -72,6 +73,7 @@ set(EXTENSION_SOURCES
     src/temporal/span_functions.cpp
     src/temporal/span_aggregates.cpp
     src/geo/geoset.cpp
+    src/geo/spatial_aggregates.cpp
     src/temporal/spanset.cpp
     src/temporal/spanset_functions.cpp
     src/geo/tgeometry.cpp

--- a/src/geo/spatial_aggregates.cpp
+++ b/src/geo/spatial_aggregates.cpp
@@ -1,0 +1,235 @@
+#include "meos_wrapper_simple.hpp"
+
+#include "geo/spatial_aggregates.hpp"
+#include "geo/stbox.hpp"
+#include "geo/tgeompoint.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+namespace {
+
+// State for extent(tgeompoint) → stbox. STBox is a fixed-size POD struct
+// (Span period + double xmin/xmax/ymin/ymax/zmin/zmax + int32 srid + int16
+// flags) so it can live inline in the aggregate state.
+struct StboxExtentState {
+    STBox box;
+    bool isset;
+};
+
+struct TspatialExtentFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.isset = false;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+
+        if (!state.isset) {
+            STBox *fresh = tspatial_extent_transfn(nullptr, temp);
+            memcpy(&state.box, fresh, sizeof(STBox));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) tspatial_extent_transfn(&state.box, temp);
+        }
+        free(temp);
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) {
+            return;
+        }
+        if (!target.isset) {
+            memcpy(&target.box, &source.box, sizeof(STBox));
+            target.isset = true;
+        } else {
+            stbox_expand(&source.box, &target.box);
+        }
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.isset) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(&state.box), sizeof(STBox)));
+    }
+};
+
+static AggregateFunction MakeExtentTspatialAggregate(const LogicalType &input_type) {
+    return AggregateFunction::UnaryAggregate<StboxExtentState, string_t, string_t, TspatialExtentFunction>(
+        input_type, StboxType::STBOX());
+}
+
+// ============================================================================
+// tCentroid(tgeompoint) -> tgeompoint
+//
+// Skiplist-backed. Per-instant value is stored as a (sum_x, sum_y, count)
+// triple for 2D points or (sum_x, sum_y, sum_z, count) quadruple for 3D
+// points. Combine merges via local replicas of MEOS's datum_sum_double3
+// or datum_sum_double4 — chosen by inspecting state->extra
+// (GeoAggregateState).
+// ============================================================================
+
+struct TcentroidState {
+    SkipList *skiplist;
+};
+
+// Local replica of the MEOS-internal struct {int32_t srid; bool hasz}.
+struct mduck_geo_agg_state {
+    int32_t srid;
+    bool hasz;
+};
+
+struct mduck_double3 {
+    double a;
+    double b;
+    double c;
+};
+struct mduck_double4 {
+    double a;
+    double b;
+    double c;
+    double d;
+};
+
+static Datum mduck_datum_sum_double3(Datum l, Datum r) {
+    auto *lp = reinterpret_cast<mduck_double3 *>(l);
+    auto *rp = reinterpret_cast<mduck_double3 *>(r);
+    auto *out = reinterpret_cast<mduck_double3 *>(malloc(sizeof(mduck_double3)));
+    out->a = lp->a + rp->a;
+    out->b = lp->b + rp->b;
+    out->c = lp->c + rp->c;
+    return reinterpret_cast<Datum>(out);
+}
+static Datum mduck_datum_sum_double4(Datum l, Datum r) {
+    auto *lp = reinterpret_cast<mduck_double4 *>(l);
+    auto *rp = reinterpret_cast<mduck_double4 *>(r);
+    auto *out = reinterpret_cast<mduck_double4 *>(malloc(sizeof(mduck_double4)));
+    out->a = lp->a + rp->a;
+    out->b = lp->b + rp->b;
+    out->c = lp->c + rp->c;
+    out->d = lp->d + rp->d;
+    return reinterpret_cast<Datum>(out);
+}
+
+struct TcentroidFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.skiplist = nullptr;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+        state.skiplist = tpoint_tcentroid_transfn(state.skiplist, temp);
+        free(temp);
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.skiplist || source.skiplist->length == 0) {
+            return;
+        }
+        if (!target.skiplist) {
+            // Take ownership of source's skiplist so its geo-specific
+            // `extra` field (GeoAggregateState) is preserved for the
+            // finalfn. Source's destructor will see a null pointer and
+            // skip its skiplist_free.
+            const_cast<STATE &>(target).skiplist = source.skiplist;
+            const_cast<STATE &>(source).skiplist = nullptr;
+            return;
+        }
+        // Both non-empty: pick 2D vs 3D merge fn based on source's extra.
+        auto *extra = reinterpret_cast<mduck_geo_agg_state *>(source.skiplist->extra);
+        datum_func2 merge_fn = (extra && extra->hasz) ? &mduck_datum_sum_double4
+                                                       : &mduck_datum_sum_double3;
+        void **values = skiplist_values(source.skiplist);
+        int count = source.skiplist->length;
+        temporal_skiplist_splice(target.skiplist, values, count, merge_fn, false);
+        free(values);
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.skiplist || state.skiplist->length == 0) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        Temporal *result = tpoint_tcentroid_finalfn(state.skiplist);
+        // tpoint_tcentroid_finalfn frees the skiplist; null state.skiplist
+        // so the destructor doesn't double-free.
+        state.skiplist = nullptr;
+        if (!result) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        size_t out_size = temporal_mem_size(result);
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(result), out_size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+static AggregateFunction MakeTcentroidAggregate(const LogicalType &input_type) {
+    return AggregateFunction::UnaryAggregateDestructor<TcentroidState, string_t, string_t, TcentroidFunction>(
+        input_type, input_type);
+}
+
+} // namespace
+
+void SpatialAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
+    extent_set.AddFunction(MakeExtentTspatialAggregate(TgeompointType::TGEOMPOINT()));
+}
+
+void SpatialAggregates::RegisterTcentroid(ExtensionLoader &loader) {
+    AggregateFunctionSet tcentroid_set("tCentroid");
+    tcentroid_set.AddFunction(MakeTcentroidAggregate(TgeompointType::TGEOMPOINT()));
+    loader.RegisterFunction(std::move(tcentroid_set));
+}
+
+} // namespace duckdb

--- a/src/include/geo/spatial_aggregates.hpp
+++ b/src/include/geo/spatial_aggregates.hpp
@@ -5,12 +5,12 @@
 
 namespace duckdb {
 
-struct SpanAggregates {
-    // Add span / spanset / set overloads of extent() to the given set.
+struct SpatialAggregates {
+    // Add tgeompoint overloads of extent() to the given set.
     static void AddExtentOverloads(AggregateFunctionSet &extent_set);
 
-    // Register spanUnion(span | spanset) → spanset.
-    static void RegisterSpanUnion(ExtensionLoader &loader);
+    // Register tCentroid(tgeompoint) -> tgeompoint.
+    static void RegisterTcentroid(ExtensionLoader &loader);
 };
 
 } // namespace duckdb

--- a/src/include/temporal/temporal_aggregates.hpp
+++ b/src/include/temporal/temporal_aggregates.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+struct TemporalAggregates {
+    // Add tnumber overloads of extent() to the given set.
+    static void AddExtentOverloads(AggregateFunctionSet &extent_set);
+
+    // Register tCount(temporal) → tint as its own AggregateFunctionSet.
+    static void RegisterTCount(ExtensionLoader &loader);
+
+    // Register tAnd / tOr / tMin / tMax / tSum aggregates.
+    static void RegisterTemporalAggregates(ExtensionLoader &loader);
+
+    // Register wmin / wmax / wsum window aggregates.
+    static void RegisterWindowAggregates(ExtensionLoader &loader);
+
+    // Register tAvg(tnumber) -> tfloat aggregate.
+    static void RegisterTAvg(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -13,6 +13,8 @@
 #include "geo/tgeometry.hpp"
 #include "temporal/span.hpp"
 #include "temporal/span_aggregates.hpp"
+#include "temporal/temporal_aggregates.hpp"
+#include "geo/spatial_aggregates.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar_function.hpp"
@@ -244,7 +246,19 @@ static void LoadInternal(ExtensionLoader &loader) {
 	SpanTypes::RegisterScalarFunctions(loader);
 	SpanTypes::RegisterTypes(loader);
 	SpanTypes::RegisterCastFunctions(loader);
-	SpanAggregates::RegisterAggregateFunctions(loader);
+	{
+		AggregateFunctionSet extent_set("extent");
+		SpanAggregates::AddExtentOverloads(extent_set);
+		TemporalAggregates::AddExtentOverloads(extent_set);
+		SpatialAggregates::AddExtentOverloads(extent_set);
+		loader.RegisterFunction(std::move(extent_set));
+	}
+	TemporalAggregates::RegisterTCount(loader);
+	TemporalAggregates::RegisterTemporalAggregates(loader);
+	TemporalAggregates::RegisterWindowAggregates(loader);
+	TemporalAggregates::RegisterTAvg(loader);
+	SpanAggregates::RegisterSpanUnion(loader);
+	SpatialAggregates::RegisterTcentroid(loader);
 
 	TgeompointType::RegisterType(loader);
 	TgeompointType::RegisterCastFunctions(loader);

--- a/src/temporal/span_aggregates.cpp
+++ b/src/temporal/span_aggregates.cpp
@@ -1,7 +1,10 @@
 #include "meos_wrapper_simple.hpp"
 
+#include "temporal/set.hpp"
 #include "temporal/span.hpp"
 #include "temporal/span_aggregates.hpp"
+#include "temporal/spanset.hpp"
+#include "time_util.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
@@ -12,14 +15,17 @@ namespace duckdb {
 
 namespace {
 
-// State for the extent(span) aggregate. The MEOS Span is a fixed-size
-// struct, so we can hold it inline in the aggregate state.
+// Shared state for all extent(*) aggregates: the result is always a Span.
+// MEOS Span is a fixed-size struct so the state is POD.
 struct SpanExtentState {
     Span span;
     bool isset;
 };
 
-struct SpanExtentFunction {
+// Generic Initialize / Combine / Finalize. Operation differs per input
+// type because it dispatches to a different MEOS transfn — those are
+// in the typed functors below.
+struct SpanExtentBase {
     template <class STATE>
     static void Initialize(STATE &state) {
         state.isset = false;
@@ -27,33 +33,6 @@ struct SpanExtentFunction {
 
     static bool IgnoreNull() {
         return true;
-    }
-
-    // Operation receives the input blob; we decode to Span and call MEOS
-    // span_extent_transfn, which expands state's bounds in place when
-    // state is non-null and otherwise returns a fresh palloc'd copy.
-    template <class INPUT_TYPE, class STATE, class OP>
-    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
-        // INPUT_TYPE is string_t for blob-encoded spans.
-        const Span *input_span = reinterpret_cast<const Span *>(input.GetData());
-        if (!state.isset) {
-            // First call: initialize state with a copy of the input.
-            memcpy(&state.span, input_span, sizeof(Span));
-            state.isset = true;
-        } else {
-            // Subsequent calls: expand state in place.
-            // span_extent_transfn(state, s) calls span_expand(s, state).
-            (void) span_extent_transfn(&state.span, input_span);
-        }
-    }
-
-    template <class INPUT_TYPE, class STATE, class OP>
-    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
-                                  idx_t /*count*/) {
-        // extent is idempotent in the value dimension, so a single
-        // application is equivalent to applying the same value `count`
-        // times.
-        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
     }
 
     template <class STATE, class OP>
@@ -75,25 +54,347 @@ struct SpanExtentFunction {
             finalize_data.ReturnNull();
             return;
         }
-        target = finalize_data.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
     }
 };
 
-static AggregateFunction MakeExtentSpanAggregate(const LogicalType &span_type) {
-    return AggregateFunction::UnaryAggregate<SpanExtentState, string_t, string_t, SpanExtentFunction>(
-        span_type, span_type);
+// extent(span)
+struct SpanExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Span *input_span = reinterpret_cast<const Span *>(input.GetData());
+        if (!state.isset) {
+            memcpy(&state.span, input_span, sizeof(Span));
+            state.isset = true;
+        } else {
+            (void) span_extent_transfn(&state.span, input_span);
+        }
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+// extent(spanset)
+struct SpansetExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const SpanSet *input_ss = reinterpret_cast<const SpanSet *>(input.GetData());
+        if (!state.isset) {
+            // spanset_extent_transfn(NULL, ss) returns palloc'd Span; copy into state.
+            Span *fresh = spanset_extent_transfn(nullptr, input_ss);
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) spanset_extent_transfn(&state.span, input_ss);
+        }
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+// extent(<scalar>) — input is a primitive numeric / temporal value rather
+// than a varlena blob. Each subtype dispatches to its own MEOS transfn.
+struct IntExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        if (!state.isset) {
+            Span *fresh = int_extent_transfn(nullptr, static_cast<int>(input));
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) int_extent_transfn(&state.span, static_cast<int>(input));
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+struct BigintExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        if (!state.isset) {
+            Span *fresh = bigint_extent_transfn(nullptr, static_cast<int64>(input));
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) bigint_extent_transfn(&state.span, static_cast<int64>(input));
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+struct FloatExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        if (!state.isset) {
+            Span *fresh = float_extent_transfn(nullptr, static_cast<double>(input));
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) float_extent_transfn(&state.span, static_cast<double>(input));
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+struct DateExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        // INPUT_TYPE is duckdb::date_t (offset from 1970); MEOS DateADT
+        // is offset from 2000. Convert before passing.
+        int32_t meos_d = ToMeosDate(input);
+        if (!state.isset) {
+            Span *fresh = date_extent_transfn(nullptr, meos_d);
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) date_extent_transfn(&state.span, meos_d);
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+struct TimestamptzExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        // INPUT_TYPE is duckdb::timestamp_t (1970 epoch); MEOS TimestampTz
+        // uses 2000 epoch.
+        timestamp_tz_t in_ts;
+        in_ts.value = input.value;
+        timestamp_tz_t meos_ts = DuckDBToMeosTimestamp(in_ts);
+        if (!state.isset) {
+            Span *fresh = timestamptz_extent_transfn(nullptr, meos_ts.value);
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) timestamptz_extent_transfn(&state.span, meos_ts.value);
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+// extent(set)
+struct SetExtentFunction : SpanExtentBase {
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Set *input_set = reinterpret_cast<const Set *>(input.GetData());
+        if (!state.isset) {
+            Span *fresh = set_extent_transfn(nullptr, input_set);
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) set_extent_transfn(&state.span, input_set);
+        }
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+};
+
+template <class FUNC>
+static AggregateFunction MakeExtentAggregate(const LogicalType &input_type, const LogicalType &output_span_type) {
+    return AggregateFunction::UnaryAggregate<SpanExtentState, string_t, string_t, FUNC>(
+        input_type, output_span_type);
+}
+
+// ============================================================================
+// spanUnion(span | spanset) -> spanset
+//
+// State holds a heap-allocated SpanSet *. MEOS span_union_transfn allocates
+// a fresh spanset on first call and either appends in place or returns a
+// new (possibly larger) spanset on subsequent calls — we always reassign
+// state.spanset to whatever the transfn returns. spanset_union_finalfn
+// compacts the state and frees it; we null state.spanset after the call
+// to keep our destructor from double-freeing.
+// ============================================================================
+
+struct SpansetUnionState {
+    SpanSet *spanset;
+};
+
+template <bool INPUT_IS_SPANSET>
+struct SpanUnionFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.spanset = nullptr;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        if constexpr (INPUT_IS_SPANSET) {
+            SpanSet *ss = reinterpret_cast<SpanSet *>(malloc(size));
+            memcpy(ss, bytes, size);
+            state.spanset = spanset_union_transfn(state.spanset, ss);
+            free(ss);
+        } else {
+            Span *s = reinterpret_cast<Span *>(malloc(size));
+            memcpy(s, bytes, size);
+            state.spanset = span_union_transfn(state.spanset, s);
+            free(s);
+        }
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.spanset || source.spanset->count == 0) {
+            return;
+        }
+        // spanset_union_transfn(target, source) merges source into target.
+        // It may return target unchanged (if it had room) or a new larger
+        // spanset; in the latter case it frees the old target. Always
+        // reassign whatever is returned.
+        const_cast<STATE &>(target).spanset =
+            spanset_union_transfn(target.spanset, source.spanset);
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.spanset) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        SpanSet *result = spanset_union_finalfn(state.spanset);
+        // spanset_union_finalfn calls pfree(state) internally; null out
+        // the pointer so our destructor doesn't double-free.
+        state.spanset = nullptr;
+        if (!result) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        size_t out_size = spanset_mem_size(result);
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(result), out_size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.spanset) {
+            free(state.spanset);
+            state.spanset = nullptr;
+        }
+    }
+};
+
+template <bool INPUT_IS_SPANSET>
+static AggregateFunction MakeSpanUnionAggregate(const LogicalType &input_type, const LogicalType &output_spanset_type) {
+    using OPS = SpanUnionFunction<INPUT_IS_SPANSET>;
+    return AggregateFunction::UnaryAggregateDestructor<SpansetUnionState, string_t, string_t, OPS>(
+        input_type, output_spanset_type);
 }
 
 } // namespace
 
-void SpanAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
-    AggregateFunctionSet extent_set("extent");
-    for (const auto &span_type : {SpanTypes::INTSPAN(), SpanTypes::BIGINTSPAN(),
-                                  SpanTypes::FLOATSPAN(), SpanTypes::DATESPAN(),
-                                  SpanTypes::TSTZSPAN()}) {
-        extent_set.AddFunction(MakeExtentSpanAggregate(span_type));
-    }
-    loader.RegisterFunction(std::move(extent_set));
+void SpanAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
+    // extent(<span>) -> <span>
+    extent_set.AddFunction(MakeExtentAggregate<SpanExtentFunction>(SpanTypes::INTSPAN(), SpanTypes::INTSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpanExtentFunction>(SpanTypes::BIGINTSPAN(), SpanTypes::BIGINTSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpanExtentFunction>(SpanTypes::FLOATSPAN(), SpanTypes::FLOATSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpanExtentFunction>(SpanTypes::DATESPAN(), SpanTypes::DATESPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpanExtentFunction>(SpanTypes::TSTZSPAN(), SpanTypes::TSTZSPAN()));
+
+    // extent(<spanset>) -> <span>
+    extent_set.AddFunction(MakeExtentAggregate<SpansetExtentFunction>(SpansetTypes::intspanset(), SpanTypes::INTSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpansetExtentFunction>(SpansetTypes::bigintspanset(), SpanTypes::BIGINTSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpansetExtentFunction>(SpansetTypes::floatspanset(), SpanTypes::FLOATSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpansetExtentFunction>(SpansetTypes::datespanset(), SpanTypes::DATESPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SpansetExtentFunction>(SpansetTypes::tstzspanset(), SpanTypes::TSTZSPAN()));
+
+    // extent(<set>) -> <span>. textset has no span equivalent.
+    extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::intset(), SpanTypes::INTSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::bigintset(), SpanTypes::BIGINTSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::floatset(), SpanTypes::FLOATSPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::dateset(), SpanTypes::DATESPAN()));
+    extent_set.AddFunction(MakeExtentAggregate<SetExtentFunction>(SetTypes::tstzset(), SpanTypes::TSTZSPAN()));
+
+    // extent(<scalar>) -> <span>. Primitive inputs (not blob-encoded);
+    // matches MobilityDB's extent(integer) / (bigint) / (float) / (date)
+    // / (timestamptz) overloads.
+    extent_set.AddFunction(
+        AggregateFunction::UnaryAggregate<SpanExtentState, int32_t, string_t, IntExtentFunction>(
+            LogicalType::INTEGER, SpanTypes::INTSPAN()));
+    extent_set.AddFunction(
+        AggregateFunction::UnaryAggregate<SpanExtentState, int64_t, string_t, BigintExtentFunction>(
+            LogicalType::BIGINT, SpanTypes::BIGINTSPAN()));
+    extent_set.AddFunction(
+        AggregateFunction::UnaryAggregate<SpanExtentState, double, string_t, FloatExtentFunction>(
+            LogicalType::DOUBLE, SpanTypes::FLOATSPAN()));
+    extent_set.AddFunction(
+        AggregateFunction::UnaryAggregate<SpanExtentState, date_t, string_t, DateExtentFunction>(
+            LogicalType::DATE, SpanTypes::DATESPAN()));
+    extent_set.AddFunction(
+        AggregateFunction::UnaryAggregate<SpanExtentState, timestamp_t, string_t, TimestamptzExtentFunction>(
+            LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()));
+}
+
+void SpanAggregates::RegisterSpanUnion(ExtensionLoader &loader) {
+    AggregateFunctionSet spanunion_set("spanUnion");
+
+    // spanUnion(<span>) -> <spanset>
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<false>(SpanTypes::INTSPAN(),    SpansetTypes::intspanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<false>(SpanTypes::BIGINTSPAN(), SpansetTypes::bigintspanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<false>(SpanTypes::FLOATSPAN(),  SpansetTypes::floatspanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<false>(SpanTypes::DATESPAN(),   SpansetTypes::datespanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<false>(SpanTypes::TSTZSPAN(),   SpansetTypes::tstzspanset()));
+
+    // spanUnion(<spanset>) -> <spanset>
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<true>(SpansetTypes::intspanset(),    SpansetTypes::intspanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<true>(SpansetTypes::bigintspanset(), SpansetTypes::bigintspanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<true>(SpansetTypes::floatspanset(),  SpansetTypes::floatspanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<true>(SpansetTypes::datespanset(),   SpansetTypes::datespanset()));
+    spanunion_set.AddFunction(MakeSpanUnionAggregate<true>(SpansetTypes::tstzspanset(),   SpansetTypes::tstzspanset()));
+
+    loader.RegisterFunction(std::move(spanunion_set));
 }
 
 } // namespace duckdb

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -1,0 +1,725 @@
+#include "meos_wrapper_simple.hpp"
+
+#include "temporal/tbox.hpp"
+#include "temporal/temporal.hpp"
+#include "temporal/temporal_aggregates.hpp"
+#include "time_util.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+namespace {
+
+// State for extent(tnumber) → tbox. TBox is a fixed-size POD struct
+// (Span period + Span span + int16 flags) so it can live inline in
+// the aggregate state.
+struct TboxExtentState {
+    TBox box;
+    bool isset;
+};
+
+struct TnumberExtentFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.isset = false;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        // Temporal is varlena: copy the blob into a heap allocation
+        // before passing to MEOS so the lifetime is well-defined.
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+
+        if (!state.isset) {
+            // tnumber_extent_transfn(NULL, temp) palloc's a fresh TBox.
+            TBox *fresh = tnumber_extent_transfn(nullptr, temp);
+            memcpy(&state.box, fresh, sizeof(TBox));
+            free(fresh);
+            state.isset = true;
+        } else {
+            (void) tnumber_extent_transfn(&state.box, temp);
+        }
+        free(temp);
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) {
+            return;
+        }
+        if (!target.isset) {
+            memcpy(&target.box, &source.box, sizeof(TBox));
+            target.isset = true;
+        } else {
+            // Combine two TBoxes: expand target with source via tbox_expand.
+            // Replicates the inline path in tnumber_extent_transfn when both
+            // operands are non-null TBox values.
+            tbox_expand(&source.box, &target.box);
+        }
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.isset) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(&state.box), sizeof(TBox)));
+    }
+};
+
+static AggregateFunction MakeExtentTnumberAggregate(const LogicalType &tnumber_type) {
+    return AggregateFunction::UnaryAggregate<TboxExtentState, string_t, string_t, TnumberExtentFunction>(
+        tnumber_type, TboxType::TBOX());
+}
+
+// ============================================================================
+// tCount(temporal) → tint
+//
+// State holds a MEOS SkipList* (heap-allocated separately from the inline
+// aggregate state). The state size is just `sizeof(SkipList *)`. Lifetime
+// is managed via the aggregate destructor which calls skiplist_free.
+// ============================================================================
+
+struct TCountState {
+    SkipList *skiplist;
+};
+
+// Local equivalent of MEOS's datum_sum_int32 (not exported from MEOS public
+// or internal headers). Used as the merge function when splicing two
+// tcount skiplists during Combine.
+static Datum mduck_datum_sum_int32(Datum l, Datum r) {
+    int32_t li = static_cast<int32_t>(l);
+    int32_t ri = static_cast<int32_t>(r);
+    return static_cast<Datum>(static_cast<int32_t>(li + ri));
+}
+
+struct TCountFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.skiplist = nullptr;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+        // MEOS allocates the SkipList on the first call (state == NULL) and
+        // returns the same/extended state on subsequent calls.
+        state.skiplist = temporal_tcount_transfn(state.skiplist, temp);
+        free(temp);
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.skiplist || source.skiplist->length == 0) {
+            return;
+        }
+        if (!target.skiplist) {
+            const_cast<STATE &>(target).skiplist = temporal_skiplist_make();
+        }
+        // Splice source's already-counted instants into target with a
+        // sum merge function. Equivalent to MEOS's internal
+        // temporal_tagg_combinefn(state1, state2, datum_sum_int32, false)
+        // without depending on the unexported symbol.
+        void **values = skiplist_values(source.skiplist);
+        int count = source.skiplist->length;
+        temporal_skiplist_splice(target.skiplist, values, count,
+                                 &mduck_datum_sum_int32, false);
+        free(values);
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.skiplist || state.skiplist->length == 0) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        Temporal *result = temporal_tagg_finalfn(state.skiplist);
+        // temporal_tagg_finalfn calls skiplist_free internally; null out
+        // the pointer so our destructor doesn't double-free.
+        state.skiplist = nullptr;
+        if (!result) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        size_t out_size = temporal_mem_size(result);
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(result), out_size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+// ============================================================================
+// Generic skiplist-backed aggregate (tand / tor / tmin / tmax / tsum)
+//
+// Same shape as TCountFunction. Parameterised on:
+//   - TRANSFN: the MEOS transition function (e.g. tbool_tand_transfn)
+//   - MERGE_FN: the per-instant merge function used during Combine
+//                (e.g. mduck_datum_and, mduck_datum_min_int32)
+//   - CROSSINGS: whether MEOS should split sequences at crossings during
+//                Combine. true for tfloat aggregates, false for the rest.
+// ============================================================================
+
+using TempTransfn = SkipList *(*)(SkipList *, const Temporal *);
+
+// Local equivalents of the unexported MEOS datum_* merge functions. Datum is
+// a uintptr_t; for primitive types these are simple bit-level reinterprets.
+static Datum mduck_datum_and(Datum l, Datum r) {
+    return static_cast<Datum>(static_cast<bool>(l) && static_cast<bool>(r));
+}
+static Datum mduck_datum_or(Datum l, Datum r) {
+    return static_cast<Datum>(static_cast<bool>(l) || static_cast<bool>(r));
+}
+static Datum mduck_datum_min_int32(Datum l, Datum r) {
+    int32_t li = static_cast<int32_t>(l);
+    int32_t ri = static_cast<int32_t>(r);
+    return static_cast<Datum>(static_cast<int32_t>(li < ri ? li : ri));
+}
+static Datum mduck_datum_max_int32(Datum l, Datum r) {
+    int32_t li = static_cast<int32_t>(l);
+    int32_t ri = static_cast<int32_t>(r);
+    return static_cast<Datum>(static_cast<int32_t>(li > ri ? li : ri));
+}
+// Float8: PostgreSQL/MEOS pass-by-value convention encodes the IEEE 754 bits
+// of the double in the Datum. Convert via an aliased union to avoid UB.
+static double datum_to_float8(Datum d) {
+    union { uint64_t u; double f; } u;
+    u.u = static_cast<uint64_t>(d);
+    return u.f;
+}
+static Datum float8_to_datum(double f) {
+    union { uint64_t u; double f; } u;
+    u.f = f;
+    return static_cast<Datum>(u.u);
+}
+static Datum mduck_datum_min_float8(Datum l, Datum r) {
+    double lf = datum_to_float8(l);
+    double rf = datum_to_float8(r);
+    return float8_to_datum(lf < rf ? lf : rf);
+}
+static Datum mduck_datum_max_float8(Datum l, Datum r) {
+    double lf = datum_to_float8(l);
+    double rf = datum_to_float8(r);
+    return float8_to_datum(lf > rf ? lf : rf);
+}
+static Datum mduck_datum_sum_float8(Datum l, Datum r) {
+    return float8_to_datum(datum_to_float8(l) + datum_to_float8(r));
+}
+// double2 — internal MEOS struct for {sum, count} pairs used by tavg.
+// Layout per meos/include/temporal/doublen.h: { double a; double b; }
+// MEOS internal (not in public install). We replicate the layout here
+// and provide a sum function for use as the merge function in tavg
+// combine. Allocation matches the palloc path used internally so the
+// MEOS skiplist's free path interoperates with our state.
+struct mduck_double2 {
+    double a;
+    double b;
+};
+static Datum mduck_datum_sum_double2(Datum l, Datum r) {
+    auto *lp = reinterpret_cast<mduck_double2 *>(l);
+    auto *rp = reinterpret_cast<mduck_double2 *>(r);
+    auto *out = reinterpret_cast<mduck_double2 *>(malloc(sizeof(mduck_double2)));
+    out->a = lp->a + rp->a;
+    out->b = lp->b + rp->b;
+    return reinterpret_cast<Datum>(out);
+}
+
+// Text comparison: Datum carries text* (PG varlena). text_cmp is exported
+// from MEOS so we just invoke it on the two pointers and pick whichever
+// Datum we want.
+static Datum mduck_datum_min_text(Datum l, Datum r) {
+    return text_cmp(reinterpret_cast<text *>(l), reinterpret_cast<text *>(r)) < 0 ? l : r;
+}
+static Datum mduck_datum_max_text(Datum l, Datum r) {
+    return text_cmp(reinterpret_cast<text *>(l), reinterpret_cast<text *>(r)) > 0 ? l : r;
+}
+
+template <TempTransfn TRANSFN, Datum (*MERGE_FN)(Datum, Datum), bool CROSSINGS>
+struct SkiplistAggFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.skiplist = nullptr;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+        state.skiplist = TRANSFN(state.skiplist, temp);
+        free(temp);
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.skiplist || source.skiplist->length == 0) {
+            return;
+        }
+        if (!target.skiplist) {
+            const_cast<STATE &>(target).skiplist = temporal_skiplist_make();
+        }
+        void **values = skiplist_values(source.skiplist);
+        int count = source.skiplist->length;
+        temporal_skiplist_splice(target.skiplist, values, count, MERGE_FN, CROSSINGS);
+        free(values);
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.skiplist || state.skiplist->length == 0) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        Temporal *result = temporal_tagg_finalfn(state.skiplist);
+        state.skiplist = nullptr;
+        if (!result) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        size_t out_size = temporal_mem_size(result);
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(result), out_size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+template <TempTransfn TRANSFN, Datum (*MERGE_FN)(Datum, Datum), bool CROSSINGS>
+static AggregateFunction MakeSkiplistAggregate(const LogicalType &input_type, const LogicalType &output_type) {
+    using OPS = SkiplistAggFunction<TRANSFN, MERGE_FN, CROSSINGS>;
+    return AggregateFunction::UnaryAggregateDestructor<TCountState, string_t, string_t, OPS>(
+        input_type, output_type);
+}
+
+// ============================================================================
+// tAvg(tnumber) -> tfloat — Skiplist of {sum, count} pairs.
+//
+// Differs from the generic skiplist pattern in two places:
+//   1. Combine uses mduck_datum_sum_double2 (sum-of-pair merge).
+//   2. Finalize uses tnumber_tavg_finalfn (computes sum/count per
+//      instant) instead of the generic temporal_tagg_finalfn.
+// ============================================================================
+
+struct TAvgFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.skiplist = nullptr;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(input.GetData());
+        size_t size = input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+        state.skiplist = tnumber_tavg_transfn(state.skiplist, temp);
+        free(temp);
+    }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+                                  idx_t /*count*/) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.skiplist || source.skiplist->length == 0) {
+            return;
+        }
+        if (!target.skiplist) {
+            const_cast<STATE &>(target).skiplist = temporal_skiplist_make();
+        }
+        void **values = skiplist_values(source.skiplist);
+        int count = source.skiplist->length;
+        temporal_skiplist_splice(target.skiplist, values, count, &mduck_datum_sum_double2, false);
+        free(values);
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.skiplist || state.skiplist->length == 0) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        Temporal *result = tnumber_tavg_finalfn(state.skiplist);
+        // tnumber_tavg_finalfn calls skiplist_free internally — same
+        // contract as temporal_tagg_finalfn.
+        state.skiplist = nullptr;
+        if (!result) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        size_t out_size = temporal_mem_size(result);
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(result), out_size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+static AggregateFunction MakeTavgAggregate(const LogicalType &input_type) {
+    return AggregateFunction::UnaryAggregateDestructor<TCountState, string_t, string_t, TAvgFunction>(
+        input_type, TemporalTypes::TFLOAT());
+}
+
+// ============================================================================
+// Window aggregates (wmin / wmax / wsum) — Binary input: (Temporal, Interval)
+//
+// Same skiplist state shape as TCountFunction. Difference: Operation takes
+// the window-width interval as second arg and forwards it to the MEOS
+// w*_transfn function. Combine reuses the same merge function as the
+// non-windowed counterpart since the per-instant value layout is identical.
+// ============================================================================
+
+using TempWindowTransfn = SkipList *(*)(SkipList *, const Temporal *, const ::Interval *);
+
+template <TempWindowTransfn TRANSFN, Datum (*MERGE_FN)(Datum, Datum), bool CROSSINGS>
+struct WindowAggFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.skiplist = nullptr;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class A_TYPE, class B_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const A_TYPE &a_input, const B_TYPE &b_input,
+                          AggregateBinaryInput &) {
+        // a_input is string_t holding a Temporal blob.
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(a_input.GetData());
+        size_t size = a_input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+
+        // b_input is duckdb::interval_t; convert to MEOS Interval.
+        MeosInterval interv = IntervaltToInterval(b_input);
+
+        state.skiplist = TRANSFN(state.skiplist, temp, &interv);
+        free(temp);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.skiplist || source.skiplist->length == 0) {
+            return;
+        }
+        if (!target.skiplist) {
+            const_cast<STATE &>(target).skiplist = temporal_skiplist_make();
+        }
+        void **values = skiplist_values(source.skiplist);
+        int count = source.skiplist->length;
+        temporal_skiplist_splice(target.skiplist, values, count, MERGE_FN, CROSSINGS);
+        free(values);
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.skiplist || state.skiplist->length == 0) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        Temporal *result = temporal_tagg_finalfn(state.skiplist);
+        state.skiplist = nullptr;
+        if (!result) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        size_t out_size = temporal_mem_size(result);
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(result), out_size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+template <TempWindowTransfn TRANSFN, Datum (*MERGE_FN)(Datum, Datum), bool CROSSINGS>
+static AggregateFunction MakeWindowAggregate(const LogicalType &input_type, const LogicalType &output_type) {
+    using OPS = WindowAggFunction<TRANSFN, MERGE_FN, CROSSINGS>;
+    AggregateFunction fn = AggregateFunction::BinaryAggregate<TCountState, string_t, interval_t, string_t, OPS>(
+        input_type, LogicalType::INTERVAL, output_type);
+    fn.destructor = AggregateFunction::StateDestroy<TCountState, OPS>;
+    return fn;
+}
+
+// wavg uses tnumber_tavg_finalfn instead of temporal_tagg_finalfn so it
+// has its own functor parametrised on the window transfn only.
+template <TempWindowTransfn TRANSFN>
+struct WavgFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.skiplist = nullptr;
+    }
+
+    static bool IgnoreNull() {
+        return true;
+    }
+
+    template <class A_TYPE, class B_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const A_TYPE &a_input, const B_TYPE &b_input,
+                          AggregateBinaryInput &) {
+        const uint8_t *bytes = reinterpret_cast<const uint8_t *>(a_input.GetData());
+        size_t size = a_input.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, bytes, size);
+        MeosInterval interv = IntervaltToInterval(b_input);
+        state.skiplist = TRANSFN(state.skiplist, temp, &interv);
+        free(temp);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.skiplist || source.skiplist->length == 0) {
+            return;
+        }
+        if (!target.skiplist) {
+            const_cast<STATE &>(target).skiplist = temporal_skiplist_make();
+        }
+        void **values = skiplist_values(source.skiplist);
+        int count = source.skiplist->length;
+        temporal_skiplist_splice(target.skiplist, values, count, &mduck_datum_sum_double2, false);
+        free(values);
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
+        if (!state.skiplist || state.skiplist->length == 0) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        Temporal *result = tnumber_tavg_finalfn(state.skiplist);
+        state.skiplist = nullptr;
+        if (!result) {
+            finalize_data.ReturnNull();
+            return;
+        }
+        size_t out_size = temporal_mem_size(result);
+        target = finalize_data.ReturnString(
+            string_t(reinterpret_cast<const char *>(result), out_size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+template <TempWindowTransfn TRANSFN>
+static AggregateFunction MakeWavgAggregate(const LogicalType &input_type) {
+    using OPS = WavgFunction<TRANSFN>;
+    AggregateFunction fn = AggregateFunction::BinaryAggregate<TCountState, string_t, interval_t, string_t, OPS>(
+        input_type, LogicalType::INTERVAL, TemporalTypes::TFLOAT());
+    fn.destructor = AggregateFunction::StateDestroy<TCountState, OPS>;
+    return fn;
+}
+
+} // namespace
+
+void TemporalAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
+    extent_set.AddFunction(MakeExtentTnumberAggregate(TemporalTypes::TINT()));
+    extent_set.AddFunction(MakeExtentTnumberAggregate(TemporalTypes::TFLOAT()));
+}
+
+void TemporalAggregates::RegisterTCount(ExtensionLoader &loader) {
+    AggregateFunctionSet tcount_set("tCount");
+    for (const auto &t : TemporalTypes::AllTypes()) {
+        AggregateFunction fn =
+            AggregateFunction::UnaryAggregateDestructor<TCountState, string_t, string_t, TCountFunction>(
+                t, TemporalTypes::TINT());
+        tcount_set.AddFunction(fn);
+    }
+    loader.RegisterFunction(std::move(tcount_set));
+}
+
+void TemporalAggregates::RegisterTemporalAggregates(ExtensionLoader &loader) {
+    // tAnd / tOr: tbool only.
+    {
+        AggregateFunctionSet tand_set("tAnd");
+        tand_set.AddFunction(
+            MakeSkiplistAggregate<&tbool_tand_transfn, &mduck_datum_and, false>(
+                TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
+        loader.RegisterFunction(std::move(tand_set));
+
+        AggregateFunctionSet tor_set("tOr");
+        tor_set.AddFunction(
+            MakeSkiplistAggregate<&tbool_tor_transfn, &mduck_datum_or, false>(
+                TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
+        loader.RegisterFunction(std::move(tor_set));
+    }
+
+    // tMin / tMax / tSum: registered as tagg_min / tagg_max / tagg_sum
+    // because the names Tmin / Tmax are already taken by scalar
+    // time-min / time-max accessors on tbox / stbox (registered in
+    // src/temporal/tbox.cpp and src/geo/stbox.cpp). DuckDB's catalog
+    // is case-insensitive at the name level, so registering an
+    // aggregate with the same lowercased name as an existing scalar
+    // triggers an ALTER path that CreateAggregateFunctionInfo doesn't
+    // support and the extension fails to load.
+    {
+        AggregateFunctionSet tmin_set("tagg_min");
+        tmin_set.AddFunction(
+            MakeSkiplistAggregate<&tint_tmin_transfn, &mduck_datum_min_int32, false>(
+                TemporalTypes::TINT(), TemporalTypes::TINT()));
+        tmin_set.AddFunction(
+            MakeSkiplistAggregate<&tfloat_tmin_transfn, &mduck_datum_min_float8, true>(
+                TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        tmin_set.AddFunction(
+            MakeSkiplistAggregate<&ttext_tmin_transfn, &mduck_datum_min_text, false>(
+                TemporalTypes::TTEXT(), TemporalTypes::TTEXT()));
+        loader.RegisterFunction(std::move(tmin_set));
+
+        AggregateFunctionSet tmax_set("tagg_max");
+        tmax_set.AddFunction(
+            MakeSkiplistAggregate<&tint_tmax_transfn, &mduck_datum_max_int32, false>(
+                TemporalTypes::TINT(), TemporalTypes::TINT()));
+        tmax_set.AddFunction(
+            MakeSkiplistAggregate<&tfloat_tmax_transfn, &mduck_datum_max_float8, true>(
+                TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        tmax_set.AddFunction(
+            MakeSkiplistAggregate<&ttext_tmax_transfn, &mduck_datum_max_text, false>(
+                TemporalTypes::TTEXT(), TemporalTypes::TTEXT()));
+        loader.RegisterFunction(std::move(tmax_set));
+
+        AggregateFunctionSet tsum_set("tagg_sum");
+        tsum_set.AddFunction(
+            MakeSkiplistAggregate<&tint_tsum_transfn, &mduck_datum_sum_int32, false>(
+                TemporalTypes::TINT(), TemporalTypes::TINT()));
+        tsum_set.AddFunction(
+            MakeSkiplistAggregate<&tfloat_tsum_transfn, &mduck_datum_sum_float8, true>(
+                TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(tsum_set));
+    }
+}
+
+void TemporalAggregates::RegisterWindowAggregates(ExtensionLoader &loader) {
+    // wmin: tint, tfloat
+    {
+        AggregateFunctionSet wmin_set("wmin");
+        wmin_set.AddFunction(
+            MakeWindowAggregate<&tint_wmin_transfn, &mduck_datum_min_int32, false>(
+                TemporalTypes::TINT(), TemporalTypes::TINT()));
+        wmin_set.AddFunction(
+            MakeWindowAggregate<&tfloat_wmin_transfn, &mduck_datum_min_float8, true>(
+                TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(wmin_set));
+    }
+    // wmax: tint, tfloat
+    {
+        AggregateFunctionSet wmax_set("wmax");
+        wmax_set.AddFunction(
+            MakeWindowAggregate<&tint_wmax_transfn, &mduck_datum_max_int32, false>(
+                TemporalTypes::TINT(), TemporalTypes::TINT()));
+        wmax_set.AddFunction(
+            MakeWindowAggregate<&tfloat_wmax_transfn, &mduck_datum_max_float8, true>(
+                TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(wmax_set));
+    }
+    // wsum: tint, tfloat
+    {
+        AggregateFunctionSet wsum_set("wsum");
+        wsum_set.AddFunction(
+            MakeWindowAggregate<&tint_wsum_transfn, &mduck_datum_sum_int32, false>(
+                TemporalTypes::TINT(), TemporalTypes::TINT()));
+        wsum_set.AddFunction(
+            MakeWindowAggregate<&tfloat_wsum_transfn, &mduck_datum_sum_float8, true>(
+                TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(wsum_set));
+    }
+    // wavg: tnumber (output is tfloat).
+    {
+        AggregateFunctionSet wavg_set("wavg");
+        wavg_set.AddFunction(MakeWavgAggregate<&tnumber_wavg_transfn>(TemporalTypes::TINT()));
+        wavg_set.AddFunction(MakeWavgAggregate<&tnumber_wavg_transfn>(TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(wavg_set));
+    }
+}
+
+void TemporalAggregates::RegisterTAvg(ExtensionLoader &loader) {
+    AggregateFunctionSet tavg_set("tAvg");
+    tavg_set.AddFunction(MakeTavgAggregate(TemporalTypes::TINT()));
+    tavg_set.AddFunction(MakeTavgAggregate(TemporalTypes::TFLOAT()));
+    loader.RegisterFunction(std::move(tavg_set));
+}
+
+} // namespace duckdb


### PR DESCRIPTION
## Summary

Adds the temporal-centroid aggregate — per-instant geographic centroid across a column of tgeompoint values.

\`\`\`sql
SELECT asText(tCentroid(t)) FROM (VALUES (tgeompoint 'Point(0 0)@2000-01-01'),
                                          (tgeompoint 'Point(2 2)@2000-01-01')) tt(t);
-- {POINT(1 1)@2000-01-01 00:00:00+00}
\`\`\`

## Implementation

State holds a \`SkipList\` of \`(sum_x, sum_y, count)\` triples for 2D points or \`(sum_x, sum_y, sum_z, count)\` quadruples for 3D points.

| Step | What it does |
|---|---|
| \`Operation\` | Calls \`tpoint_tcentroid_transfn\` which sets up the skiplist's \`extra\` field (\`GeoAggregateState\`: srid + hasz). |
| \`Combine\` | When target is empty, takes ownership of source's skiplist (preserves \`extra\`). When both have data, splices via \`mduck_datum_sum_double3\` or \`double4\` as chosen by the source's \`hasz\` flag. |
| \`Finalize\` | Calls \`tpoint_tcentroid_finalfn\` which divides each instant's \`(sum_x, sum_y[, sum_z])\` by \`count\` and frees the skiplist. |

\`datum_sum_double3\` / \`double4\` and \`GeoAggregateState\` are not exported by MEOS public headers; their layouts are simple enough to replicate locally:

\`\`\`cpp
struct mduck_double3 { double a, b, c; };          // (sum_x, sum_y, count)
struct mduck_double4 { double a, b, c, d; };       // (sum_x, sum_y, sum_z, count)
struct mduck_geo_agg_state { int32_t srid; bool hasz; };
\`\`\`

## Test plan
- [x] Single-row tCentroid returns the input point unchanged
- [x] Two-row same-instant centroid produces the midpoint correctly
- [x] No segfault on cleanup (destructor + finalfn double-free guard)