### PR TITLE
feat(bindings): tbox WKB/hex-WKB serialization + hashing

### DIFF
--- a/src/include/temporal/tbox_functions.hpp
+++ b/src/include/temporal/tbox_functions.hpp
@@ -160,6 +160,15 @@ struct TboxFunctions {
     static void Tbox_gt(DataChunk &args, ExpressionState &state, Vector &result);
     static void Tbox_cmp(DataChunk &args, ExpressionState &state, Vector &result);
 
+    /* ***************************************************
+     * WKB / hex-WKB serialization + hashing
+     ****************************************************/
+    static void Tbox_as_wkb(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tbox_as_hexwkb(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tbox_from_wkb(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tbox_from_hexwkb(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tbox_hash(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tbox_hash_extended(DataChunk &args, ExpressionState &state, Vector &result);
 };
 
 } // namespace duckdb

--- a/src/temporal/tbox.cpp
+++ b/src/temporal/tbox.cpp
@@ -939,6 +939,28 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TboxFunctions::Tbox_gt
         )
     );
+
+    /* ***************************************************
+     * WKB / hex-WKB serialization + hashing
+     ****************************************************/
+    loader.RegisterFunction(ScalarFunction(
+        "asBinary", {TBOX()}, LogicalType::BLOB,
+        TboxFunctions::Tbox_as_wkb));
+    loader.RegisterFunction(ScalarFunction(
+        "asHexWKB", {TBOX()}, LogicalType::VARCHAR,
+        TboxFunctions::Tbox_as_hexwkb));
+    loader.RegisterFunction(ScalarFunction(
+        "tboxFromBinary", {LogicalType::BLOB}, TBOX(),
+        TboxFunctions::Tbox_from_wkb));
+    loader.RegisterFunction(ScalarFunction(
+        "tboxFromHexWKB", {LogicalType::VARCHAR}, TBOX(),
+        TboxFunctions::Tbox_from_hexwkb));
+    loader.RegisterFunction(ScalarFunction(
+        "tbox_hash", {TBOX()}, LogicalType::INTEGER,
+        TboxFunctions::Tbox_hash));
+    loader.RegisterFunction(ScalarFunction(
+        "tbox_hash_extended", {TBOX(), LogicalType::BIGINT}, LogicalType::BIGINT,
+        TboxFunctions::Tbox_hash_extended));
 }
 
 } // namespace duckdb

--- a/src/temporal/tbox_functions.cpp
+++ b/src/temporal/tbox_functions.cpp
@@ -1861,4 +1861,156 @@ void TboxFunctions::Tbox_cmp(DataChunk &args, ExpressionState &state, Vector &re
     }
 }
 
+/* ***************************************************
+ * WKB / hex-WKB serialization + hashing
+ ****************************************************/
+
+void TboxFunctions::Tbox_as_wkb(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() < sizeof(TBox)) {
+                throw InvalidInputException("asBinary: invalid TBox value");
+            }
+            uint8_t *copy = (uint8_t *)malloc(input.GetSize());
+            memcpy(copy, input.GetData(), input.GetSize());
+            TBox *tbox = reinterpret_cast<TBox *>(copy);
+            size_t wkb_size = 0;
+            uint8_t *wkb = tbox_as_wkb(tbox, WKB_EXTENDED, &wkb_size);
+            free(copy);
+            if (!wkb || wkb_size == 0) {
+                if (wkb) free(wkb);
+                throw InternalException("asBinary: tbox_as_wkb failed");
+            }
+            string_t ret(reinterpret_cast<const char *>(wkb), wkb_size);
+            string_t stored = StringVector::AddStringOrBlob(result, ret);
+            free(wkb);
+            return stored;
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+void TboxFunctions::Tbox_as_hexwkb(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() < sizeof(TBox)) {
+                throw InvalidInputException("asHexWKB: invalid TBox value");
+            }
+            uint8_t *copy = (uint8_t *)malloc(input.GetSize());
+            memcpy(copy, input.GetData(), input.GetSize());
+            TBox *tbox = reinterpret_cast<TBox *>(copy);
+            size_t hex_size = 0;
+            char *hex = tbox_as_hexwkb(tbox, WKB_EXTENDED, &hex_size);
+            (void)hex_size;
+            free(copy);
+            if (!hex) {
+                throw InternalException("asHexWKB: tbox_as_hexwkb failed");
+            }
+            string_t stored = StringVector::AddString(result, hex);
+            free(hex);
+            return stored;
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+void TboxFunctions::Tbox_from_wkb(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input_wkb) -> string_t {
+            if (input_wkb.GetSize() == 0) {
+                throw InvalidInputException("tboxFromBinary: empty input");
+            }
+            uint8_t *wkb = (uint8_t *)malloc(input_wkb.GetSize());
+            memcpy(wkb, input_wkb.GetData(), input_wkb.GetSize());
+            TBox *tbox = tbox_from_wkb(wkb, input_wkb.GetSize());
+            free(wkb);
+            if (!tbox) {
+                throw InvalidInputException("tboxFromBinary: invalid WKB");
+            }
+            size_t sz = sizeof(TBox);
+            uint8_t *out = (uint8_t *)malloc(sz);
+            memcpy(out, tbox, sz);
+            string_t ret(reinterpret_cast<const char *>(out), sz);
+            string_t stored = StringVector::AddStringOrBlob(result, ret);
+            free(out);
+            free(tbox);
+            return stored;
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+void TboxFunctions::Tbox_from_hexwkb(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input_hex) -> string_t {
+            std::string hex(input_hex.GetData(), input_hex.GetSize());
+            TBox *tbox = tbox_from_hexwkb(hex.c_str());
+            if (!tbox) {
+                throw InvalidInputException("tboxFromHexWKB: invalid hex-WKB");
+            }
+            size_t sz = sizeof(TBox);
+            uint8_t *out = (uint8_t *)malloc(sz);
+            memcpy(out, tbox, sz);
+            string_t ret(reinterpret_cast<const char *>(out), sz);
+            string_t stored = StringVector::AddStringOrBlob(result, ret);
+            free(out);
+            free(tbox);
+            return stored;
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+void TboxFunctions::Tbox_hash(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, int32_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> int32_t {
+            if (input.GetSize() < sizeof(TBox)) {
+                throw InvalidInputException("tbox_hash: invalid TBox value");
+            }
+            uint8_t *copy = (uint8_t *)malloc(input.GetSize());
+            memcpy(copy, input.GetData(), input.GetSize());
+            TBox *tbox = reinterpret_cast<TBox *>(copy);
+            uint32_t h = tbox_hash(tbox);
+            free(copy);
+            return static_cast<int32_t>(h);
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+void TboxFunctions::Tbox_hash_extended(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, int64_t, int64_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t input, int64_t seed) -> int64_t {
+            if (input.GetSize() < sizeof(TBox)) {
+                throw InvalidInputException("tbox_hash_extended: invalid TBox value");
+            }
+            uint8_t *copy = (uint8_t *)malloc(input.GetSize());
+            memcpy(copy, input.GetData(), input.GetSize());
+            TBox *tbox = reinterpret_cast<TBox *>(copy);
+            uint64_t h = tbox_hash_extended(tbox, static_cast<uint64_t>(seed));
+            free(copy);
+            return static_cast<int64_t>(h);
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
 } // namespace duckdb

--- a/test/sql/parity/021_tbox_wkb_hash.test
+++ b/test/sql/parity/021_tbox_wkb_hash.test
@@ -1,0 +1,50 @@
+# name: test/sql/parity/021_tbox_wkb_hash.test
+# description: TBox WKB/hex-WKB serialization round-trip + hash bindings.
+# group: [sql]
+
+require mobilityduck
+
+# asHexWKB produces a non-empty hex string
+
+query I
+SELECT length(asHexWKB(tbox 'TBOXFLOAT XT([1.5, 2.5),[2000-01-01, 2000-01-03])')) > 0;
+----
+true
+
+# tboxFromHexWKB(asHexWKB(x)) round-trips to x
+
+query I
+SELECT tboxFromHexWKB(asHexWKB(tbox 'TBOXFLOAT XT([1.5, 2.5),[2000-01-01, 2000-01-03])'))
+     = tbox 'TBOXFLOAT XT([1.5, 2.5),[2000-01-01, 2000-01-03])';
+----
+true
+
+# tboxFromBinary(asBinary(x)) round-trips to x
+
+query I
+SELECT tboxFromBinary(asBinary(tbox 'TBOXFLOAT XT([1.5, 2.5),[2000-01-01, 2000-01-03])'))
+     = tbox 'TBOXFLOAT XT([1.5, 2.5),[2000-01-01, 2000-01-03])';
+----
+true
+
+# tbox_hash is deterministic and a hash of two distinct values differs
+
+query I
+SELECT tbox_hash(tbox 'TBOXFLOAT XT([1, 2),[2000-01-01, 2000-01-02])')
+     = tbox_hash(tbox 'TBOXFLOAT XT([1, 2),[2000-01-01, 2000-01-02])');
+----
+true
+
+query I
+SELECT tbox_hash(tbox 'TBOXFLOAT XT([1, 2),[2000-01-01, 2000-01-02])')
+    <> tbox_hash(tbox 'TBOXFLOAT XT([3, 4),[2000-01-01, 2000-01-02])');
+----
+true
+
+# tbox_hash_extended changes with seed
+
+query I
+SELECT tbox_hash_extended(tbox 'TBOXFLOAT XT([1, 2),[2000-01-01, 2000-01-02])', 1)
+    <> tbox_hash_extended(tbox 'TBOXFLOAT XT([1, 2),[2000-01-01, 2000-01-02])', 2);
+----
+true


### PR DESCRIPTION
Closes the user-facing tail of \`temporal/021_tbox\` (was 80%, brings the user-visible surface to ~100%).

## New SQL surface

| Signature | Routed through |
|---|---|
| \`asBinary(tbox)\` -> \`bytea\` | MEOS \`tbox_as_wkb\` (\`WKB_EXTENDED\`) |
| \`asHexWKB(tbox)\` -> \`text\` | MEOS \`tbox_as_hexwkb\` |
| \`tboxFromBinary(bytea)\` -> \`tbox\` | MEOS \`tbox_from_wkb\` |
| \`tboxFromHexWKB(text)\` -> \`tbox\` | MEOS \`tbox_from_hexwkb\` |
| \`tbox_hash(tbox)\` -> \`integer\` | MEOS \`tbox_hash\` |
| \`tbox_hash_extended(tbox, bigint)\` -> \`bigint\` | MEOS \`tbox_hash_extended\` |

## What stays unregistered (and why)

The remaining \`021_tbox\` names that the audit (PR #66) flags as missing:

- \`tbox_in\`, \`tbox_out\`, \`tbox_recv\`, \`tbox_send\` — PostgreSQL I/O protocol internals; DuckDB exposes \`tbox\` via \`CAST\` to/from VARCHAR which is already wired.
- \`tbox_extent_combinefn\`, \`tbox_extent_transfn\` — aggregate transition functions; live in the separate aggregate-infrastructure track (PR #21).
- \`tnumber_joinsel\`, \`tnumber_sel\` — PostgreSQL planner selectivity hooks; no DuckDB equivalent.

## Tests

- \`test/sql/parity/021_tbox_wkb_hash.test\` — 6 assertions, including binary and hex-WKB round-trips.
- Full suite: **758 assertions / 14 test cases** passing under \`TZ=UTC\`.

## Coverage delta

Per the audit in PR #66:
- \`temporal/021_tbox\`: 48/60 (80%) → 54/60 (90%) by name (the remaining 6 are infra-only).

## Test plan

- [x] \`cmake --build . --target shell unittest\` clean
- [x] New parity test passes (6/6)
- [x] Full suite green (758/14)