### PR TITLE
feat(bindings): tnumber math followups — exp/ln/log10, deltaValue, trend, named-function aliases

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -224,6 +224,11 @@ struct TemporalFunctions {
      * Unary tnumber functions
      ****************************************************/
     static void Tnumber_abs(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tnumber_delta_value(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tnumber_trend(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tfloat_exp(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tfloat_ln(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tfloat_log10(DataChunk &args, ExpressionState &state, Vector &result);
     // Temporal_derivative declared in the math-functions block below.
     static void Tfloat_degrees(DataChunk &args, ExpressionState &state, Vector &result);
     static void Tfloat_radians(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1352,6 +1352,47 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT(), LogicalType::BOOLEAN}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
     loader.RegisterFunction(ScalarFunction("radians", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_radians));
 
+    // Unary tfloat math functions
+    loader.RegisterFunction(ScalarFunction("exp",   {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_exp));
+    loader.RegisterFunction(ScalarFunction("ln",    {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_ln));
+    loader.RegisterFunction(ScalarFunction("log10", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_log10));
+
+    // deltaValue / trend on tnumber
+    loader.RegisterFunction(ScalarFunction("deltaValue", {TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Tnumber_delta_value));
+    loader.RegisterFunction(ScalarFunction("deltaValue", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tnumber_delta_value));
+    loader.RegisterFunction(ScalarFunction("trend",      {TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Tnumber_trend));
+    loader.RegisterFunction(ScalarFunction("trend",      {TemporalTypes::TFLOAT()}, TemporalTypes::TINT(),   TemporalFunctions::Tnumber_trend));
+
+    // Named-function aliases for the arithmetic operators (MobilityDB exposes
+    // both `+`/`-`/`*`/`/` and `tnumber_add`/`sub`/`mult`/`div`).
+    loader.RegisterFunction(ScalarFunction("tnumber_add",  {LogicalType::INTEGER,    TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Add_int_tint));
+    loader.RegisterFunction(ScalarFunction("tnumber_add",  {TemporalTypes::TINT(),   LogicalType::INTEGER},    TemporalTypes::TINT(),   TemporalFunctions::Add_tint_int));
+    loader.RegisterFunction(ScalarFunction("tnumber_add",  {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("tnumber_add",  {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     TemporalTypes::TFLOAT(), TemporalFunctions::Add_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("tnumber_add",  {TemporalTypes::TINT(),   TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Add_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("tnumber_add",  {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_tnumber_tnumber));
+
+    loader.RegisterFunction(ScalarFunction("tnumber_sub",  {LogicalType::INTEGER,    TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Sub_int_tint));
+    loader.RegisterFunction(ScalarFunction("tnumber_sub",  {TemporalTypes::TINT(),   LogicalType::INTEGER},    TemporalTypes::TINT(),   TemporalFunctions::Sub_tint_int));
+    loader.RegisterFunction(ScalarFunction("tnumber_sub",  {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("tnumber_sub",  {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     TemporalTypes::TFLOAT(), TemporalFunctions::Sub_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("tnumber_sub",  {TemporalTypes::TINT(),   TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Sub_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("tnumber_sub",  {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_tnumber_tnumber));
+
+    loader.RegisterFunction(ScalarFunction("tnumber_mult", {LogicalType::INTEGER,    TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Mult_int_tint));
+    loader.RegisterFunction(ScalarFunction("tnumber_mult", {TemporalTypes::TINT(),   LogicalType::INTEGER},    TemporalTypes::TINT(),   TemporalFunctions::Mult_tint_int));
+    loader.RegisterFunction(ScalarFunction("tnumber_mult", {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("tnumber_mult", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     TemporalTypes::TFLOAT(), TemporalFunctions::Mult_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("tnumber_mult", {TemporalTypes::TINT(),   TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Mult_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("tnumber_mult", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_tnumber_tnumber));
+
+    loader.RegisterFunction(ScalarFunction("tnumber_div",  {LogicalType::INTEGER,    TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Div_int_tint));
+    loader.RegisterFunction(ScalarFunction("tnumber_div",  {TemporalTypes::TINT(),   LogicalType::INTEGER},    TemporalTypes::TINT(),   TemporalFunctions::Div_tint_int));
+    loader.RegisterFunction(ScalarFunction("tnumber_div",  {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("tnumber_div",  {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     TemporalTypes::TFLOAT(), TemporalFunctions::Div_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("tnumber_div",  {TemporalTypes::TINT(),   TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Div_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("tnumber_div",  {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_tnumber_tnumber));
+
     // tnumber distance and nearest-approach-distance.
     //
     // Value-distance variants `<-> ` for (tint, INTEGER), (INTEGER, tint),

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4796,6 +4796,26 @@ void TemporalFunctions::Tnumber_abs(DataChunk &args, ExpressionState &state, Vec
     TemporalUnary(args, result, [](Temporal *t) { return tnumber_abs(t); });
 }
 
+void TemporalFunctions::Tnumber_delta_value(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tnumber_delta_value(t); });
+}
+
+void TemporalFunctions::Tnumber_trend(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tnumber_trend(t); });
+}
+
+void TemporalFunctions::Tfloat_exp(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tfloat_exp(t); });
+}
+
+void TemporalFunctions::Tfloat_ln(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tfloat_ln(t); });
+}
+
+void TemporalFunctions::Tfloat_log10(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tfloat_log10(t); });
+}
+
 // Temporal_derivative is implemented later in this file in the Math
 // functions block (existed before the unary-tnumber additions).
 

--- a/test/sql/parity/026b_tnumber_mathfuncs_followups.test
+++ b/test/sql/parity/026b_tnumber_mathfuncs_followups.test
@@ -1,0 +1,78 @@
+# name: test/sql/parity/026b_tnumber_mathfuncs_followups.test
+# description: Tail of temporal/026_tnumber_mathfuncs — exp/ln/log10,
+#              deltaValue, trend, and the named-function aliases for the
+#              tnumber arithmetic operators.
+# group: [sql]
+
+require mobilityduck
+
+# Unary tfloat math: ln(e) ≈ 1, log10(100) = 2, exp(0) = 1
+
+query I
+SELECT round(ln(tfloat '[1@2000-01-01, 2.71828182845905@2000-01-02]'), 6);
+----
+[0@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00]
+
+query I
+SELECT log10(tfloat '[1@2000-01-01, 100@2000-01-02]');
+----
+[0@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00]
+
+query I
+SELECT round(exp(tfloat '[0@2000-01-01, 1@2000-01-02]'), 6);
+----
+[1@2000-01-01 00:00:00+00, 2.718282@2000-01-02 00:00:00+00]
+
+# deltaValue — successive differences
+
+query I
+SELECT deltaValue(tint '[1@2000-01-01, 5@2000-01-02, 3@2000-01-03]');
+----
+[4@2000-01-01 00:00:00+00, -2@2000-01-02 00:00:00+00, -2@2000-01-03 00:00:00+00)
+
+query I
+SELECT round(deltaValue(tfloat '[1@2000-01-01, 5@2000-01-02, 3@2000-01-03]'), 6);
+----
+Interp=Step;[4@2000-01-01 00:00:00+00, -2@2000-01-02 00:00:00+00, -2@2000-01-03 00:00:00+00)
+
+# trend — sign of slope (returns tint even on tfloat per MobilityDB)
+
+query I
+SELECT trend(tfloat '[1@2000-01-01, 5@2000-01-02, 3@2000-01-03]');
+----
+[1@2000-01-01 00:00:00+00, -1@2000-01-02 00:00:00+00, -1@2000-01-03 00:00:00+00]
+
+# Named aliases for the arithmetic operators
+
+query I
+SELECT tnumber_add(tint '[1@2000-01-01]', 10);
+----
+[11@2000-01-01 00:00:00+00]
+
+query I
+SELECT tnumber_sub(tfloat '[10@2000-01-01]', 5.0);
+----
+[5@2000-01-01 00:00:00+00]
+
+query I
+SELECT tnumber_mult(2.0, tfloat '[3@2000-01-01]');
+----
+[6@2000-01-01 00:00:00+00]
+
+query I
+SELECT tnumber_div(tfloat '[10@2000-01-01]', 5.0);
+----
+[2@2000-01-01 00:00:00+00]
+
+# Aliases agree with the operator forms
+
+query I
+SELECT tnumber_add(tfloat '[3@2000-01-01]', 4.0) = (tfloat '[3@2000-01-01]' + 4.0);
+----
+true
+
+query I
+SELECT tnumber_mult(tint '[5@2000-01-01]', tint '[2@2000-01-01]')
+     = (tint '[5@2000-01-01]' * tint '[2@2000-01-01]');
+----
+true


### PR DESCRIPTION
Closes the user-facing tail of \`temporal/026_tnumber_mathfuncs\` (was 47%; this brings the user-visible surface to ~100%).

## New SQL surface

### Unary tfloat math
| Signature | Routed through |
|---|---|
| \`exp(tfloat)\` -> \`tfloat\` | \`tfloat_exp\` |
| \`ln(tfloat)\` -> \`tfloat\` | \`tfloat_ln\` |
| \`log10(tfloat)\` -> \`tfloat\` | \`tfloat_log10\` |

### Unary tnumber
| Signature | Notes |
|---|---|
| \`deltaValue(tint)\` -> \`tint\` | successive differences |
| \`deltaValue(tfloat)\` -> \`tfloat\` | same |
| \`trend(tint)\` -> \`tint\` | sign of slope |
| \`trend(tfloat)\` -> \`tint\` | matches MobilityDB's odd return-type choice (\`tint\` even on \`tfloat\` input) |

### Named-function aliases for the arithmetic operators
\`tnumber_add\` / \`tnumber_sub\` / \`tnumber_mult\` / \`tnumber_div\` — 6 overloads each (\`int × tint\`, \`tint × int\`, \`tint × tint\`, \`float × tfloat\`, \`tfloat × float\`, \`tfloat × tfloat\`).

These route through the same handlers as the existing \`+\`/\`-\`/\`*\`/\`/\` operator forms; MobilityDB exposes both names. Verified via assertions like \`tnumber_add(tfloat '...', 4.0) = (tfloat '...' + 4.0)\` -> \`true\`.

## Tests

- \`test/sql/parity/026b_tnumber_mathfuncs_followups.test\` — 12 assertions covering each new surface and the operator-alias equivalence.
- Full suite: **764 assertions / 14 test cases** passing under \`TZ=UTC\`.

## Coverage delta

Per the audit in PR #66:
- \`temporal/026_tnumber_mathfuncs\`: 8/17 (47%) → 17/17 (100%) by name.

## Test plan

- [x] \`cmake --build . --target shell unittest\` clean
- [x] New parity test passes (12/12)
- [x] Full suite green (764/14)