### PR TITLE
feat(bindings): tspatial topological predicates — operators + named aliases

### DIFF
--- a/src/geo/stbox.cpp
+++ b/src/geo/stbox.cpp
@@ -3,6 +3,7 @@
 #include "common.hpp"
 #include "geo/stbox.hpp"
 #include "geo/stbox_functions.hpp"
+#include "geo/tgeompoint.hpp"
 
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/function/function.hpp"
@@ -466,6 +467,32 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Adjacent_stbox_stbox
         )
     );
+
+    /* ***************************************************
+     * Tspatial topological predicates (5 ops × 3 type pairs)
+     * Operators + MobilityDB-canonical named-function aliases.
+     ****************************************************/
+    {
+        const auto P = TgeompointType::TGEOMPOINT();
+        const auto B = STBOX();
+
+#define REG_TSPATIAL_TOPO(L, R, FN_SUFFIX)                                                                                       \
+    loader.RegisterFunction(ScalarFunction("@>",                {L, R}, LogicalType::BOOLEAN, StboxFunctions::Contains_##FN_SUFFIX));   \
+    loader.RegisterFunction(ScalarFunction("temporal_contains", {L, R}, LogicalType::BOOLEAN, StboxFunctions::Contains_##FN_SUFFIX));   \
+    loader.RegisterFunction(ScalarFunction("<@",                 {L, R}, LogicalType::BOOLEAN, StboxFunctions::Contained_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_contained", {L, R}, LogicalType::BOOLEAN, StboxFunctions::Contained_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("&&",                {L, R}, LogicalType::BOOLEAN, StboxFunctions::Overlaps_##FN_SUFFIX));   \
+    loader.RegisterFunction(ScalarFunction("temporal_overlaps", {L, R}, LogicalType::BOOLEAN, StboxFunctions::Overlaps_##FN_SUFFIX));   \
+    loader.RegisterFunction(ScalarFunction("~=",                {L, R}, LogicalType::BOOLEAN, StboxFunctions::Same_##FN_SUFFIX));       \
+    loader.RegisterFunction(ScalarFunction("temporal_same",     {L, R}, LogicalType::BOOLEAN, StboxFunctions::Same_##FN_SUFFIX));       \
+    loader.RegisterFunction(ScalarFunction("-|-",                {L, R}, LogicalType::BOOLEAN, StboxFunctions::Adjacent_##FN_SUFFIX));  \
+    loader.RegisterFunction(ScalarFunction("temporal_adjacent", {L, R}, LogicalType::BOOLEAN, StboxFunctions::Adjacent_##FN_SUFFIX));
+
+        REG_TSPATIAL_TOPO(P, B, tspatial_stbox)
+        REG_TSPATIAL_TOPO(B, P, stbox_tspatial)
+        REG_TSPATIAL_TOPO(P, P, tspatial_tspatial)
+#undef REG_TSPATIAL_TOPO
+    }
 
         loader.RegisterFunction(
         ScalarFunction(

--- a/src/geo/stbox_functions.cpp
+++ b/src/geo/stbox_functions.cpp
@@ -2834,6 +2834,69 @@ void StboxFunctions::Stbox_cmp(DataChunk &args, ExpressionState &state, Vector &
     }
 }
 
+/* ***************************************************
+ * Tspatial topological predicates against stbox / tspatial
+ ****************************************************/
 
+namespace {
+
+inline Temporal *BlobToTemp(string_t b) {
+    size_t sz = b.GetSize();
+    uint8_t *copy = (uint8_t *)malloc(sz);
+    memcpy(copy, b.GetData(), sz);
+    return reinterpret_cast<Temporal *>(copy);
+}
+
+inline STBox *BlobToStbox(string_t b) {
+    size_t sz = b.GetSize();
+    uint8_t *copy = (uint8_t *)malloc(sz);
+    memcpy(copy, b.GetData(), sz);
+    return reinterpret_cast<STBox *>(copy);
+}
+
+} // namespace
+
+#define DEFINE_TSPATIAL_TOPO(OP, MEOS)                                                                                                       \
+void StboxFunctions::OP##_tspatial_stbox(DataChunk &args, ExpressionState &state, Vector &result) {                                          \
+    BinaryExecutor::Execute<string_t, string_t, bool>(                                                                                       \
+        args.data[0], args.data[1], result, args.size(),                                                                                     \
+        [](string_t bt, string_t bs) -> bool {                                                                                               \
+            Temporal *t = BlobToTemp(bt);                                                                                                    \
+            STBox    *s = BlobToStbox(bs);                                                                                                   \
+            bool r = MEOS##_tspatial_stbox(t, s);                                                                                            \
+            free(t); free(s);                                                                                                                \
+            return r;                                                                                                                        \
+        });                                                                                                                                   \
+}                                                                                                                                             \
+void StboxFunctions::OP##_stbox_tspatial(DataChunk &args, ExpressionState &state, Vector &result) {                                          \
+    BinaryExecutor::Execute<string_t, string_t, bool>(                                                                                       \
+        args.data[0], args.data[1], result, args.size(),                                                                                     \
+        [](string_t bs, string_t bt) -> bool {                                                                                               \
+            STBox    *s = BlobToStbox(bs);                                                                                                   \
+            Temporal *t = BlobToTemp(bt);                                                                                                    \
+            bool r = MEOS##_stbox_tspatial(s, t);                                                                                            \
+            free(s); free(t);                                                                                                                \
+            return r;                                                                                                                        \
+        });                                                                                                                                   \
+}                                                                                                                                             \
+void StboxFunctions::OP##_tspatial_tspatial(DataChunk &args, ExpressionState &state, Vector &result) {                                       \
+    BinaryExecutor::Execute<string_t, string_t, bool>(                                                                                       \
+        args.data[0], args.data[1], result, args.size(),                                                                                     \
+        [](string_t b1, string_t b2) -> bool {                                                                                               \
+            Temporal *t1 = BlobToTemp(b1);                                                                                                   \
+            Temporal *t2 = BlobToTemp(b2);                                                                                                   \
+            bool r = MEOS##_tspatial_tspatial(t1, t2);                                                                                       \
+            free(t1); free(t2);                                                                                                              \
+            return r;                                                                                                                        \
+        });                                                                                                                                   \
+}
+
+DEFINE_TSPATIAL_TOPO(Contains,  contains)
+DEFINE_TSPATIAL_TOPO(Contained, contained)
+DEFINE_TSPATIAL_TOPO(Overlaps,  overlaps)
+DEFINE_TSPATIAL_TOPO(Same,      same)
+DEFINE_TSPATIAL_TOPO(Adjacent,  adjacent)
+
+#undef DEFINE_TSPATIAL_TOPO
 
 } // namespace duckdb

--- a/src/include/geo/stbox_functions.hpp
+++ b/src/include/geo/stbox_functions.hpp
@@ -104,6 +104,18 @@ struct StboxFunctions {
     static void Same_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result);
 
+#define DECL_TSPATIAL_TOPO(OP)                                                                                  \
+    static void OP##_tspatial_stbox(DataChunk &args, ExpressionState &state, Vector &result);                   \
+    static void OP##_stbox_tspatial(DataChunk &args, ExpressionState &state, Vector &result);                   \
+    static void OP##_tspatial_tspatial(DataChunk &args, ExpressionState &state, Vector &result);
+
+    DECL_TSPATIAL_TOPO(Contains)
+    DECL_TSPATIAL_TOPO(Contained)
+    DECL_TSPATIAL_TOPO(Overlaps)
+    DECL_TSPATIAL_TOPO(Same)
+    DECL_TSPATIAL_TOPO(Adjacent)
+#undef DECL_TSPATIAL_TOPO
+
     /* ***************************************************
      * Position operators
      ****************************************************/

--- a/test/sql/parity/060_tspatial_topops.test
+++ b/test/sql/parity/060_tspatial_topops.test
@@ -1,0 +1,72 @@
+# name: test/sql/parity/060_tspatial_topops.test
+# description: Tspatial × {stbox, tspatial} topological predicates —
+#              temporal_contains/contained/overlaps/same/adjacent and the
+#              corresponding @>/<@/&&/~=/-|- operator forms.
+# group: [sql]
+
+require mobilityduck
+
+# Operator + named-function forms are equivalent
+
+query I
+SELECT (tgeompoint '[POINT(0 0)@2000-01-01, POINT(10 10)@2000-01-02]'
+        @> stbox 'STBOX X((1, 1), (5, 5))')
+     = temporal_contains(tgeompoint '[POINT(0 0)@2000-01-01, POINT(10 10)@2000-01-02]',
+                         stbox 'STBOX X((1, 1), (5, 5))');
+----
+true
+
+# stbox × tspatial direction
+
+query I
+SELECT temporal_overlaps(stbox 'STBOX X((0, 0), (10, 10))',
+                         tgeompoint '[POINT(5 5)@2000-01-01]');
+----
+true
+
+query I
+SELECT (stbox 'STBOX X((0, 0), (10, 10))' && tgeompoint '[POINT(5 5)@2000-01-01]');
+----
+true
+
+# Same on tgeompoint × tgeompoint
+
+query I
+SELECT temporal_same(tgeompoint '[POINT(0 0)@2000-01-01]',
+                     tgeompoint '[POINT(0 0)@2000-01-01]');
+----
+true
+
+query I
+SELECT (tgeompoint '[POINT(0 0)@2000-01-01]' ~= tgeompoint '[POINT(0 0)@2000-01-01]');
+----
+true
+
+# Disjoint trajectories: not same, not contains
+
+query I
+SELECT temporal_same(tgeompoint '[POINT(0 0)@2000-01-01]',
+                     tgeompoint '[POINT(1 1)@2000-01-01]');
+----
+false
+
+# Adjacent — point on the box corner shares the boundary
+
+query I
+SELECT temporal_adjacent(tgeompoint '[POINT(0 0)@2000-01-01]', stbox 'STBOX X((0, 0), (5, 5))');
+----
+true
+
+# Contains via stbox × tspatial
+
+query I
+SELECT temporal_contains(stbox 'STBOX X((0, 0), (10, 10))', tgeompoint '[POINT(5 5)@2000-01-01]');
+----
+true
+
+# Contained as the inverse
+
+query I
+SELECT temporal_contained(tgeompoint '[POINT(5 5)@2000-01-01]', stbox 'STBOX X((0, 0), (10, 10))');
+----
+true


### PR DESCRIPTION
Adds the **5 topological predicates** across the \`tspatial × {stbox, tspatial}\` surface that previously had no handlers in MobilityDuck.

## New SQL surface

Five predicates: \`contains\` / \`contained\` / \`overlaps\` / \`same\` / \`adjacent\`. Each is registered both as the operator form and as the MobilityDB-canonical named-function alias.

| Operator | Alias |
|---|---|
| \`@>\` | \`temporal_contains\` |
| \`<@\` | \`temporal_contained\` |
| \`&&\` | \`temporal_overlaps\` |
| \`~=\` | \`temporal_same\` |
| \`-|-\` | \`temporal_adjacent\` |

Coverage:
- \`tgeompoint × stbox\`
- \`stbox × tgeompoint\`
- \`tgeompoint × tgeompoint\`

That's 5 ops × 2 names × 3 type-pairs = **30 new registrations** plus 15 new handler functions.

## Implementation

Three new handler families per op, each calling the matching MEOS export (\`contains_tspatial_stbox\` / \`contains_stbox_tspatial\` / \`contains_tspatial_tspatial\`, ditto for contained/overlaps/same/adjacent). A \`DEFINE_TSPATIAL_TOPO\` macro in \`stbox_functions.cpp\` factors the boilerplate; a parallel \`REG_TSPATIAL_TOPO\` macro in \`stbox.cpp\` emits the operator + named-alias pair for each \`(L, R, FN_SUFFIX)\` triple.

## Closes the temporal_same gap

PR #72 (\`temporal/032_temporal_boxops\`) deferred \`temporal_same\` because the underlying \`Same_*\` handler family wasn't wired. This PR adds them on the tspatial side. The \`stbox × stbox\` \`~=\` operator was already wired (with \`Same_stbox_stbox\`); the \`temporal × temporal\` and \`tnumber × {numspan, tbox}\` \`~=\` cases stay deferred — separate small follow-up.

## Tests

- \`test/sql/parity/060_tspatial_topops.test\` — 9 assertions covering each of the 5 ops in both directions plus operator-vs-alias equivalence.
- Full suite: **761 assertions / 14 test cases** passing under \`TZ=UTC\`.

## Coverage delta

Per the audit in PR #66:
- \`geo/060_tpoint_boxops\` and \`geo/060_tgeo_boxops\` move significantly closer to 100%; the remaining gaps are \`stboxes\`/\`splitN/EachNStboxes\` (already in PR #64) and \`tgeography\`/\`tgeogpoint\` overloads.

## Test plan

- [x] \`cmake --build . --target shell unittest\` clean
- [x] New parity test passes (9/9)
- [x] Full suite green (761/14)