### PR TITLE
feat(bindings): temporal boxops followups — named-function aliases + tboxes/splitN/splitEachN

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -224,6 +224,9 @@ struct TemporalFunctions {
      * Unary tnumber functions
      ****************************************************/
     static void Tnumber_abs(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tnumber_tboxes(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tnumber_split_n_tboxes(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tnumber_split_each_n_tboxes(DataChunk &args, ExpressionState &state, Vector &result);
     // Temporal_derivative declared in the math-functions block below.
     static void Tfloat_degrees(DataChunk &args, ExpressionState &state, Vector &result);
     static void Tfloat_radians(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1376,25 +1376,42 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
     loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
 
-    // Temporal topological predicates: temporal × temporal (4 ops × 4 type pairs)
+    // Temporal topological predicates: temporal × temporal (4 ops × 4 type pairs).
+    // Each operator is also exposed under its MobilityDB-canonical named-function
+    // form (`temporal_contains`, `temporal_contained`, `temporal_overlaps`,
+    // `temporal_adjacent`) for compatibility with code that does not use the
+    // operator syntax.
     for (auto &t1 : TemporalTypes::AllTypes()) {
         for (auto &t2 : TemporalTypes::AllTypes()) {
-            loader.RegisterFunction(ScalarFunction("@>", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_temporal));
-            loader.RegisterFunction(ScalarFunction("<@", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_temporal));
-            loader.RegisterFunction(ScalarFunction("&&", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_temporal));
-            loader.RegisterFunction(ScalarFunction("-|-", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("@>",                {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_contains", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("<@",                 {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_contained", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("&&",                {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_overlaps", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("-|-",                {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_adjacent", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_temporal));
         }
     }
     // Temporal × tstzspan (and the reverse direction)
     for (auto &t : TemporalTypes::AllTypes()) {
-        loader.RegisterFunction(ScalarFunction("@>", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("<@", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("&&", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("-|-", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("@>", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tstzspan_temporal));
-        loader.RegisterFunction(ScalarFunction("<@", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tstzspan_temporal));
-        loader.RegisterFunction(ScalarFunction("&&", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tstzspan_temporal));
-        loader.RegisterFunction(ScalarFunction("-|-", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("@>",                {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_contains", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("<@",                 {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_contained", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("&&",                {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_overlaps", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("-|-",                {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_adjacent", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_tstzspan));
+
+        loader.RegisterFunction(ScalarFunction("@>",                {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_contains", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("<@",                 {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_contained", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("&&",                {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_overlaps", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("-|-",                {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_adjacent", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tstzspan_temporal));
     }
 
     // Temporal time-position predicates registered as named functions:
@@ -1475,34 +1492,39 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         auto fspan = SpanTypes::FLOATSPAN();
         auto tbox  = TboxType::TBOX();
 
-        // tnumber × numspan
-        loader.RegisterFunction(ScalarFunction("@>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("<@",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&&",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("-|-", {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("@>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("<@",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&&",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("-|-", {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
-        // numspan × tnumber
-        loader.RegisterFunction(ScalarFunction("@>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("<@",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&&",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("-|-", {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("@>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("<@",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&&",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("-|-", {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
-        // tnumber × tbox
+#define REG_TOP4(L, R, FN_SUFFIX) \
+    loader.RegisterFunction(ScalarFunction("@>",                {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Contains_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_contains", {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Contains_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("<@",                 {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Contained_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_contained", {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Contained_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("&&",                {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_overlaps", {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("-|-",                {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_adjacent", {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_##FN_SUFFIX));
+
+        // tnumber × numspan / numspan × tnumber
+        REG_TOP4(tint, ispan, tnumber_numspan)
+        REG_TOP4(tflt, fspan, tnumber_numspan)
+        REG_TOP4(ispan, tint, numspan_tnumber)
+        REG_TOP4(fspan, tflt, numspan_tnumber)
+        // tnumber × tbox / tbox × tnumber
         for (auto &t : {tint, tflt}) {
-            loader.RegisterFunction(ScalarFunction("@>",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("<@",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("&&",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("-|-", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("@>",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("<@",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("&&",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("-|-", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tbox_tnumber));
+            REG_TOP4(t, tbox, tnumber_tbox)
+            REG_TOP4(tbox, t, tbox_tnumber)
+        }
+#undef REG_TOP4
+
+        // tboxes / splitNTboxes / splitEachNTboxes — temporal number to LIST(tbox)
+        const auto tbox_list = LogicalType::LIST(TboxType::TBOX());
+        for (auto &t : {tint, tflt}) {
+            loader.RegisterFunction(ScalarFunction(
+                "tboxes", {t}, tbox_list, TemporalFunctions::Tnumber_tboxes));
+            loader.RegisterFunction(ScalarFunction(
+                "splitNTboxes", {t, LogicalType::INTEGER}, tbox_list,
+                TemporalFunctions::Tnumber_split_n_tboxes));
+            loader.RegisterFunction(ScalarFunction(
+                "splitEachNTboxes", {t, LogicalType::INTEGER}, tbox_list,
+                TemporalFunctions::Tnumber_split_each_n_tboxes));
         }
 
         // Position ops (<<, >>, &<, &>) — same surface

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4796,6 +4796,82 @@ void TemporalFunctions::Tnumber_abs(DataChunk &args, ExpressionState &state, Vec
     TemporalUnary(args, result, [](Temporal *t) { return tnumber_abs(t); });
 }
 
+namespace {
+
+template <typename Producer>
+void RunTboxesEmit(DataChunk &args, Vector &result, Producer produce, bool has_n_arg) {
+    const idx_t row_count = args.size();
+    args.data[0].Flatten(row_count);
+    if (has_n_arg) args.data[1].Flatten(row_count);
+    auto in_data = FlatVector::GetData<string_t>(args.data[0]);
+    auto &valid_in = FlatVector::Validity(args.data[0]);
+
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &out_validity = FlatVector::Validity(result);
+
+    idx_t total = 0;
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!valid_in.RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            list_entries[row] = list_entry_t{total, 0};
+            continue;
+        }
+        int n = 0;
+        if (has_n_arg) {
+            auto &nv = args.data[1];
+            if (!FlatVector::Validity(nv).RowIsValid(row)) {
+                out_validity.SetInvalid(row);
+                list_entries[row] = list_entry_t{total, 0};
+                continue;
+            }
+            n = FlatVector::GetData<int32_t>(nv)[row];
+        }
+        Temporal *t = BlobToTemporal(in_data[row]);
+        int count = 0;
+        TBox *boxes = produce(t, n, &count);
+        free(t);
+        if (!boxes || count <= 0) {
+            list_entries[row] = list_entry_t{total, 0};
+            if (boxes) free(boxes);
+            continue;
+        }
+        ListVector::Reserve(result, total + count);
+        ListVector::SetListSize(result, total + count);
+        list_entries[row] = list_entry_t{total, static_cast<uint64_t>(count)};
+        auto &child = ListVector::GetEntry(result);
+        auto child_data = FlatVector::GetData<string_t>(child);
+        for (int k = 0; k < count; k++) {
+            string_t one(reinterpret_cast<const char *>(&boxes[k]), sizeof(TBox));
+            child_data[total + k] = StringVector::AddStringOrBlob(child, one);
+        }
+        total += count;
+        free(boxes);
+    }
+    if (row_count == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+} // namespace
+
+void TemporalFunctions::Tnumber_tboxes(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunTboxesEmit(args, result,
+        [](const Temporal *t, int /*unused*/, int *count) { return tnumber_tboxes(t, count); },
+        /*has_n_arg=*/false);
+}
+
+void TemporalFunctions::Tnumber_split_n_tboxes(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunTboxesEmit(args, result,
+        [](const Temporal *t, int n, int *count) { return tnumber_split_n_tboxes(t, n, count); },
+        /*has_n_arg=*/true);
+}
+
+void TemporalFunctions::Tnumber_split_each_n_tboxes(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunTboxesEmit(args, result,
+        [](const Temporal *t, int n, int *count) { return tnumber_split_each_n_tboxes(t, n, count); },
+        /*has_n_arg=*/true);
+}
+
 // Temporal_derivative is implemented later in this file in the Math
 // functions block (existed before the unary-tnumber additions).
 

--- a/test/sql/parity/032_temporal_boxops_followups.test
+++ b/test/sql/parity/032_temporal_boxops_followups.test
@@ -1,0 +1,65 @@
+# name: test/sql/parity/032_temporal_boxops_followups.test
+# description: Tail of temporal/032_temporal_boxops — named-function aliases
+#              (temporal_contains/contained/overlaps/adjacent) for the
+#              already-wired @>/<@/&&/-|- operators, plus tboxes /
+#              splitNTboxes / splitEachNTboxes.
+# group: [sql]
+
+require mobilityduck
+
+# Named-function aliases agree with the operator forms
+
+query I
+SELECT temporal_contains(tint '[1@2000-01-01, 5@2000-01-05]', tint '[2@2000-01-02, 3@2000-01-03]')
+     = (tint '[1@2000-01-01, 5@2000-01-05]' @> tint '[2@2000-01-02, 3@2000-01-03]');
+----
+true
+
+query I
+SELECT temporal_contained(tint '[2@2000-01-02, 3@2000-01-03]', tint '[1@2000-01-01, 5@2000-01-05]')
+     = (tint '[2@2000-01-02, 3@2000-01-03]' <@ tint '[1@2000-01-01, 5@2000-01-05]');
+----
+true
+
+query I
+SELECT temporal_overlaps(tint '[1@2000-01-01]', tint '[1@2000-01-01]');
+----
+true
+
+query I
+SELECT temporal_adjacent(tint '[1@2000-01-01, 2@2000-01-02]', tint '[3@2000-01-03, 4@2000-01-04]');
+----
+false
+
+# Aliases also work for (temporal × tstzspan)
+
+query I
+SELECT temporal_contains(tstzspan '[2000-01-01, 2000-01-10]', tint '[3@2000-01-03, 4@2000-01-04]');
+----
+true
+
+# Aliases on (tnumber × numspan) and (tnumber × tbox)
+
+query I
+SELECT temporal_overlaps(tint '[1@2000-01-01, 5@2000-01-05]', intspan '[2, 4)');
+----
+true
+
+# tboxes(tnumber) returns at least one tbox
+
+query I
+SELECT len(tboxes(tfloat '[1@2000-01-01, 2@2000-01-02]')) > 0;
+----
+true
+
+# splitNTboxes / splitEachNTboxes return non-empty lists for a sequence
+
+query I
+SELECT len(splitNTboxes(tfloat '[1@2000-01-01, 5@2000-01-05]', 2)) >= 1;
+----
+true
+
+query I
+SELECT len(splitEachNTboxes(tfloat '[1@2000-01-01, 2@2000-01-02, 3@2000-01-03, 4@2000-01-04, 5@2000-01-05]', 2)) >= 1;
+----
+true


### PR DESCRIPTION
Closes 7 of 8 missing names in \`temporal/032_temporal_boxops\` (was 27%; this brings the user-visible surface to ~88%).

## New SQL surface

### Named-function aliases for the existing topological operators

MobilityDB exposes both the operator and named-function form for each topological predicate. The operator forms (\`@>\`, \`<@\`, \`&&\`, \`-|-\`) are already wired across all 36 existing overloads; this PR registers the matching named functions against the same handlers.

| Operator | Named alias |
|---|---|
| \`@>\` | \`temporal_contains\` |
| \`<@\` | \`temporal_contained\` |
| \`&&\` | \`temporal_overlaps\` |
| \`-|-\` | \`temporal_adjacent\` |

Coverage:
- temporal × temporal (every base-type pair)
- temporal × tstzspan and tstzspan × temporal
- tnumber × numspan / numspan × tnumber
- tnumber × tbox / tbox × tnumber

A small \`REG_TOP4\` macro factors the tnumber × {numspan, tbox} 4-handler block.

### tnumber → LIST(tbox) emitters

| Signature | Routed through |
|---|---|
| \`tboxes(tnumber)\` -> \`LIST(tbox)\` | \`tnumber_tboxes\` |
| \`splitNTboxes(tnumber, integer)\` -> \`LIST(tbox)\` | \`tnumber_split_n_tboxes\` |
| \`splitEachNTboxes(tnumber, integer)\` -> \`LIST(tbox)\` | \`tnumber_split_each_n_tboxes\` |

## What stays unregistered

The 8th missing name, \`temporal_same\` (alias of \`~=\`), is deferred. The underlying \`~=\` operator handlers (\`Same_temporal_temporal\`, \`Same_tnumber_numspan\`, \`Same_tnumber_tbox\`, \`Same_temporal_tstzspan\`) are **not yet wired** in MobilityDuck. Adding them is straightforward MEOS plumbing — one new handler family + a parallel registration block — but warrants a focused PR rather than expanding the surface of this one.

## Tests

- \`test/sql/parity/032_temporal_boxops_followups.test\` — 9 assertions covering the alias-equivalence with operators, the cross-type variants, and the tboxes/splitN/splitEachN list-returning surface.
- Full suite: **761 assertions / 14 test cases** passing under \`TZ=UTC\`.

## Coverage delta

Per the audit in PR #66:
- \`temporal/032_temporal_boxops\`: 3/11 (27%) → 10/11 (91%) by name.

## Test plan

- [x] \`cmake --build . --target shell unittest\` clean
- [x] New parity test passes (9/9)
- [x] Full suite green (761/14)