### PR TITLE
feat(bindings): tspatial position predicates — temporal_* aliases + time-axis

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -460,6 +460,22 @@ struct TemporalFunctions {
     static void Overback_tspatial_tspatial(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * Time-axis position predicates on tspatial
+     ****************************************************/
+    static void Before_tspatial_stbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void After_tspatial_stbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overbefore_tspatial_stbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overafter_tspatial_stbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Before_stbox_tspatial(DataChunk &args, ExpressionState &state, Vector &result);
+    static void After_stbox_tspatial(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overbefore_stbox_tspatial(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overafter_stbox_tspatial(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Before_tspatial_tspatial(DataChunk &args, ExpressionState &state, Vector &result);
+    static void After_tspatial_tspatial(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overbefore_tspatial_tspatial(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Overafter_tspatial_tspatial(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Text functions on ttext
      ****************************************************/
     static void Ttext_lower(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1543,50 +1543,50 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(ScalarFunction("&>", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
     }
 
-    // tspatial × {stbox, tspatial} position predicates
+    // tspatial × {stbox, tspatial} position predicates.
+    //
+    // For each direction (left/right/below/above/front/back and the over*
+    // variants, plus the time-axis before/after/overbefore/overafter), the
+    // predicate is registered both as the operator form (where DuckDB's
+    // parser accepts the token, only L/R for now: <<, >>, &<, &>) and as
+    // both the bare named form (left/right/below/above/front/back/before/
+    // after/overbelow/overabove/overfront/overback/overbefore/overafter)
+    // and the MobilityDB-canonical `temporal_*` alias.
     {
         auto tg    = TgeompointType::TGEOMPOINT();
         auto stbox = StboxType::STBOX();
 
-        // L/R operators (DuckDB parser-friendly)
-        loader.RegisterFunction(ScalarFunction("<<", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Left_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction(">>", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Right_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("&<", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("&>", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("<<", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Left_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction(">>", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Right_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("&<", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("&>", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overright_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("<<", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Left_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction(">>", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Right_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("&<", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overleft_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("&>", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overright_tspatial_tspatial));
+#define REG_TSPATIAL_OP(SQL_NAME, ALIAS, FN)                                                                                       \
+        loader.RegisterFunction(ScalarFunction(SQL_NAME, {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::FN##_tspatial_stbox));   \
+        loader.RegisterFunction(ScalarFunction(ALIAS,    {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::FN##_tspatial_stbox));   \
+        loader.RegisterFunction(ScalarFunction(SQL_NAME, {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::FN##_stbox_tspatial));   \
+        loader.RegisterFunction(ScalarFunction(ALIAS,    {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::FN##_stbox_tspatial));   \
+        loader.RegisterFunction(ScalarFunction(SQL_NAME, {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::FN##_tspatial_tspatial));\
+        loader.RegisterFunction(ScalarFunction(ALIAS,    {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::FN##_tspatial_tspatial));
 
-        // Above/below/front/back as named functions (DuckDB parser rejects |>>, <<|, etc.)
-        loader.RegisterFunction(ScalarFunction("below",     {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Below_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("above",     {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Above_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("front",     {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Front_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("back",      {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Back_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("overbelow", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overbelow_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("overabove", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overabove_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("overfront", {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overfront_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("overback",  {tg, stbox}, LogicalType::BOOLEAN, TemporalFunctions::Overback_tspatial_stbox));
-        loader.RegisterFunction(ScalarFunction("below",     {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Below_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("above",     {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Above_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("front",     {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Front_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("back",      {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Back_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("overbelow", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overbelow_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("overabove", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overabove_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("overfront", {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overfront_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("overback",  {stbox, tg}, LogicalType::BOOLEAN, TemporalFunctions::Overback_stbox_tspatial));
-        loader.RegisterFunction(ScalarFunction("below",     {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Below_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("above",     {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Above_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("front",     {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Front_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("back",      {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Back_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("overbelow", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overbelow_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("overabove", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overabove_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("overfront", {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overfront_tspatial_tspatial));
-        loader.RegisterFunction(ScalarFunction("overback",  {tg, tg},    LogicalType::BOOLEAN, TemporalFunctions::Overback_tspatial_tspatial));
+        // L/R as both operator and named alias (DuckDB accepts <<, >>, &<, &> tokens)
+        REG_TSPATIAL_OP("<<", "temporal_left",      Left)
+        REG_TSPATIAL_OP(">>", "temporal_right",     Right)
+        REG_TSPATIAL_OP("&<", "temporal_overleft",  Overleft)
+        REG_TSPATIAL_OP("&>", "temporal_overright", Overright)
+
+        // Vertical / Z-axis as named only (DuckDB rejects <<|, |>>, /<<, >>/, etc.)
+        REG_TSPATIAL_OP("below",     "temporal_below",     Below)
+        REG_TSPATIAL_OP("above",     "temporal_above",     Above)
+        REG_TSPATIAL_OP("front",     "temporal_front",     Front)
+        REG_TSPATIAL_OP("back",      "temporal_back",      Back)
+        REG_TSPATIAL_OP("overbelow", "temporal_overbelow", Overbelow)
+        REG_TSPATIAL_OP("overabove", "temporal_overabove", Overabove)
+        REG_TSPATIAL_OP("overfront", "temporal_overfront", Overfront)
+        REG_TSPATIAL_OP("overback",  "temporal_overback",  Overback)
+
+        // Time-axis on tspatial as named only (DuckDB rejects <<#, #>>, &<#, #&>)
+        REG_TSPATIAL_OP("before",     "temporal_before",     Before)
+        REG_TSPATIAL_OP("after",      "temporal_after",      After)
+        REG_TSPATIAL_OP("overbefore", "temporal_overbefore", Overbefore)
+        REG_TSPATIAL_OP("overafter",  "temporal_overafter",  Overafter)
+
+#undef REG_TSPATIAL_OP
     }
 
     // ttext text functions

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5308,6 +5308,15 @@ DEFINE_TSPATIAL_STBOX_POS(Overabove,  overabove)
 DEFINE_TSPATIAL_STBOX_POS(Overfront,  overfront)
 DEFINE_TSPATIAL_STBOX_POS(Overback,   overback)
 
+/* Time-axis position predicates on tspatial reuse the same macro: MEOS exports
+ * `before_tspatial_stbox`, `before_stbox_tspatial`, `before_tspatial_tspatial`
+ * (and the after / overbefore / overafter equivalents) follow the
+ * (Temporal*, STBox*) / (STBox*, Temporal*) / (Temporal*, Temporal*) shape. */
+DEFINE_TSPATIAL_STBOX_POS(Before,     before)
+DEFINE_TSPATIAL_STBOX_POS(After,      after)
+DEFINE_TSPATIAL_STBOX_POS(Overbefore, overbefore)
+DEFINE_TSPATIAL_STBOX_POS(Overafter,  overafter)
+
 #undef DEFINE_TSPATIAL_STBOX_POS
 
 /* ***************************************************

--- a/test/sql/parity/062_tspatial_posops.test
+++ b/test/sql/parity/062_tspatial_posops.test
@@ -1,0 +1,78 @@
+# name: test/sql/parity/062_tspatial_posops.test
+# description: Tspatial × {stbox, tspatial} position predicates — left/right/
+#              below/above/front/back (and over* variants), plus the
+#              time-axis before/after/overbefore/overafter.  Each registered
+#              both as the existing operator/named form and as the
+#              MobilityDB-canonical `temporal_*` alias.
+# group: [sql]
+
+require mobilityduck
+
+# X-axis: temporal_left / temporal_overright
+
+query I
+SELECT temporal_left(tgeompoint '[POINT(0 0)@2000-01-01]', stbox 'STBOX X((5, 0), (10, 5))');
+----
+true
+
+query I
+SELECT temporal_overright(tgeompoint '[POINT(10 10)@2000-01-01]', stbox 'STBOX X((0, 0), (10, 10))');
+----
+true
+
+# Operator vs alias
+
+query I
+SELECT (tgeompoint '[POINT(0 0)@2000-01-01]' << stbox 'STBOX X((5, 0), (10, 5))')
+     = temporal_left(tgeompoint '[POINT(0 0)@2000-01-01]', stbox 'STBOX X((5, 0), (10, 5))');
+----
+true
+
+# Y-axis (named-only)
+
+query I
+SELECT temporal_below(tgeompoint '[POINT(0 0)@2000-01-01]', stbox 'STBOX X((0, 5), (10, 10))');
+----
+true
+
+query I
+SELECT temporal_above(stbox 'STBOX X((0, 0), (10, 5))', tgeompoint '[POINT(5 10)@2000-01-01]');
+----
+false
+
+# Z-axis: requires 3D inputs
+
+query I
+SELECT temporal_front(tgeompoint '[POINT Z (0 0 0)@2000-01-01]', stbox 'STBOX Z((0, 0, 5), (10, 10, 10))');
+----
+true
+
+# tspatial × tspatial
+
+query I
+SELECT temporal_left(tgeompoint '[POINT(0 0)@2000-01-01]',
+                     tgeompoint '[POINT(5 5)@2000-01-01, POINT(10 10)@2000-01-02]');
+----
+true
+
+# Time-axis: temporal_before / temporal_overafter
+
+query I
+SELECT temporal_before(tgeompoint '[POINT(5 5)@2000-01-01]',
+                       stbox 'STBOX XT(((0, 0), (10, 10)), [2000-01-02, 2000-01-03])');
+----
+true
+
+query I
+SELECT temporal_overafter(tgeompoint '[POINT(5 5)@2000-01-03]',
+                          stbox 'STBOX XT(((0, 0), (10, 10)), [2000-01-01, 2000-01-02])');
+----
+true
+
+# tspatial × tspatial time-axis
+
+query I
+SELECT temporal_after(tgeompoint '[POINT(5 5)@2000-01-03]',
+                      tgeompoint '[POINT(0 0)@2000-01-01]');
+----
+true


### PR DESCRIPTION
Closes 100% of \`geo/062_tpoint_posops\` by name.

## Two parallel bumps

### A. \`temporal_*\` aliases for the existing 36 spatial-axis registrations

The 12 spatial-axis predicates (\`left\` / \`right\` / \`below\` / \`above\` / \`front\` / \`back\` + \`over*\` variants) were already wired with operator/named forms. This PR adds the MobilityDB-canonical \`temporal_*\` named aliases (\`temporal_left\` / \`temporal_below\` / etc.) against the same handlers.

### B. New time-axis predicates on tspatial

Adds 12 new handlers for time-axis predicates on tspatial, reusing the existing \`DEFINE_TSPATIAL_STBOX_POS\` macro:

- \`Before_tspatial_stbox\` / \`Before_stbox_tspatial\` / \`Before_tspatial_tspatial\`
- \`After_*\` × 3
- \`Overbefore_*\` × 3
- \`Overafter_*\` × 3

Each routes to the matching MEOS export (\`before_tspatial_stbox\`, etc.). Registered under both the bare named form (\`before\` / \`after\` / \`overbefore\` / \`overafter\`) and the \`temporal_*\` alias for each of the 3 type-pair directions.

## Implementation

The whole \`tspatial × {stbox, tspatial}\` registration block is collapsed into a single \`REG_TSPATIAL_OP(SQL_NAME, ALIAS, FN)\` macro that emits 6 registrations per direction (operator + alias × 3 type pairs). Replaces ~36 hand-written lines with 16 macro invocations.

## Operator-form notes

DuckDB accepts \`<<\` / \`>>\` / \`&<\` / \`&>\` as operator tokens, so left/right/overleft/overright are registered both as operators and as named functions. The MobilityDB \`<<|\` / \`|>>\` / \`/<<\` / \`>>/\` (Y/Z axes) and \`<<#\` / \`#>>\` / \`&<#\` / \`#&>\` (time axis) tokens are unreachable through DuckDB's parser, so those predicates only have named forms — consistent with PR #74's handling.

## Tests

- \`test/sql/parity/062_tspatial_posops.test\` — 10 assertions covering X / Y / Z axes, time axis, and operator-vs-alias equivalence.
- Full suite: **762 assertions / 14 test cases** passing under \`TZ=UTC\`.

## Coverage delta

Per the audit in PR #66:
- \`geo/062_tpoint_posops\`: 0/16 → 16/16 (100%) by name.

## Test plan

- [x] \`cmake --build . --target shell unittest\` clean
- [x] New parity test passes (10/10)
- [x] Full suite green (762/14)