### PR TITLE
feat(bindings): tprecision / tsample — temporal time-domain rebinning

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -109,8 +109,8 @@ struct TemporalFunctions {
     static void Temporal_shift_time(DataChunk &args, ExpressionState &state, Vector &result);
     static void Temporal_scale_time(DataChunk &args, ExpressionState &state, Vector &result);
     static void Temporal_shift_scale_time(DataChunk &args, ExpressionState &state, Vector &result);
-    // TODO: static void Temporal_tprecision
-    // TODO: static void Temporal_tsample
+    static void Temporal_tprecision(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_tsample(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
      * Transformation functions

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1347,6 +1347,25 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     // Unary tnumber functions
     loader.RegisterFunction(ScalarFunction("abs", {TemporalTypes::TINT()}, TemporalTypes::TINT(), TemporalFunctions::Tnumber_abs));
     loader.RegisterFunction(ScalarFunction("abs", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tnumber_abs));
+
+    // tprecision / tsample — time-domain rebinning
+    {
+        const auto I = LogicalType::INTERVAL;
+        const auto TS = LogicalType::TIMESTAMP_TZ;
+        const auto V = LogicalType::VARCHAR;
+
+        for (auto &t : {TemporalTypes::TINT(), TemporalTypes::TFLOAT()}) {
+            loader.RegisterFunction(ScalarFunction("tprecision", {t, I},     t, TemporalFunctions::Temporal_tprecision));
+            loader.RegisterFunction(ScalarFunction("tprecision", {t, I, TS}, t, TemporalFunctions::Temporal_tprecision));
+        }
+
+        for (auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
+                        TemporalTypes::TFLOAT(), TemporalTypes::TTEXT()}) {
+            loader.RegisterFunction(ScalarFunction("tsample", {t, I},        t, TemporalFunctions::Temporal_tsample));
+            loader.RegisterFunction(ScalarFunction("tsample", {t, I, TS},    t, TemporalFunctions::Temporal_tsample));
+            loader.RegisterFunction(ScalarFunction("tsample", {t, I, TS, V}, t, TemporalFunctions::Temporal_tsample));
+        }
+    }
     loader.RegisterFunction(ScalarFunction("derivative", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Temporal_derivative));
     loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
     loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT(), LogicalType::BOOLEAN}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -5311,6 +5311,115 @@ DEFINE_TSPATIAL_STBOX_POS(Overback,   overback)
 #undef DEFINE_TSPATIAL_STBOX_POS
 
 /* ***************************************************
+ * tprecision / tsample — time-domain rebinning
+ ****************************************************/
+
+namespace {
+
+interpType ParseInterpString(const string_t &s) {
+    std::string str(s.GetData(), s.GetSize());
+    for (auto &c : str) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    if (str == "none" || str.empty())  return INTERP_NONE;
+    if (str == "discrete")             return DISCRETE;
+    if (str == "step")                 return STEP;
+    if (str == "linear")               return LINEAR;
+    throw InvalidInputException("Invalid interpolation: '" + str +
+        "' (expected one of: none, discrete, step, linear)");
+}
+
+constexpr TimestampTz DEFAULT_T_ORIGIN = 0;  // 2000-01-03 in MEOS internal repr
+
+} // namespace
+
+void TemporalFunctions::Temporal_tprecision(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t row_count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(row_count);
+    auto in_data = FlatVector::GetData<string_t>(args.data[0]);
+    auto dur_data = FlatVector::GetData<interval_t>(args.data[1]);
+    auto &v0 = FlatVector::Validity(args.data[0]);
+    auto &v1 = FlatVector::Validity(args.data[1]);
+    const bool has_origin = args.ColumnCount() > 2;
+    auto out_data = FlatVector::GetData<string_t>(result);
+    auto &out_validity = FlatVector::Validity(result);
+
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!v0.RowIsValid(row) || !v1.RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            continue;
+        }
+        TimestampTz origin = DEFAULT_T_ORIGIN;
+        if (has_origin) {
+            auto &ov = args.data[2];
+            if (!FlatVector::Validity(ov).RowIsValid(row)) {
+                out_validity.SetInvalid(row);
+                continue;
+            }
+            timestamp_tz_t t = FlatVector::GetData<timestamp_tz_t>(ov)[row];
+            origin = (TimestampTz) DuckDBToMeosTimestamp(t).value;
+        }
+        Temporal *temp = BlobToTemporal(in_data[row]);
+        MeosInterval mi = IntervaltToInterval(dur_data[row]);
+        Temporal *r = temporal_tprecision(temp, &mi, origin);
+        free(temp);
+        if (!r) { out_validity.SetInvalid(row); continue; }
+        size_t sz = temporal_mem_size(r);
+        string_t blob(reinterpret_cast<const char *>(r), sz);
+        out_data[row] = StringVector::AddStringOrBlob(result, blob);
+        free(r);
+    }
+    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+void TemporalFunctions::Temporal_tsample(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t row_count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(row_count);
+    auto in_data = FlatVector::GetData<string_t>(args.data[0]);
+    auto dur_data = FlatVector::GetData<interval_t>(args.data[1]);
+    auto &v0 = FlatVector::Validity(args.data[0]);
+    auto &v1 = FlatVector::Validity(args.data[1]);
+    const bool has_origin = args.ColumnCount() > 2;
+    const bool has_interp = args.ColumnCount() > 3;
+    auto out_data = FlatVector::GetData<string_t>(result);
+    auto &out_validity = FlatVector::Validity(result);
+
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!v0.RowIsValid(row) || !v1.RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            continue;
+        }
+        TimestampTz origin = DEFAULT_T_ORIGIN;
+        if (has_origin) {
+            auto &ov = args.data[2];
+            if (!FlatVector::Validity(ov).RowIsValid(row)) {
+                out_validity.SetInvalid(row);
+                continue;
+            }
+            timestamp_tz_t t = FlatVector::GetData<timestamp_tz_t>(ov)[row];
+            origin = (TimestampTz) DuckDBToMeosTimestamp(t).value;
+        }
+        interpType interp = DISCRETE;
+        if (has_interp) {
+            auto &iv = args.data[3];
+            if (!FlatVector::Validity(iv).RowIsValid(row)) {
+                out_validity.SetInvalid(row);
+                continue;
+            }
+            interp = ParseInterpString(FlatVector::GetData<string_t>(iv)[row]);
+        }
+        Temporal *temp = BlobToTemporal(in_data[row]);
+        MeosInterval mi = IntervaltToInterval(dur_data[row]);
+        Temporal *r = temporal_tsample(temp, &mi, origin, interp);
+        free(temp);
+        if (!r) { out_validity.SetInvalid(row); continue; }
+        size_t sz = temporal_mem_size(r);
+        string_t blob(reinterpret_cast<const char *>(r), sz);
+        out_data[row] = StringVector::AddStringOrBlob(result, blob);
+        free(r);
+    }
+    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 

--- a/test/sql/parity/022_temporal_tprecision_tsample.test
+++ b/test/sql/parity/022_temporal_tprecision_tsample.test
@@ -1,0 +1,56 @@
+# name: test/sql/parity/022_temporal_tprecision_tsample.test
+# description: Temporal time-domain rebinning — tprecision and tsample on
+#              tnumber and ttext.
+# group: [sql]
+
+require mobilityduck
+
+# tprecision(tfloat, interval) — bin-mean by default origin
+
+query I
+SELECT tprecision(tfloat '[1@2000-01-01, 5@2000-01-05]', INTERVAL '1 day');
+----
+[1.5@2000-01-01 00:00:00+00, 4.5@2000-01-04 00:00:00+00, 5@2000-01-05 00:00:00+00]
+
+# tprecision(tfloat, interval, timestamptz) — explicit origin
+
+query I
+SELECT tprecision(tfloat '[1@2000-01-01, 5@2000-01-05]', INTERVAL '1 day', TIMESTAMP '2000-01-01');
+----
+[1.5@2000-01-01 00:00:00+00, 4.5@2000-01-04 00:00:00+00, 5@2000-01-05 00:00:00+00]
+
+# tsample(tfloat, interval) — discrete by default
+
+query I
+SELECT tsample(tfloat '[1@2000-01-01, 5@2000-01-05]', INTERVAL '1 day');
+----
+{1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00, 3@2000-01-03 00:00:00+00, 4@2000-01-04 00:00:00+00, 5@2000-01-05 00:00:00+00}
+
+# tsample with explicit linear interpolation
+
+query I
+SELECT tsample(tfloat '[1@2000-01-01, 5@2000-01-05]', INTERVAL '1 day', TIMESTAMP '2000-01-01', 'linear');
+----
+[1@2000-01-01 00:00:00+00, 5@2000-01-05 00:00:00+00]
+
+# tsample on tbool
+
+query I
+SELECT tsample(tbool '[t@2000-01-01, f@2000-01-03]', INTERVAL '12 hours', TIMESTAMP '2000-01-01');
+----
+{t@2000-01-01 00:00:00+00, t@2000-01-01 12:00:00+00, t@2000-01-02 00:00:00+00, t@2000-01-02 12:00:00+00, f@2000-01-03 00:00:00+00}
+
+# tsample on tint (tint defaults to step interpolation, so the last sample
+# carries the upper-end value)
+
+query I
+SELECT tsample(tint '[1@2000-01-01, 5@2000-01-05]', INTERVAL '2 days', TIMESTAMP '2000-01-01');
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-03 00:00:00+00, 5@2000-01-05 00:00:00+00}
+
+# Invalid interpolation rejected
+
+statement error
+SELECT tsample(tfloat '[1@2000-01-01]', INTERVAL '1 day', TIMESTAMP '2000-01-01', 'invalid');
+----
+Invalid interpolation


### PR DESCRIPTION
Closes the user-facing tprecision/tsample gap in \`temporal/022_temporal\`.

## New SQL surface

| Signature | Routed through |
|---|---|
| \`tprecision(tint, interval)\` | \`temporal_tprecision\` (default origin = MEOS \`2000-01-03\`) |
| \`tprecision(tint, interval, timestamptz)\` | same |
| \`tprecision(tfloat, ...)\` × 2 | same |
| \`tsample(tbool, interval)\` | \`temporal_tsample\` (default origin, default \`discrete\` interp) |
| \`tsample(tbool, interval, timestamptz)\` | same |
| \`tsample(tbool, interval, timestamptz, varchar)\` | same |
| \`tsample(tint|tfloat|ttext, ...)\` × 3 each | same |

**16 new registrations** total: 4 \`tprecision\` overloads + 12 \`tsample\` overloads.

## Implementation

Both handlers walk the rows manually (rather than using \`BinaryExecutor\`) since they have variable arity (2-4 args). The interpolation string is parsed in C++ via \`ParseInterpString\`:

- \`"none"\` / \`""\` → \`INTERP_NONE\`
- \`"discrete"\` → \`DISCRETE\`
- \`"step"\` → \`STEP\`
- \`"linear"\` → \`LINEAR\`

Unknown values throw \`InvalidInputException\`.

\`DEFAULT_T_ORIGIN\` is \`0\` (MEOS encodes its \`2000-01-03\` reference origin as 0 microseconds), matching MobilityDB's SQL \`DEFAULT '2000-01-03'\`.

## Tests

- \`test/sql/parity/022_temporal_tprecision_tsample.test\` — 7 assertions including default-origin and explicit-origin variants, linear/step/discrete interpolation, and a \`statement error\` case for an invalid interp string.
- Full suite: **759 assertions / 14 test cases** passing under \`TZ=UTC\`.

## Coverage delta

Per the audit in PR #66:
- \`temporal/022_temporal\`: tprecision (2/2) + tsample (4/4) names now covered.

## Test plan

- [x] \`cmake --build . --target shell unittest\` clean
- [x] New parity test passes (7/7)
- [x] Full suite green (759/14)