### PR TITLE
feat(bindings): bins(span | spanset, vsize, vorigin) table function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(EXTENSION_SOURCES
     src/temporal/set_functions.cpp
     src/temporal/span.cpp
     src/temporal/span_functions.cpp
+    src/temporal/span_table_functions.cpp
     src/geo/geoset.cpp
     src/temporal/spanset.cpp
     src/temporal/spanset_functions.cpp

--- a/src/include/temporal/span_table_functions.hpp
+++ b/src/include/temporal/span_table_functions.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+struct SpanTableFunctions {
+    static void RegisterBins(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -12,6 +12,7 @@
 #include "duckdb.hpp"
 #include "geo/tgeometry.hpp"
 #include "temporal/span.hpp"
+#include "temporal/span_table_functions.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar_function.hpp"
@@ -243,6 +244,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	SpanTypes::RegisterScalarFunctions(loader);
 	SpanTypes::RegisterTypes(loader);
 	SpanTypes::RegisterCastFunctions(loader);
+	SpanTableFunctions::RegisterBins(loader);
 
 	TgeompointType::RegisterType(loader);
 	TgeompointType::RegisterCastFunctions(loader);

--- a/src/temporal/span_table_functions.cpp
+++ b/src/temporal/span_table_functions.cpp
@@ -1,0 +1,267 @@
+#include "meos_wrapper_simple.hpp"
+
+#include "temporal/span.hpp"
+#include "temporal/span_table_functions.hpp"
+#include "temporal/spanset.hpp"
+#include "time_util.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+namespace {
+
+// Tag identifying the input span / spanset variant. Drives which MEOS
+// function the global-state init dispatches to.
+enum class BinsKind {
+    INTSPAN,
+    BIGINTSPAN,
+    FLOATSPAN,
+    DATESPAN,
+    TSTZSPAN,
+    INTSPANSET,
+    BIGINTSPANSET,
+    FLOATSPANSET,
+    DATESPANSET,
+    TSTZSPANSET,
+};
+
+struct BinsBindData : public FunctionData {
+    BinsKind kind;
+    LogicalType output_span_type;
+    // Captured constant arguments — bins() args are constants (the input
+    // span/spanset blob, the vsize/duration, and the vorigin/torigin).
+    string blob;
+    Value vsize;
+    Value vorigin;
+
+    unique_ptr<FunctionData> Copy() const override {
+        auto r = make_uniq<BinsBindData>();
+        r->kind = kind;
+        r->output_span_type = output_span_type;
+        r->blob = blob;
+        r->vsize = vsize;
+        r->vorigin = vorigin;
+        return r;
+    }
+    bool Equals(const FunctionData &other_p) const override {
+        auto &other = other_p.Cast<BinsBindData>();
+        return kind == other.kind && blob == other.blob && vsize == other.vsize && vorigin == other.vorigin;
+    }
+};
+
+// Materializes the bin array on first row of execution. Stores the
+// flat array of span bytes plus the count.
+struct BinsGlobalState : public GlobalTableFunctionState {
+    Span *bins = nullptr;
+    int count = 0;
+    int offset = 0;
+
+    ~BinsGlobalState() {
+        if (bins) {
+            free(bins);
+        }
+    }
+};
+
+static unique_ptr<GlobalTableFunctionState> BinsInitGlobal(ClientContext &, TableFunctionInitInput &input) {
+    auto &bind_data = input.bind_data->Cast<BinsBindData>();
+    auto state = make_uniq<BinsGlobalState>();
+
+    const void *raw_blob = bind_data.blob.data();
+    size_t raw_size = bind_data.blob.size();
+
+    switch (bind_data.kind) {
+        case BinsKind::INTSPAN: {
+            Span *s = reinterpret_cast<Span *>(malloc(raw_size));
+            memcpy(s, raw_blob, raw_size);
+            state->bins = intspan_bins(s, bind_data.vsize.GetValue<int32_t>(),
+                                       bind_data.vorigin.GetValue<int32_t>(), &state->count);
+            free(s);
+            break;
+        }
+        case BinsKind::BIGINTSPAN: {
+            Span *s = reinterpret_cast<Span *>(malloc(raw_size));
+            memcpy(s, raw_blob, raw_size);
+            state->bins = bigintspan_bins(s, bind_data.vsize.GetValue<int64_t>(),
+                                          bind_data.vorigin.GetValue<int64_t>(), &state->count);
+            free(s);
+            break;
+        }
+        case BinsKind::FLOATSPAN: {
+            Span *s = reinterpret_cast<Span *>(malloc(raw_size));
+            memcpy(s, raw_blob, raw_size);
+            state->bins = floatspan_bins(s, bind_data.vsize.GetValue<double>(),
+                                         bind_data.vorigin.GetValue<double>(), &state->count);
+            free(s);
+            break;
+        }
+        case BinsKind::DATESPAN: {
+            Span *s = reinterpret_cast<Span *>(malloc(raw_size));
+            memcpy(s, raw_blob, raw_size);
+            interval_t duck_duration = bind_data.vsize.GetValue<interval_t>();
+            MeosInterval duration = IntervaltToInterval(duck_duration);
+            int32_t torigin = ToMeosDate(bind_data.vorigin.GetValue<date_t>());
+            state->bins = datespan_bins(s, &duration, torigin, &state->count);
+            free(s);
+            break;
+        }
+        case BinsKind::TSTZSPAN: {
+            Span *s = reinterpret_cast<Span *>(malloc(raw_size));
+            memcpy(s, raw_blob, raw_size);
+            interval_t duck_duration = bind_data.vsize.GetValue<interval_t>();
+            MeosInterval duration = IntervaltToInterval(duck_duration);
+            timestamp_tz_t in_ts;
+            in_ts.value = bind_data.vorigin.GetValueUnsafe<timestamp_t>().value;
+            timestamp_tz_t meos_ts = DuckDBToMeosTimestamp(in_ts);
+            state->bins = tstzspan_bins(s, &duration, meos_ts.value, &state->count);
+            free(s);
+            break;
+        }
+        case BinsKind::INTSPANSET: {
+            SpanSet *ss = reinterpret_cast<SpanSet *>(malloc(raw_size));
+            memcpy(ss, raw_blob, raw_size);
+            state->bins = intspanset_bins(ss, bind_data.vsize.GetValue<int32_t>(),
+                                          bind_data.vorigin.GetValue<int32_t>(), &state->count);
+            free(ss);
+            break;
+        }
+        case BinsKind::BIGINTSPANSET: {
+            SpanSet *ss = reinterpret_cast<SpanSet *>(malloc(raw_size));
+            memcpy(ss, raw_blob, raw_size);
+            state->bins = bigintspanset_bins(ss, bind_data.vsize.GetValue<int64_t>(),
+                                             bind_data.vorigin.GetValue<int64_t>(), &state->count);
+            free(ss);
+            break;
+        }
+        case BinsKind::FLOATSPANSET: {
+            SpanSet *ss = reinterpret_cast<SpanSet *>(malloc(raw_size));
+            memcpy(ss, raw_blob, raw_size);
+            state->bins = floatspanset_bins(ss, bind_data.vsize.GetValue<double>(),
+                                            bind_data.vorigin.GetValue<double>(), &state->count);
+            free(ss);
+            break;
+        }
+        case BinsKind::DATESPANSET: {
+            SpanSet *ss = reinterpret_cast<SpanSet *>(malloc(raw_size));
+            memcpy(ss, raw_blob, raw_size);
+            interval_t duck_duration = bind_data.vsize.GetValue<interval_t>();
+            MeosInterval duration = IntervaltToInterval(duck_duration);
+            int32_t torigin = ToMeosDate(bind_data.vorigin.GetValue<date_t>());
+            state->bins = datespanset_bins(ss, &duration, torigin, &state->count);
+            free(ss);
+            break;
+        }
+        case BinsKind::TSTZSPANSET: {
+            SpanSet *ss = reinterpret_cast<SpanSet *>(malloc(raw_size));
+            memcpy(ss, raw_blob, raw_size);
+            interval_t duck_duration = bind_data.vsize.GetValue<interval_t>();
+            MeosInterval duration = IntervaltToInterval(duck_duration);
+            timestamp_tz_t in_ts;
+            in_ts.value = bind_data.vorigin.GetValueUnsafe<timestamp_t>().value;
+            timestamp_tz_t meos_ts = DuckDBToMeosTimestamp(in_ts);
+            state->bins = tstzspanset_bins(ss, &duration, meos_ts.value, &state->count);
+            free(ss);
+            break;
+        }
+    }
+    return std::move(state);
+}
+
+static void BinsExecute(ClientContext &, TableFunctionInput &data_p, DataChunk &output) {
+    auto &state = data_p.global_state->Cast<BinsGlobalState>();
+    if (state.offset >= state.count) {
+        output.SetCardinality(0);
+        return;
+    }
+    idx_t row = 0;
+    auto &out_vec = output.data[0];
+    auto *out_data = FlatVector::GetData<string_t>(out_vec);
+    while (state.offset < state.count && row < STANDARD_VECTOR_SIZE) {
+        out_data[row] = StringVector::AddStringOrBlob(
+            out_vec, reinterpret_cast<const char *>(&state.bins[state.offset]), sizeof(Span));
+        state.offset++;
+        row++;
+    }
+    output.SetCardinality(row);
+}
+
+template <BinsKind KIND>
+static unique_ptr<FunctionData> BinsBind(ClientContext &, TableFunctionBindInput &input,
+                                          vector<LogicalType> &return_types, vector<string> &names) {
+    if (input.inputs.size() != 3) {
+        throw BinderException("bins(...) requires exactly 3 arguments");
+    }
+    for (idx_t i = 0; i < 3; i++) {
+        if (input.inputs[i].IsNull()) {
+            throw BinderException("bins(...) does not accept NULL arguments");
+        }
+    }
+
+    auto data = make_uniq<BinsBindData>();
+    data->kind = KIND;
+    auto blob = input.inputs[0].GetValueUnsafe<string_t>();
+    data->blob.assign(blob.GetData(), blob.GetSize());
+    data->vsize = input.inputs[1];
+    data->vorigin = input.inputs[2];
+
+    LogicalType span_out;
+    switch (KIND) {
+        case BinsKind::INTSPAN:
+        case BinsKind::INTSPANSET:    span_out = SpanTypes::INTSPAN(); break;
+        case BinsKind::BIGINTSPAN:
+        case BinsKind::BIGINTSPANSET: span_out = SpanTypes::BIGINTSPAN(); break;
+        case BinsKind::FLOATSPAN:
+        case BinsKind::FLOATSPANSET:  span_out = SpanTypes::FLOATSPAN(); break;
+        case BinsKind::DATESPAN:
+        case BinsKind::DATESPANSET:   span_out = SpanTypes::DATESPAN(); break;
+        case BinsKind::TSTZSPAN:
+        case BinsKind::TSTZSPANSET:   span_out = SpanTypes::TSTZSPAN(); break;
+    }
+    data->output_span_type = span_out;
+    return_types.emplace_back(span_out);
+    names.emplace_back("bin");
+    return std::move(data);
+}
+
+template <BinsKind KIND>
+static TableFunction MakeBinsFunction(const LogicalType &input_type, const LogicalType &vsize_type,
+                                       const LogicalType &vorigin_type) {
+    return TableFunction("bins",
+                         {input_type, vsize_type, vorigin_type},
+                         BinsExecute,
+                         BinsBind<KIND>,
+                         BinsInitGlobal);
+}
+
+} // namespace
+
+void SpanTableFunctions::RegisterBins(ExtensionLoader &loader) {
+    // span variants
+    loader.RegisterFunction(MakeBinsFunction<BinsKind::INTSPAN>(
+        SpanTypes::INTSPAN(), LogicalType::INTEGER, LogicalType::INTEGER));
+    loader.RegisterFunction(MakeBinsFunction<BinsKind::BIGINTSPAN>(
+        SpanTypes::BIGINTSPAN(), LogicalType::BIGINT, LogicalType::BIGINT));
+    loader.RegisterFunction(MakeBinsFunction<BinsKind::FLOATSPAN>(
+        SpanTypes::FLOATSPAN(), LogicalType::DOUBLE, LogicalType::DOUBLE));
+    loader.RegisterFunction(MakeBinsFunction<BinsKind::DATESPAN>(
+        SpanTypes::DATESPAN(), LogicalType::INTERVAL, LogicalType::DATE));
+    loader.RegisterFunction(MakeBinsFunction<BinsKind::TSTZSPAN>(
+        SpanTypes::TSTZSPAN(), LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ));
+
+    // spanset variants
+    loader.RegisterFunction(MakeBinsFunction<BinsKind::INTSPANSET>(
+        SpansetTypes::intspanset(), LogicalType::INTEGER, LogicalType::INTEGER));
+    loader.RegisterFunction(MakeBinsFunction<BinsKind::BIGINTSPANSET>(
+        SpansetTypes::bigintspanset(), LogicalType::BIGINT, LogicalType::BIGINT));
+    loader.RegisterFunction(MakeBinsFunction<BinsKind::FLOATSPANSET>(
+        SpansetTypes::floatspanset(), LogicalType::DOUBLE, LogicalType::DOUBLE));
+    loader.RegisterFunction(MakeBinsFunction<BinsKind::DATESPANSET>(
+        SpansetTypes::datespanset(), LogicalType::INTERVAL, LogicalType::DATE));
+    loader.RegisterFunction(MakeBinsFunction<BinsKind::TSTZSPANSET>(
+        SpansetTypes::tstzspanset(), LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ));
+}
+
+} // namespace duckdb


### PR DESCRIPTION
## Summary

Adds the first MobilityDuck TableFunction registration: \`bins()\` that partitions a span (or spanset) into uniformly-sized bins anchored at a given origin and emits one row per bin.

\`\`\`sql
SELECT bin FROM bins(intspan '[1, 10)', 2, 0);
-- [0, 2)
-- [2, 4)
-- [4, 6)
-- [6, 8)
-- [8, 10)

SELECT bin FROM bins(tstzspan '[2000-01-01, 2000-01-04)',
                     INTERVAL '1 day',
                     TIMESTAMPTZ '2000-01-01');
-- [2000-01-01, 2000-01-02)
-- [2000-01-02, 2000-01-03)
-- [2000-01-03, 2000-01-04)
\`\`\`

## Coverage

10 overloads — every span / spanset base type:

| Input | vsize | vorigin |
|---|---|---|
| \`intspan\` / \`intspanset\` | \`INTEGER\` | \`INTEGER\` |
| \`bigintspan\` / \`bigintspanset\` | \`BIGINT\` | \`BIGINT\` |
| \`floatspan\` / \`floatspanset\` | \`DOUBLE\` | \`DOUBLE\` |
| \`datespan\` / \`datespanset\` | \`INTERVAL\` | \`DATE\` |
| \`tstzspan\` / \`tstzspanset\` | \`INTERVAL\` | \`TIMESTAMP_TZ\` |

Each overload returns a one-column relation \`(bin <span>)\` matching the input's base type.

## Implementation

| Component | What it does |
|---|---|
| \`BinsKind\` enum | 10-way tag dispatching to the right MEOS \`*_bins\` function. |
| \`BinsBindData\` (\`FunctionData\`) | Captures the three constant arguments at bind time and the chosen output span type. |
| \`BinsInitGlobal\` | Allocates the MEOS-managed \`Span *bins\` array via the appropriate MEOS \`*_bins(s, vsize, vorigin, &count)\` call. |
| \`BinsExecute\` | Emits up to \`STANDARD_VECTOR_SIZE\` rows per chunk; advances state offset. |
| \`~BinsGlobalState\` | Frees the MEOS-allocated array. |

Date and timestamptz inputs are converted from DuckDB's 1970 epoch to MEOS's 2000 epoch via the existing \`time_util.hpp\` helpers. Output bins are stored in MEOS-native epoch form, which round-trips correctly through the span in/out functions.

This establishes the \`bind\` / \`init_global\` / \`execute\` scaffolding that follow-up table functions (\`tsample\`, \`tprecision\`, \`similarityPath\`, \`tspatial_value/time_split\`) can reuse.

## Test plan
- [x] All 10 overloads emit the expected bins for representative inputs
- [x] Date / timestamptz round-trip correctly across the epoch boundary
- [x] Chunk boundary handled (output stops at \`STANDARD_VECTOR_SIZE\`, advances offset for next chunk)
- [x] Destructor frees the MEOS array