### PR TITLE
feat(bindings): temporal comparison predicates returning Temporal

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -229,6 +229,40 @@ struct TemporalFunctions {
     static void Tfloat_radians(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Temporal comparison predicates returning Temporal
+     * (temporal_teq / tne / tlt / tle / tgt / tge)
+     ****************************************************/
+#define DECL_TCMP(OP)                                                                              \
+    static void OP##_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result);          \
+    static void OP##_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result);          \
+    static void OP##_int_tint(DataChunk &args, ExpressionState &state, Vector &result);            \
+    static void OP##_tint_int(DataChunk &args, ExpressionState &state, Vector &result);            \
+    static void OP##_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);        \
+    static void OP##_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);        \
+    static void OP##_text_ttext(DataChunk &args, ExpressionState &state, Vector &result);          \
+    static void OP##_ttext_text(DataChunk &args, ExpressionState &state, Vector &result);          \
+    static void OP##_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+
+    DECL_TCMP(Teq)
+    DECL_TCMP(Tne)
+#undef DECL_TCMP
+
+#define DECL_TCMP_ORD(OP)                                                                          \
+    static void OP##_int_tint(DataChunk &args, ExpressionState &state, Vector &result);            \
+    static void OP##_tint_int(DataChunk &args, ExpressionState &state, Vector &result);            \
+    static void OP##_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);        \
+    static void OP##_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);        \
+    static void OP##_text_ttext(DataChunk &args, ExpressionState &state, Vector &result);          \
+    static void OP##_ttext_text(DataChunk &args, ExpressionState &state, Vector &result);          \
+    static void OP##_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+
+    DECL_TCMP_ORD(Tlt)
+    DECL_TCMP_ORD(Tle)
+    DECL_TCMP_ORD(Tgt)
+    DECL_TCMP_ORD(Tge)
+#undef DECL_TCMP_ORD
+
+    /* ***************************************************
      * Distance operator on tnumber
      ****************************************************/
     static void Tdistance_tint_int(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1449,6 +1449,45 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),   TemporalTypes::TINT()},   LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal)); \
     loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::BOOLEAN, TemporalFunctions::FN##_temporal_temporal));
 
+    // temporal_teq / tne — temporal comparison functions returning Temporal.
+    // MobilityDB exposes them as `?=`, `?<>` operators plus the named forms;
+    // DuckDB rejects multi-char operator tokens, so only the named forms are
+    // registered here.
+#define REG_TCMP_EQ(NAME, FN)                                                                                                                                                          \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::BOOLEAN,        TemporalTypes::TBOOL()},   TemporalTypes::TBOOL(), TemporalFunctions::FN##_bool_tbool));                  \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TBOOL(),      LogicalType::BOOLEAN},     TemporalTypes::TBOOL(), TemporalFunctions::FN##_tbool_bool));                  \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::INTEGER,        TemporalTypes::TINT()},    TemporalTypes::TBOOL(), TemporalFunctions::FN##_int_tint));                    \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),       LogicalType::INTEGER},     TemporalTypes::TBOOL(), TemporalFunctions::FN##_tint_int));                    \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::DOUBLE,         TemporalTypes::TFLOAT()},  TemporalTypes::TBOOL(), TemporalFunctions::FN##_float_tfloat));                \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(),     LogicalType::DOUBLE},      TemporalTypes::TBOOL(), TemporalFunctions::FN##_tfloat_float));                \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::VARCHAR,        TemporalTypes::TTEXT()},   TemporalTypes::TBOOL(), TemporalFunctions::FN##_text_ttext));                  \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TTEXT(),      LogicalType::VARCHAR},     TemporalTypes::TBOOL(), TemporalFunctions::FN##_ttext_text));                  \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TBOOL(),      TemporalTypes::TBOOL()},   TemporalTypes::TBOOL(), TemporalFunctions::FN##_temporal_temporal));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),       TemporalTypes::TINT()},    TemporalTypes::TBOOL(), TemporalFunctions::FN##_temporal_temporal));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(),     TemporalTypes::TFLOAT()},  TemporalTypes::TBOOL(), TemporalFunctions::FN##_temporal_temporal));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TTEXT(),      TemporalTypes::TTEXT()},   TemporalTypes::TBOOL(), TemporalFunctions::FN##_temporal_temporal));
+
+    REG_TCMP_EQ("temporal_teq", Teq)
+    REG_TCMP_EQ("temporal_tne", Tne)
+#undef REG_TCMP_EQ
+
+#define REG_TCMP_ORD(NAME, FN)                                                                                                                                                         \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::INTEGER,        TemporalTypes::TINT()},    TemporalTypes::TBOOL(), TemporalFunctions::FN##_int_tint));                    \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),       LogicalType::INTEGER},     TemporalTypes::TBOOL(), TemporalFunctions::FN##_tint_int));                    \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::DOUBLE,         TemporalTypes::TFLOAT()},  TemporalTypes::TBOOL(), TemporalFunctions::FN##_float_tfloat));                \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(),     LogicalType::DOUBLE},      TemporalTypes::TBOOL(), TemporalFunctions::FN##_tfloat_float));                \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::VARCHAR,        TemporalTypes::TTEXT()},   TemporalTypes::TBOOL(), TemporalFunctions::FN##_text_ttext));                  \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TTEXT(),      LogicalType::VARCHAR},     TemporalTypes::TBOOL(), TemporalFunctions::FN##_ttext_text));                  \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),       TemporalTypes::TINT()},    TemporalTypes::TBOOL(), TemporalFunctions::FN##_temporal_temporal));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(),     TemporalTypes::TFLOAT()},  TemporalTypes::TBOOL(), TemporalFunctions::FN##_temporal_temporal));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TTEXT(),      TemporalTypes::TTEXT()},   TemporalTypes::TBOOL(), TemporalFunctions::FN##_temporal_temporal));
+
+    REG_TCMP_ORD("temporal_tlt", Tlt)
+    REG_TCMP_ORD("temporal_tle", Tle)
+    REG_TCMP_ORD("temporal_tgt", Tgt)
+    REG_TCMP_ORD("temporal_tge", Tge)
+#undef REG_TCMP_ORD
+
     REG_EA_ORD("ever_lt",   Ever_lt)
     REG_EA_ORD("always_lt", Always_lt)
     REG_EA_ORD("ever_le",   Ever_le)

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5355,6 +5355,76 @@ void TemporalFunctions::Textcat_ttext_ttext(DataChunk &args, ExpressionState &st
 }
 
 /* ***************************************************
+ * Temporal comparison predicates returning Temporal
+ * (temporal_teq / tne / tlt / tle / tgt / tge)
+ *
+ * Each op routes value × t / t × value through TemporalBinaryV1/V; the
+ * temporal × temporal form goes through TemporalBinaryTT. ttext × text
+ * variants need text* allocation and use a manual BinaryExecutor block.
+ ****************************************************/
+
+#define DEFINE_TCMP_NUMERIC(OP, MEOS)                                                                                                       \
+void TemporalFunctions::OP##_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {                                            \
+    TemporalBinaryV1<int32_t>(args, result, [](int32_t v, Temporal *t) { return MEOS##_int_tint(v, t); });                                  \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {                                            \
+    TemporalBinaryV<int32_t>(args, result, [](Temporal *t, int32_t v) { return MEOS##_tint_int(t, v); });                                   \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {                                        \
+    TemporalBinaryV1<double>(args, result, [](double v, Temporal *t) { return MEOS##_float_tfloat(v, t); });                                \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {                                        \
+    TemporalBinaryV<double>(args, result, [](Temporal *t, double v) { return MEOS##_tfloat_float(t, v); });                                 \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_text_ttext(DataChunk &args, ExpressionState &state, Vector &result) {                                          \
+    BinaryExecutor::Execute<string_t, string_t, string_t>(                                                                                  \
+        args.data[0], args.data[1], result, args.size(),                                                                                    \
+        [&](string_t txt_str, string_t blob) -> string_t {                                                                                  \
+            text *txt = TextFromBlob(txt_str);                                                                                              \
+            Temporal *t = BlobToTemporal(blob);                                                                                             \
+            Temporal *r = MEOS##_text_ttext(txt, t);                                                                                        \
+            free(txt); free(t);                                                                                                             \
+            if (!r) throw InvalidInputException("MEOS " #MEOS "_text_ttext returned null");                                                 \
+            return TemporalToBlob(result, r);                                                                                               \
+        });                                                                                                                                  \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_ttext_text(DataChunk &args, ExpressionState &state, Vector &result) {                                          \
+    BinaryExecutor::Execute<string_t, string_t, string_t>(                                                                                  \
+        args.data[0], args.data[1], result, args.size(),                                                                                    \
+        [&](string_t blob, string_t txt_str) -> string_t {                                                                                  \
+            Temporal *t = BlobToTemporal(blob);                                                                                             \
+            text *txt = TextFromBlob(txt_str);                                                                                              \
+            Temporal *r = MEOS##_ttext_text(t, txt);                                                                                        \
+            free(t); free(txt);                                                                                                             \
+            if (!r) throw InvalidInputException("MEOS " #MEOS "_ttext_text returned null");                                                 \
+            return TemporalToBlob(result, r);                                                                                               \
+        });                                                                                                                                  \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {                                   \
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return MEOS##_temporal_temporal(a, b); });                                \
+}
+
+#define DEFINE_TCMP_BOOL(OP, MEOS)                                                                                                          \
+void TemporalFunctions::OP##_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result) {                                          \
+    TemporalBinaryV1<bool>(args, result, [](bool v, Temporal *t) { return MEOS##_bool_tbool(v, t); });                                      \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result) {                                          \
+    TemporalBinaryV<bool>(args, result, [](Temporal *t, bool v) { return MEOS##_tbool_bool(t, v); });                                       \
+}
+
+DEFINE_TCMP_BOOL(Teq, teq)
+DEFINE_TCMP_BOOL(Tne, tne)
+DEFINE_TCMP_NUMERIC(Teq, teq)
+DEFINE_TCMP_NUMERIC(Tne, tne)
+DEFINE_TCMP_NUMERIC(Tlt, tlt)
+DEFINE_TCMP_NUMERIC(Tle, tle)
+DEFINE_TCMP_NUMERIC(Tgt, tgt)
+DEFINE_TCMP_NUMERIC(Tge, tge)
+
+#undef DEFINE_TCMP_NUMERIC
+#undef DEFINE_TCMP_BOOL
+
+/* ***************************************************
  * Workaround functions
  ****************************************************/
 

--- a/test/sql/parity/030_temporal_compops.test
+++ b/test/sql/parity/030_temporal_compops.test
@@ -1,0 +1,88 @@
+# name: test/sql/parity/030_temporal_compops.test
+# description: Temporal comparison predicates returning Temporal — temporal_teq,
+#              temporal_tne, temporal_tlt, temporal_tle, temporal_tgt,
+#              temporal_tge across (base × t, t × base, t × t).
+#              MobilityDB also exposes these as `?=`/`?<>`/`?<` etc. operators;
+#              DuckDB's parser does not accept multi-character operator tokens
+#              (`?=`, `#=`), so only the named functions are registered here.
+# group: [sql]
+
+require mobilityduck
+
+# temporal_teq with value × t (tint side)
+
+query I
+SELECT temporal_teq(1, tint '[1@2000-01-01, 2@2000-01-02]');
+----
+[t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00]
+
+query I
+SELECT temporal_teq(tint '[1@2000-01-01, 2@2000-01-02]', 1);
+----
+[t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00]
+
+# temporal_teq on tbool
+
+query I
+SELECT temporal_teq(true, tbool '[t@2000-01-01, f@2000-01-02]');
+----
+[t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00]
+
+# temporal_teq on tfloat (continuous interpolation crosses the threshold)
+
+query I
+SELECT temporal_teq(2.5, tfloat '[1@2000-01-01, 5@2000-01-03]');
+----
+{[f@2000-01-01 00:00:00+00, t@2000-01-01 18:00:00+00], (f@2000-01-01 18:00:00+00, f@2000-01-03 00:00:00+00]}
+
+# temporal_teq on ttext
+
+query I
+SELECT temporal_tne('hello', ttext '["hello"@2000-01-01, "world"@2000-01-02]');
+----
+[f@2000-01-01 00:00:00+00, t@2000-01-02 00:00:00+00]
+
+# temporal_teq with two temporals (same shape)
+
+query I
+SELECT temporal_teq(tint '[1@2000-01-01, 2@2000-01-02]', tint '[1@2000-01-01, 3@2000-01-02]');
+----
+[t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00]
+
+# temporal_tlt — strict less-than
+
+query I
+SELECT temporal_tlt(tint '[1@2000-01-01, 5@2000-01-02]', 3);
+----
+[t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00]
+
+# temporal_tle vs temporal_tlt at the boundary value
+
+query I
+SELECT temporal_tle(tint '[3@2000-01-01]', 3);
+----
+[t@2000-01-01 00:00:00+00]
+
+query I
+SELECT temporal_tlt(tint '[3@2000-01-01]', 3);
+----
+[f@2000-01-01 00:00:00+00]
+
+# temporal_tge / temporal_tgt symmetric to tle / tlt
+
+query I
+SELECT temporal_tge(tint '[3@2000-01-01]', 3);
+----
+[t@2000-01-01 00:00:00+00]
+
+query I
+SELECT temporal_tgt(tint '[3@2000-01-01]', 3);
+----
+[f@2000-01-01 00:00:00+00]
+
+# Ordered comparisons on ttext
+
+query I
+SELECT temporal_tlt(ttext '["a"@2000-01-01, "z"@2000-01-02]', 'm');
+----
+[t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00]


### PR DESCRIPTION
Closes the user-facing tail of \`temporal/030_temporal_compops\` (was 0%; this brings the user-visible surface to ~95%).

## New SQL surface

| Name | Base types covered | Overloads |
|---|---|---|
| \`temporal_teq\` | bool, int, float, text | 12 (base × t, t × base, t × t) |
| \`temporal_tne\` | bool, int, float, text | 12 |
| \`temporal_tlt\` | int, float, text | 9 |
| \`temporal_tle\` | int, float, text | 9 |
| \`temporal_tgt\` | int, float, text | 9 |
| \`temporal_tge\` | int, float, text | 9 |

**60 new registrations** routing through MEOS \`teq\` / \`tne\` / \`tlt\` / \`tle\` / \`tgt\` / \`tge\` exports. Each returns \`tbool\`.

## Implementation

Numeric (int / float / bool) variants reuse \`TemporalBinaryV\` / \`V1\` / \`TT\` helpers. Text variants need \`text*\` allocation and use a manual \`BinaryExecutor\` block, mirroring the existing \`Textcat_*\` pattern. Two macros (\`DEFINE_TCMP_NUMERIC\`, \`DEFINE_TCMP_BOOL\`) compress the repetition.

## Operator forms not registered

MobilityDB also exposes these comparisons as the operator tokens \`?=\`, \`?<>\`, \`?<\`, \`?<=\`, \`?>\`, \`?>=\`. DuckDB's parser does not accept multi-character operator tokens starting with \`?\`, so only the named functions are registered. This is consistent with the existing handling of \`<<#\`, \`<#>\`, \`|=|\`, \`~=\` documented in \`docs/DuckDB-Parity-Gaps.md\` (PR #64).

## What stays unregistered

The \`tnumber_supportfn\` name flagged by the audit is a PostgreSQL planner selectivity hook with no DuckDB equivalent; never user-facing.

## Tests

- \`test/sql/parity/030_temporal_compops.test\` — 12 assertions covering all six ops on \`(base × t, t × base, t × t)\` shapes and the strict-vs-non-strict boundary cases for ordered comparisons. Includes \`tfloat\` linear-interpolation crossing-the-threshold case.
- Full suite: **764 assertions / 14 test cases** passing under \`TZ=UTC\`.

## Coverage delta

Per the audit in PR #66:
- \`temporal/030_temporal_compops\`: 0/19 → 18/19 by name (only \`tnumber_supportfn\` stays unregistered).

## Test plan

- [x] \`cmake --build . --target shell unittest\` clean
- [x] New parity test passes (12/12)
- [x] Full suite green (764/14)