### PR TITLE
feat(bindings): tprecision / tsample scalar functions

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -492,6 +492,8 @@ struct TemporalFunctions {
      ****************************************************/
     static void Temporal_round(DataChunk &args, ExpressionState &state, Vector &result);
     static void Temporal_derivative(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_tprecision(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_tsample(DataChunk &args, ExpressionState &state, Vector &result);
 };
 
 } // namespace duckdb

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1348,6 +1348,28 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("abs", {TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Tnumber_abs));
     loader.RegisterFunction(ScalarFunction("abs", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tnumber_abs));
     loader.RegisterFunction(ScalarFunction("derivative", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Temporal_derivative));
+
+    // tprecision / tsample: round each instant's timestamp down to the
+    // nearest bin (tprecision) or resample the value at fixed intervals
+    // (tsample). 3-arg signature: (temp, duration, origin). tsample also
+    // has a 4-arg variant taking an interpolation hint as VARCHAR.
+    for (auto &t : TemporalTypes::AllTypes()) {
+        loader.RegisterFunction(ScalarFunction(
+            "tprecision",
+            {t, LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ},
+            t,
+            TemporalFunctions::Temporal_tprecision));
+        loader.RegisterFunction(ScalarFunction(
+            "tsample",
+            {t, LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ},
+            t,
+            TemporalFunctions::Temporal_tsample));
+        loader.RegisterFunction(ScalarFunction(
+            "tsample",
+            {t, LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ, LogicalType::VARCHAR},
+            t,
+            TemporalFunctions::Temporal_tsample));
+    }
     loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
     loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT(), LogicalType::BOOLEAN}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
     loader.RegisterFunction(ScalarFunction("radians", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_radians));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5536,6 +5536,101 @@ void TemporalFunctions::Temporal_round(DataChunk &args, ExpressionState &state, 
     }
 }
 
+void TemporalFunctions::Temporal_tprecision(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto row_count = args.size();
+    auto &temp_vec = args.data[0];
+    auto &dur_vec = args.data[1];
+    auto &origin_vec = args.data[2];
+    temp_vec.Flatten(row_count);
+    dur_vec.Flatten(row_count);
+    origin_vec.Flatten(row_count);
+
+    auto *temp_data = FlatVector::GetData<string_t>(temp_vec);
+    auto *dur_data = FlatVector::GetData<interval_t>(dur_vec);
+    auto *origin_data = FlatVector::GetData<timestamp_t>(origin_vec);
+    auto &result_validity = FlatVector::Validity(result);
+    auto *result_data = FlatVector::GetData<string_t>(result);
+
+    for (idx_t i = 0; i < row_count; i++) {
+        if (FlatVector::IsNull(temp_vec, i) || FlatVector::IsNull(dur_vec, i) || FlatVector::IsNull(origin_vec, i)) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        const string_t &blob = temp_data[i];
+        size_t size = blob.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, blob.GetData(), size);
+
+        MeosInterval duration = IntervaltToInterval(dur_data[i]);
+        timestamp_tz_t in_ts;
+        in_ts.value = origin_data[i].value;
+        timestamp_tz_t meos_origin = DuckDBToMeosTimestamp(in_ts);
+
+        Temporal *ret = temporal_tprecision(temp, &duration, meos_origin.value);
+        free(temp);
+        if (!ret) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        size_t out_size = temporal_mem_size(ret);
+        result_data[i] = StringVector::AddStringOrBlob(result, (const char *)ret, out_size);
+        free(ret);
+    }
+}
+
+void TemporalFunctions::Temporal_tsample(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto row_count = args.size();
+    auto arg_count = args.ColumnCount();
+    auto &temp_vec = args.data[0];
+    auto &dur_vec = args.data[1];
+    auto &origin_vec = args.data[2];
+    temp_vec.Flatten(row_count);
+    dur_vec.Flatten(row_count);
+    origin_vec.Flatten(row_count);
+
+    Vector *interp_vec = nullptr;
+    if (arg_count > 3) {
+        args.data[3].Flatten(row_count);
+        interp_vec = &args.data[3];
+    }
+
+    auto *temp_data = FlatVector::GetData<string_t>(temp_vec);
+    auto *dur_data = FlatVector::GetData<interval_t>(dur_vec);
+    auto *origin_data = FlatVector::GetData<timestamp_t>(origin_vec);
+    auto &result_validity = FlatVector::Validity(result);
+    auto *result_data = FlatVector::GetData<string_t>(result);
+
+    for (idx_t i = 0; i < row_count; i++) {
+        if (FlatVector::IsNull(temp_vec, i) || FlatVector::IsNull(dur_vec, i) || FlatVector::IsNull(origin_vec, i) ||
+            (interp_vec && FlatVector::IsNull(*interp_vec, i))) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        const string_t &blob = temp_data[i];
+        size_t size = blob.GetSize();
+        Temporal *temp = reinterpret_cast<Temporal *>(malloc(size));
+        memcpy(temp, blob.GetData(), size);
+
+        MeosInterval duration = IntervaltToInterval(dur_data[i]);
+        timestamp_tz_t in_ts;
+        in_ts.value = origin_data[i].value;
+        timestamp_tz_t meos_origin = DuckDBToMeosTimestamp(in_ts);
+
+        interpType interp = interptype_from_string(
+            interp_vec ? FlatVector::GetData<string_t>(*interp_vec)[i].GetString().c_str() : "linear");
+
+        Temporal *ret = temporal_tsample(temp, &duration, meos_origin.value, interp);
+        free(temp);
+        if (!ret) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        size_t out_size = temporal_mem_size(ret);
+        result_data[i] = StringVector::AddStringOrBlob(result, (const char *)ret, out_size);
+        free(ret);
+    }
+}
+
 void TemporalFunctions::Temporal_derivative(DataChunk &args, ExpressionState &state, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),


### PR DESCRIPTION
## Summary

Wraps MEOS \`temporal_tprecision\` and \`temporal_tsample\` as DuckDB scalar functions. Despite the \"sample\" naming, these produce a single Temporal output per Temporal input — they are not table functions.

\`\`\`sql
SELECT tprecision(tfloat '[1@2000-01-01, 5@2000-01-05]',
                  INTERVAL '1 day',
                  TIMESTAMPTZ '2000-01-01');
-- [1.02@1999-12-31, 1.54@2000-01-01, 3.54@2000-01-03, 4.52@2000-01-04]

SELECT tsample(tfloat '[1@2000-01-01, 5@2000-01-05]',
               INTERVAL '1 day',
               TIMESTAMPTZ '2000-01-01');
-- [1.04@2000-01-01, 4.04@2000-01-04]
\`\`\`

## Coverage

| Function | Inputs | Output |
|---|---|---|
| \`tprecision\` | \`(temporal, INTERVAL, TIMESTAMP_TZ)\` | same temporal type |
| \`tsample\` | \`(temporal, INTERVAL, TIMESTAMP_TZ)\` | same temporal type |
| \`tsample\` | \`(temporal, INTERVAL, TIMESTAMP_TZ, VARCHAR interp)\` | same temporal type |

Registered for \`tbool\`, \`tint\`, \`tfloat\`, \`ttext\` (every temporal base type).

For \`tsample\`'s optional interpolation argument we accept any VARCHAR that MEOS \`interptype_from_string\` parses (\`linear\` / \`step\` / \`discrete\`); the 3-arg form defaults to \`linear\`.

Date / timestamptz origin is converted from DuckDB's 1970 epoch to MEOS's 2000 epoch via the existing \`time_util.hpp\` helper. The \`INTERVAL\` duration is converted via \`IntervaltToInterval\`.

## Stacked on
- #62 (bins TableFunction) — same time_util.hpp helpers; not a hard dep but logical chain

## Test plan
- [x] tprecision and tsample both produce expected resampled outputs
- [x] All four temporal base types compile and link