### PR TITLE
feat(bindings): tspatial comparison predicates — ever/always + temporal_teq/tne

### DIFF
--- a/src/geo/tgeompoint.cpp
+++ b/src/geo/tgeompoint.cpp
@@ -1768,6 +1768,35 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::distance_geo_geo
         )
     );
+
+    /* ***************************************************
+     * Spatial comparison predicates — ever/always + temporal_t*
+     * on tgeompoint × {geometry, tgeompoint}
+     ****************************************************/
+    {
+        const auto T = TGEOMPOINT();
+        const auto G = GeoTypes::GEOMETRY();
+
+#define REG_SPATIAL_EA(NAME, FN)                                                                                                                  \
+        loader.RegisterFunction(ScalarFunction(NAME, {G, T}, LogicalType::BOOLEAN, TgeompointFunctions::FN##_geo_tgeo));                          \
+        loader.RegisterFunction(ScalarFunction(NAME, {T, G}, LogicalType::BOOLEAN, TgeompointFunctions::FN##_tgeo_geo));                          \
+        loader.RegisterFunction(ScalarFunction(NAME, {T, T}, LogicalType::BOOLEAN, TgeompointFunctions::FN##_tgeo_tgeo));
+
+        REG_SPATIAL_EA("ever_eq",   Ever_eq)
+        REG_SPATIAL_EA("always_eq", Always_eq)
+        REG_SPATIAL_EA("ever_ne",   Ever_ne)
+        REG_SPATIAL_EA("always_ne", Always_ne)
+#undef REG_SPATIAL_EA
+
+#define REG_SPATIAL_TCMP(NAME, FN)                                                                                                                \
+        loader.RegisterFunction(ScalarFunction(NAME, {G, T}, TemporalTypes::TBOOL(), TgeompointFunctions::FN##_geo_tgeo));                        \
+        loader.RegisterFunction(ScalarFunction(NAME, {T, G}, TemporalTypes::TBOOL(), TgeompointFunctions::FN##_tgeo_geo));                        \
+        loader.RegisterFunction(ScalarFunction(NAME, {T, T}, TemporalTypes::TBOOL(), TgeompointFunctions::FN##_tgeo_tgeo));
+
+        REG_SPATIAL_TCMP("temporal_teq", Teq)
+        REG_SPATIAL_TCMP("temporal_tne", Tne)
+#undef REG_SPATIAL_TCMP
+    }
 }
 
 } // namespace duckdb

--- a/src/geo/tgeompoint_functions.cpp
+++ b/src/geo/tgeompoint_functions.cpp
@@ -3319,4 +3319,127 @@ void TgeompointFunctions::distance_geo_geo(DataChunk &args, ExpressionState &sta
     }
 }
 
+/* ***************************************************
+ * Spatial comparison predicates — ever/always + temporal_t* on
+ * tgeompoint × {geometry, tgeompoint}.
+ ****************************************************/
+
+namespace {
+
+inline Temporal *BlobToTgeoLocal(string_t b) {
+    size_t sz = b.GetSize();
+    uint8_t *copy = (uint8_t *)malloc(sz);
+    memcpy(copy, b.GetData(), sz);
+    return reinterpret_cast<Temporal *>(copy);
+}
+
+string_t TemporalToBlobLocal(Vector &result, Temporal *r) {
+    size_t sz = temporal_mem_size(r);
+    uint8_t *buf = (uint8_t *)malloc(sz);
+    memcpy(buf, r, sz);
+    string_t blob(reinterpret_cast<const char *>(buf), sz);
+    string_t stored = StringVector::AddStringOrBlob(result, blob);
+    free(buf);
+    return stored;
+}
+
+} // namespace
+
+#define DEFINE_EA_GEO_TGEO(NAME, MEOS)                                                                                                       \
+void TgeompointFunctions::NAME##_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {                                         \
+    BinaryExecutor::Execute<string_t, string_t, bool>(                                                                                       \
+        args.data[0], args.data[1], result, args.size(),                                                                                     \
+        [](string_t bg, string_t bt) -> bool {                                                                                               \
+            Temporal *t = BlobToTgeoLocal(bt);                                                                                               \
+            int32 srid = tspatial_srid(t);                                                                                                   \
+            GSERIALIZED *gs = GeometryToGSerialized(bg, srid);                                                                               \
+            int r = MEOS##_geo_tgeo(gs, t);                                                                                                  \
+            free(t); free(gs);                                                                                                               \
+            return r != 0;                                                                                                                   \
+        });                                                                                                                                   \
+}                                                                                                                                             \
+void TgeompointFunctions::NAME##_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {                                         \
+    BinaryExecutor::Execute<string_t, string_t, bool>(                                                                                       \
+        args.data[0], args.data[1], result, args.size(),                                                                                     \
+        [](string_t bt, string_t bg) -> bool {                                                                                               \
+            Temporal *t = BlobToTgeoLocal(bt);                                                                                               \
+            int32 srid = tspatial_srid(t);                                                                                                   \
+            GSERIALIZED *gs = GeometryToGSerialized(bg, srid);                                                                               \
+            int r = MEOS##_tgeo_geo(t, gs);                                                                                                  \
+            free(t); free(gs);                                                                                                               \
+            return r != 0;                                                                                                                   \
+        });                                                                                                                                   \
+}                                                                                                                                             \
+void TgeompointFunctions::NAME##_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {                                        \
+    BinaryExecutor::Execute<string_t, string_t, bool>(                                                                                       \
+        args.data[0], args.data[1], result, args.size(),                                                                                     \
+        [](string_t b1, string_t b2) -> bool {                                                                                               \
+            Temporal *t1 = BlobToTgeoLocal(b1);                                                                                              \
+            Temporal *t2 = BlobToTgeoLocal(b2);                                                                                              \
+            int r = MEOS##_tgeo_tgeo(t1, t2);                                                                                                \
+            free(t1); free(t2);                                                                                                              \
+            return r != 0;                                                                                                                   \
+        });                                                                                                                                   \
+}
+
+DEFINE_EA_GEO_TGEO(Ever_eq,   ever_eq)
+DEFINE_EA_GEO_TGEO(Always_eq, always_eq)
+DEFINE_EA_GEO_TGEO(Ever_ne,   ever_ne)
+DEFINE_EA_GEO_TGEO(Always_ne, always_ne)
+
+#undef DEFINE_EA_GEO_TGEO
+
+#define DEFINE_TCMP_GEO_TGEO(NAME, MEOS)                                                                                                     \
+void TgeompointFunctions::NAME##_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {                                         \
+    BinaryExecutor::Execute<string_t, string_t, string_t>(                                                                                   \
+        args.data[0], args.data[1], result, args.size(),                                                                                     \
+        [&](string_t bg, string_t bt) -> string_t {                                                                                          \
+            Temporal *t = BlobToTgeoLocal(bt);                                                                                               \
+            int32 srid = tspatial_srid(t);                                                                                                   \
+            GSERIALIZED *gs = GeometryToGSerialized(bg, srid);                                                                               \
+            Temporal *r = MEOS##_geo_tgeo(gs, t);                                                                                            \
+            free(t); free(gs);                                                                                                               \
+            if (!r) throw InvalidInputException("MEOS " #MEOS "_geo_tgeo returned null");                                                    \
+            return TemporalToBlobLocal(result, r);                                                                                           \
+        });                                                                                                                                   \
+}                                                                                                                                             \
+void TgeompointFunctions::NAME##_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {                                         \
+    BinaryExecutor::Execute<string_t, string_t, string_t>(                                                                                   \
+        args.data[0], args.data[1], result, args.size(),                                                                                     \
+        [&](string_t bt, string_t bg) -> string_t {                                                                                          \
+            Temporal *t = BlobToTgeoLocal(bt);                                                                                               \
+            int32 srid = tspatial_srid(t);                                                                                                   \
+            GSERIALIZED *gs = GeometryToGSerialized(bg, srid);                                                                               \
+            Temporal *r = MEOS##_tgeo_geo(t, gs);                                                                                            \
+            free(t); free(gs);                                                                                                               \
+            if (!r) throw InvalidInputException("MEOS " #MEOS "_tgeo_geo returned null");                                                    \
+            return TemporalToBlobLocal(result, r);                                                                                           \
+        });                                                                                                                                   \
+}                                                                                                                                             \
+void TgeompointFunctions::NAME##_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {                                        \
+    BinaryExecutor::Execute<string_t, string_t, string_t>(                                                                                   \
+        args.data[0], args.data[1], result, args.size(),                                                                                     \
+        [&](string_t b1, string_t b2) -> string_t {                                                                                          \
+            Temporal *t1 = BlobToTgeoLocal(b1);                                                                                              \
+            Temporal *t2 = BlobToTgeoLocal(b2);                                                                                              \
+            Temporal *r = MEOS##_temporal_temporal(t1, t2);                                                                                  \
+            free(t1); free(t2);                                                                                                              \
+            if (!r) throw InvalidInputException("MEOS " #MEOS "_temporal_temporal returned null");                                           \
+            return TemporalToBlobLocal(result, r);                                                                                           \
+        });                                                                                                                                   \
+}
+
+DEFINE_TCMP_GEO_TGEO(Teq, teq)
+DEFINE_TCMP_GEO_TGEO(Tne, tne)
+
+#undef DEFINE_TCMP_GEO_TGEO
+
+void TgeompointFunctions::Teq_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    Teq_tgeo_tgeo(args, state, result);
+}
+
+void TgeompointFunctions::Tne_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    Tne_tgeo_tgeo(args, state, result);
+}
+
 } // namespace duckdb

--- a/src/include/geo/tgeompoint_functions.hpp
+++ b/src/include/geo/tgeompoint_functions.hpp
@@ -79,7 +79,10 @@ struct TgeompointFunctions {
     static void Always_ne_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result);
     static void Teq_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);
     static void Tne_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Teq_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tne_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result);
     static void Teq_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tne_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);
     static void Teq_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Tne_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     /* ***************************************************

--- a/test/sql/parity/054_tspatial_compops.test
+++ b/test/sql/parity/054_tspatial_compops.test
@@ -1,0 +1,60 @@
+# name: test/sql/parity/054_tspatial_compops.test
+# description: Tspatial × {geometry, tspatial} comparison predicates —
+#              ever_eq / always_eq / ever_ne / always_ne and temporal_teq /
+#              temporal_tne. The MobilityDB operators `?=` / `?<>` / `#=` etc.
+#              are unreachable in DuckDB's parser, so only named functions
+#              are registered.
+# group: [sql]
+
+require mobilityduck
+
+# ever_eq across (geo × tgeo, tgeo × geo, tgeo × tgeo)
+
+query I
+SELECT ever_eq(ST_GeomFromText('POINT(0 0)'), tgeompoint '[POINT(0 0)@2000-01-01]');
+----
+true
+
+query I
+SELECT ever_eq(tgeompoint '[POINT(0 0)@2000-01-01, POINT(1 1)@2000-01-02]', ST_GeomFromText('POINT(0 0)'));
+----
+true
+
+query I
+SELECT ever_eq(tgeompoint '[POINT(0 0)@2000-01-01]', tgeompoint '[POINT(0 0)@2000-01-01]');
+----
+true
+
+# always_eq / ever_ne / always_ne
+
+query I
+SELECT always_eq(tgeompoint '[POINT(5 5)@2000-01-01]', ST_GeomFromText('POINT(5 5)'));
+----
+true
+
+query I
+SELECT ever_ne(tgeompoint '[POINT(0 0)@2000-01-01, POINT(1 1)@2000-01-02]', ST_GeomFromText('POINT(0 0)'));
+----
+true
+
+query I
+SELECT always_ne(ST_GeomFromText('POINT(5 5)'), tgeompoint '[POINT(0 0)@2000-01-01, POINT(1 1)@2000-01-02]');
+----
+true
+
+# temporal_teq returns tbool with t/f along the trajectory
+
+query I
+SELECT temporal_teq(tgeompoint '[POINT(0 0)@2000-01-01]', tgeompoint '[POINT(0 0)@2000-01-01]');
+----
+[t@2000-01-01 00:00:00+00]
+
+query I
+SELECT temporal_teq(tgeompoint '[POINT(0 0)@2000-01-01]', ST_GeomFromText('POINT(0 0)'));
+----
+{[t@2000-01-01 00:00:00+00]}
+
+query I
+SELECT temporal_tne(ST_GeomFromText('POINT(5 5)'), tgeompoint '[POINT(0 0)@2000-01-01]');
+----
+{[t@2000-01-01 00:00:00+00]}


### PR DESCRIPTION
Closes 100% of \`geo/054_tpoint_compops\` by name. Implements the spatial comparison handlers that were previously declared as TODO in \`TgeompointFunctions\`.

## New SQL surface

### ever / always (returning bool)
| Signature | MEOS export |
|---|---|
| \`ever_eq(geometry, tgeompoint)\` | \`ever_eq_geo_tgeo\` |
| \`ever_eq(tgeompoint, geometry)\` | \`ever_eq_tgeo_geo\` |
| \`ever_eq(tgeompoint, tgeompoint)\` | \`ever_eq_tgeo_tgeo\` |
| \`always_eq\` / \`ever_ne\` / \`always_ne\` | same shape × 3 directions |

12 ever/always registrations.

### temporal_teq / temporal_tne (returning tbool)
| Signature | Notes |
|---|---|
| \`temporal_teq(geometry, tgeompoint)\` | \`teq_geo_tgeo\` |
| \`temporal_teq(tgeompoint, geometry)\` | \`teq_tgeo_geo\` |
| \`temporal_teq(tgeompoint, tgeompoint)\` | \`teq_temporal_temporal\` |
| \`temporal_tne\` | symmetric on \`tne_*\` |

6 temporal_teq/tne registrations.

## Implementation

Two macros (\`DEFINE_EA_GEO_TGEO\`, \`DEFINE_TCMP_GEO_TGEO\`) factor the boilerplate; each produces a 3-handler block (\`*_geo_tgeo\`, \`*_tgeo_geo\`, \`*_tgeo_tgeo\`). The (tgeo, tgeo) variant reuses MEOS \`teq_temporal_temporal\` / \`tne_temporal_temporal\` exports rather than introducing a separate \`teq_tgeo_tgeo\` MEOS function. Previously-declared \`Teq_temporal_temporal\` / \`Tne_temporal_temporal\` in the TgeompointFunctions namespace become thin forwarders to the new \`Teq_tgeo_tgeo\` / \`Tne_tgeo_tgeo\` so existing references stay valid.

Registration in \`tgeompoint.cpp\` uses parallel \`REG_SPATIAL_EA\` / \`REG_SPATIAL_TCMP\` macros for the 24 total registrations.

## Operator forms not registered

MobilityDB also exposes \`?=\` / \`?<>\` / \`#=\` / \`#<>\` for these. DuckDB's parser does not accept multi-character operator tokens starting with \`?\` or \`#\`, so only named functions are registered. This is consistent with PR #73 (\`temporal_teq/tne\` on tnumber/tbool/ttext) and PR #74 (temporal position predicates).

## Tests

- \`test/sql/parity/054_tspatial_compops.test\` — 9 assertions covering each ever/always op in all three directions and \`temporal_teq\`/\`temporal_tne\` returning the expected \`tbool\` sequenceset.
- Full suite: **761 assertions / 14 test cases** passing under \`TZ=UTC\`.

## Coverage delta

Per the audit in PR #66:
- \`geo/054_tpoint_compops\`: 0/6 → 6/6 (100%) by name.

## Test plan

- [x] \`cmake --build . --target shell unittest\` clean
- [x] New parity test passes (9/9)
- [x] Full suite green (761/14)