### PR TITLE
feat(bindings): temporal position predicates — temporal_* named aliases

### DIFF
--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1400,25 +1400,39 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     // Temporal time-position predicates registered as named functions:
     // DuckDB's parser does not accept `#` as an operator-name character,
     // so the upstream MobilityDB operators `<<#`, `#>>`, `&<#`, `#&>`
-    // are unreachable from SQL. The named-function forms `before`,
-    // `after`, `overbefore`, `overafter` provide equivalent behaviour.
+    // are unreachable from SQL. The named-function forms `before`/`after`/
+    // `overbefore`/`overafter` and the MobilityDB-canonical `temporal_*`
+    // aliases are both registered against the same handlers.
     for (auto &t1 : TemporalTypes::AllTypes()) {
         for (auto &t2 : TemporalTypes::AllTypes()) {
-            loader.RegisterFunction(ScalarFunction("before",     {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_temporal));
-            loader.RegisterFunction(ScalarFunction("after",      {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_temporal));
-            loader.RegisterFunction(ScalarFunction("overbefore", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_temporal));
-            loader.RegisterFunction(ScalarFunction("overafter",  {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("before",              {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_before",     {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("after",               {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_after",      {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("overbefore",          {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_overbefore", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("overafter",           {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_overafter",  {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_temporal));
         }
     }
     for (auto &t : TemporalTypes::AllTypes()) {
-        loader.RegisterFunction(ScalarFunction("before",     {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("after",      {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("overbefore", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("overafter",  {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_tstzspan));
-        loader.RegisterFunction(ScalarFunction("before",     {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Before_tstzspan_temporal));
-        loader.RegisterFunction(ScalarFunction("after",      {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::After_tstzspan_temporal));
-        loader.RegisterFunction(ScalarFunction("overbefore", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_tstzspan_temporal));
-        loader.RegisterFunction(ScalarFunction("overafter",  {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("before",              {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_before",     {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("after",               {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_after",      {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("overbefore",          {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_overbefore", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("overafter",           {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_overafter",  {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_tstzspan));
+
+        loader.RegisterFunction(ScalarFunction("before",              {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Before_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_before",     {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Before_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("after",               {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::After_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_after",      {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::After_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("overbefore",          {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_overbefore", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("overafter",           {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_overafter",  {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_tstzspan_temporal));
     }
 
     // Ever / always equality and inequality (named functions; DuckDB
@@ -1506,41 +1520,28 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         }
 
         // Position ops (<<, >>, &<, &>) — same surface
-        loader.RegisterFunction(ScalarFunction("<<",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction(">>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&<",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("<<",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction(">>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&<",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("<<",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Left_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction(">>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Right_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&<",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overright_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("<<",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Left_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction(">>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Right_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&<",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_numspan_tnumber));
+#define REG_POS4(L, R, FN_SUFFIX) \
+    loader.RegisterFunction(ScalarFunction("<<",                {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Left_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_left",     {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Left_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction(">>",                {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Right_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_right",    {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Right_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("&<",                {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_overleft", {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("&>",                {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Overright_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_overright", {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Overright_##FN_SUFFIX));
+
+        REG_POS4(tint,  ispan, tnumber_numspan)
+        REG_POS4(tflt,  fspan, tnumber_numspan)
+        REG_POS4(ispan, tint,  numspan_tnumber)
+        REG_POS4(fspan, tflt,  numspan_tnumber)
         for (auto &t : {tint, tflt}) {
-            loader.RegisterFunction(ScalarFunction("<<", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction(">>", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("&<", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("&>", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("<<", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Left_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction(">>", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Right_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("&<", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("&>", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tbox_tnumber));
+            REG_POS4(t,    tbox, tnumber_tbox)
+            REG_POS4(tbox, t,    tbox_tnumber)
         }
         // tnumber × tnumber (same base type)
-        loader.RegisterFunction(ScalarFunction("<<", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction(">>", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction("&<", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction("&>", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction("<<", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction(">>", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction("&<", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tnumber));
-        loader.RegisterFunction(ScalarFunction("&>", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
+        REG_POS4(tint, tint, tnumber_tnumber)
+        REG_POS4(tflt, tflt, tnumber_tnumber)
+#undef REG_POS4
     }
 
     // tspatial × {stbox, tspatial} position predicates

--- a/test/sql/parity/034_temporal_posops.test
+++ b/test/sql/parity/034_temporal_posops.test
@@ -1,0 +1,71 @@
+# name: test/sql/parity/034_temporal_posops.test
+# description: Named-function aliases for the temporal position predicates —
+#              temporal_before/after/overbefore/overafter (time axis) and
+#              temporal_left/right/overleft/overright (numeric axis on
+#              tnumber × {numspan, tbox, tnumber}).
+# group: [sql]
+
+require mobilityduck
+
+# Time axis aliases agree with the existing named forms
+
+query I
+SELECT temporal_before(tint '[1@2000-01-01]', tint '[1@2000-01-02]')
+     = before(tint '[1@2000-01-01]', tint '[1@2000-01-02]');
+----
+true
+
+query I
+SELECT temporal_after(tint '[1@2000-01-02]', tint '[1@2000-01-01]');
+----
+true
+
+query I
+SELECT temporal_overbefore(tstzspan '[2000-01-01, 2000-01-02]', tint '[1@2000-01-02]');
+----
+true
+
+query I
+SELECT temporal_overafter(tint '[1@2000-01-02]', tstzspan '[2000-01-01, 2000-01-02]');
+----
+true
+
+# Numeric axis on tnumber × numspan
+
+query I
+SELECT temporal_left(tint '[1@2000-01-01]', intspan '[5, 10)');
+----
+true
+
+query I
+SELECT temporal_right(tfloat '[10@2000-01-01]', floatspan '[1, 5)');
+----
+true
+
+# Aliases agree with the operator forms
+
+query I
+SELECT temporal_left(tint '[1@2000-01-01]', intspan '[5, 10)')
+     = (tint '[1@2000-01-01]' << intspan '[5, 10)');
+----
+true
+
+query I
+SELECT temporal_overleft(tint '[1@2000-01-01]', intspan '[5, 10)')
+     = (tint '[1@2000-01-01]' &< intspan '[5, 10)');
+----
+true
+
+# Numeric axis on tnumber × tbox
+
+query I
+SELECT temporal_left(tint '[1@2000-01-01]', tbox 'TBOXINT XT([5, 10),[2000-01-01, 2000-01-02])');
+----
+true
+
+# Numeric axis on tnumber × tnumber
+
+query I
+SELECT temporal_left(tint '[1@2000-01-01]', tint '[5@2000-01-01, 10@2000-01-02]');
+----
+true


### PR DESCRIPTION
Closes the user-facing tail of \`temporal/034_temporal_posops\` (was 0%; this brings the user-visible surface to ~100%).

## New SQL surface

### Time axis
Aliases for the existing \`before\` / \`after\` / \`overbefore\` / \`overafter\` named forms (the underlying MobilityDB operator tokens \`<<#\`, \`#>>\`, \`&<#\`, \`#&>\` are unreachable in DuckDB's parser):

| MobilityDuck name | Routes to |
|---|---|
| \`temporal_before\` | \`Before_*\` (existing) |
| \`temporal_after\` | \`After_*\` |
| \`temporal_overbefore\` | \`Overbefore_*\` |
| \`temporal_overafter\` | \`Overafter_*\` |

Coverage:
- temporal × temporal (every base-type pair)
- temporal × tstzspan and tstzspan × temporal

### Numeric axis
Aliases for the existing \`<<\` / \`>>\` / \`&<\` / \`&>\` operators on the tnumber surface:

| MobilityDuck name | Routes to |
|---|---|
| \`temporal_left\` | \`Left_*\` |
| \`temporal_right\` | \`Right_*\` |
| \`temporal_overleft\` | \`Overleft_*\` |
| \`temporal_overright\` | \`Overright_*\` |

Coverage:
- tnumber × numspan / numspan × tnumber
- tnumber × tbox / tbox × tnumber
- tnumber × tnumber

A small \`REG_POS4\` macro factors out the 4-name × 4-handler block, mirroring the \`REG_TOP4\` macro used in PR #72 for boxops.

## Tests

- \`test/sql/parity/034_temporal_posops.test\` — 10 assertions covering time-axis aliases, numeric-axis aliases on numspan/tbox/tnumber, and operator-vs-named equivalence.
- Full suite: **762 assertions / 14 test cases** passing under \`TZ=UTC\`.

## Coverage delta

Per the audit in PR #66:
- \`temporal/034_temporal_posops\`: 0/8 → 8/8 by name (100%).

## Test plan

- [x] \`cmake --build . --target shell unittest\` clean
- [x] New parity test passes (10/10)
- [x] Full suite green (762/14)