### PR TITLE
feat(bindings): temporal_same — closes the topo-predicate gap

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -248,14 +248,17 @@ struct TemporalFunctions {
     static void Contained_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contains_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contained_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contains_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contained_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
      * Temporal time-position predicates (<<#, #>>, &<#, #&>)
@@ -377,18 +380,22 @@ struct TemporalFunctions {
     static void Contained_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contains_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contained_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contains_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contained_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contains_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contained_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
      * tnumber × {numspan, tbox} position predicates

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1376,12 +1376,15 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
     loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
 
-    // Temporal topological predicates: temporal × temporal (4 ops × 4 type pairs)
+    // Temporal topological predicates: temporal × temporal (5 ops × 4 type pairs).
+    // Each operator also registers the matching `temporal_*` named alias.
     for (auto &t1 : TemporalTypes::AllTypes()) {
         for (auto &t2 : TemporalTypes::AllTypes()) {
             loader.RegisterFunction(ScalarFunction("@>", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_temporal));
             loader.RegisterFunction(ScalarFunction("<@", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_temporal));
             loader.RegisterFunction(ScalarFunction("&&", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("~=", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Same_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_same", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Same_temporal_temporal));
             loader.RegisterFunction(ScalarFunction("-|-", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_temporal));
         }
     }
@@ -1390,10 +1393,15 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(ScalarFunction("@>", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_tstzspan));
         loader.RegisterFunction(ScalarFunction("<@", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_tstzspan));
         loader.RegisterFunction(ScalarFunction("&&", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("~=", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Same_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_same", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Same_temporal_tstzspan));
         loader.RegisterFunction(ScalarFunction("-|-", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_tstzspan));
+
         loader.RegisterFunction(ScalarFunction("@>", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tstzspan_temporal));
         loader.RegisterFunction(ScalarFunction("<@", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tstzspan_temporal));
         loader.RegisterFunction(ScalarFunction("&&", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("~=", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Same_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_same", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Same_tstzspan_temporal));
         loader.RegisterFunction(ScalarFunction("-|-", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tstzspan_temporal));
     }
 
@@ -1475,35 +1483,23 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         auto fspan = SpanTypes::FLOATSPAN();
         auto tbox  = TboxType::TBOX();
 
-        // tnumber × numspan
-        loader.RegisterFunction(ScalarFunction("@>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("<@",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&&",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("-|-", {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("@>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("<@",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&&",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("-|-", {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
-        // numspan × tnumber
-        loader.RegisterFunction(ScalarFunction("@>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("<@",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&&",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("-|-", {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("@>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("<@",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&&",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("-|-", {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
-        // tnumber × tbox
+#define REG_TOP5(L, R, FN_SUFFIX) \
+    loader.RegisterFunction(ScalarFunction("@>",            {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Contains_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("<@",            {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Contained_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("&&",            {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("~=",            {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Same_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_same", {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Same_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("-|-",           {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_##FN_SUFFIX));
+
+        REG_TOP5(tint,  ispan, tnumber_numspan)
+        REG_TOP5(tflt,  fspan, tnumber_numspan)
+        REG_TOP5(ispan, tint,  numspan_tnumber)
+        REG_TOP5(fspan, tflt,  numspan_tnumber)
         for (auto &t : {tint, tflt}) {
-            loader.RegisterFunction(ScalarFunction("@>",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("<@",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("&&",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("-|-", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("@>",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("<@",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("&&",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("-|-", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tbox_tnumber));
+            REG_TOP5(t,    tbox, tnumber_tbox)
+            REG_TOP5(tbox, t,    tbox_tnumber)
         }
+#undef REG_TOP5
 
         // Position ops (<<, >>, &<, &>) — same surface
         loader.RegisterFunction(ScalarFunction("<<",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4938,6 +4938,9 @@ void TemporalFunctions::Overlaps_temporal_temporal(DataChunk &args, ExpressionSt
 void TemporalFunctions::Adjacent_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
     TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return adjacent_temporal_temporal(a, b); });
 }
+void TemporalFunctions::Same_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return same_temporal_temporal(a, b); });
+}
 
 void TemporalFunctions::Contains_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
     TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return contains_temporal_tstzspan(t, s); });
@@ -4950,6 +4953,9 @@ void TemporalFunctions::Overlaps_temporal_tstzspan(DataChunk &args, ExpressionSt
 }
 void TemporalFunctions::Adjacent_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
     TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return adjacent_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Same_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return same_temporal_tstzspan(t, s); });
 }
 
 // Span-temporal direction: MEOS only exposes the temporal-span functions,
@@ -4965,6 +4971,9 @@ void TemporalFunctions::Overlaps_tstzspan_temporal(DataChunk &args, ExpressionSt
 }
 void TemporalFunctions::Adjacent_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
     SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return adjacent_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Same_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return same_tstzspan_temporal(s, t); });
 }
 
 /* ***************************************************
@@ -5198,6 +5207,9 @@ void TemporalFunctions::Overlaps_tnumber_numspan(DataChunk &args, ExpressionStat
 void TemporalFunctions::Adjacent_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) {
     TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return adjacent_tnumber_numspan(t, s); });
 }
+void TemporalFunctions::Same_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return same_tnumber_numspan(t, s); });
+}
 // numspan × tnumber
 void TemporalFunctions::Contains_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
     BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return contains_numspan_tnumber(s, t); });
@@ -5210,6 +5222,9 @@ void TemporalFunctions::Overlaps_numspan_tnumber(DataChunk &args, ExpressionStat
 }
 void TemporalFunctions::Adjacent_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
     BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return adjacent_numspan_tnumber(s, t); });
+}
+void TemporalFunctions::Same_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return same_numspan_tnumber(s, t); });
 }
 // tnumber × tbox (uses TBox)
 void TemporalFunctions::Contains_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -5224,6 +5239,9 @@ void TemporalFunctions::Overlaps_tnumber_tbox(DataChunk &args, ExpressionState &
 void TemporalFunctions::Adjacent_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
     TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return adjacent_tnumber_tbox(t, b); });
 }
+void TemporalFunctions::Same_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return same_tnumber_tbox(t, b); });
+}
 // tbox × tnumber
 void TemporalFunctions::Contains_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
     BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return contains_tbox_tnumber(b, t); });
@@ -5236,6 +5254,9 @@ void TemporalFunctions::Overlaps_tbox_tnumber(DataChunk &args, ExpressionState &
 }
 void TemporalFunctions::Adjacent_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
     BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return adjacent_tbox_tnumber(b, t); });
+}
+void TemporalFunctions::Same_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return same_tbox_tnumber(b, t); });
 }
 
 /* ***************************************************

--- a/test/sql/parity/032_temporal_same.test
+++ b/test/sql/parity/032_temporal_same.test
@@ -1,0 +1,78 @@
+# name: test/sql/parity/032_temporal_same.test
+# description: Same predicate (`~=`) and `temporal_same` named alias on
+#              temporal × {temporal, tstzspan, numspan, tbox} (and reverses).
+#              Closes the deferral from PR #72: temporal_boxops `temporal_same`
+#              is the last named-alias gap in that section, requiring new
+#              Same_* handlers (other 4 ops were already wired).
+# group: [sql]
+
+require mobilityduck
+
+# Same on temporal × temporal — operator and named alias agree
+
+query I
+SELECT (tint '[1@2000-01-01]' ~= tint '[1@2000-01-01]')
+     = temporal_same(tint '[1@2000-01-01]', tint '[1@2000-01-01]');
+----
+true
+
+# Same x temporal — different values
+
+query I
+SELECT temporal_same(tint '[1@2000-01-01]', tint '[2@2000-01-02]');
+----
+false
+
+# Same on tbool × tbool
+
+query I
+SELECT temporal_same(tbool '[t@2000-01-01]', tbool '[t@2000-01-01]');
+----
+true
+
+# Same on temporal × tstzspan (matching time domain)
+
+query I
+SELECT temporal_same(tint '[1@2000-01-01]', tstzspan '[2000-01-01, 2000-01-01]');
+----
+true
+
+query I
+SELECT (tstzspan '[2000-01-01, 2000-01-01]' ~= tint '[1@2000-01-01]');
+----
+true
+
+# Same on tnumber × numspan (matching value domain)
+
+query I
+SELECT temporal_same(tint '[1@2000-01-01, 5@2000-01-05]', intspan '[1, 6)');
+----
+true
+
+query I
+SELECT temporal_same(tint '[1@2000-01-01, 5@2000-01-05]', intspan '[2, 6)');
+----
+false
+
+# numspan × tnumber
+
+query I
+SELECT temporal_same(intspan '[1, 6)', tint '[1@2000-01-01, 5@2000-01-05]');
+----
+true
+
+# Same on tnumber × tbox
+
+query I
+SELECT temporal_same(tint '[1@2000-01-01, 5@2000-01-05]',
+                     tbox 'TBOXINT XT([1, 6),[2000-01-01, 2000-01-05])');
+----
+true
+
+# tbox × tnumber
+
+query I
+SELECT temporal_same(tbox 'TBOXINT XT([1, 6),[2000-01-01, 2000-01-05])',
+                     tint '[1@2000-01-01, 5@2000-01-05]');
+----
+true


### PR DESCRIPTION
Closes the \`temporal_same\` gap deferred from PR #72. At the time, the underlying \`Same_*\` handlers were not wired in MobilityDuck. PR #75 added \`Same\` handlers on the tspatial side; this PR finishes the temporal + tnumber side.

## New handlers (7)

| Handler | MEOS export |
|---|---|
| \`Same_temporal_temporal\` | \`same_temporal_temporal\` |
| \`Same_temporal_tstzspan\` | \`same_temporal_tstzspan\` |
| \`Same_tstzspan_temporal\` | \`same_tstzspan_temporal\` |
| \`Same_tnumber_numspan\` | \`same_tnumber_numspan\` |
| \`Same_numspan_tnumber\` | \`same_numspan_tnumber\` |
| \`Same_tnumber_tbox\` | \`same_tnumber_tbox\` |
| \`Same_tbox_tnumber\` | \`same_tbox_tnumber\` |

## SQL surface

Each handler is registered both as the \`~=\` operator and the \`temporal_same\` named alias for **32 type-pair shapes** parallel to the existing \`Contains\` / \`Contained\` / \`Overlaps\` / \`Adjacent\` surface:

- temporal × temporal (16 pairs from \`AllTypes() × AllTypes()\`)
- temporal × tstzspan (4) and tstzspan × temporal (4)
- tnumber × numspan (2 pairs) and numspan × tnumber (2 pairs)
- tnumber × tbox (2 pairs) and tbox × tnumber (2 pairs)

A new \`REG_TOP5\` macro folds the tnumber × {numspan, tbox} block (replacing 32 hand-written lines with 6 macro invocations).

## Tests

- \`test/sql/parity/032_temporal_same.test\` — 10 assertions covering each direction and the operator-vs-alias equivalence.
- Full suite: **762 assertions / 14 test cases** passing under \`TZ=UTC\`.

## Coverage delta

Per the audit in PR #66:
- \`temporal/032_temporal_boxops\`: \`temporal_same\` was the last named-alias gap. Section now 100% covered (modulo \`stboxes\`/\`splitN\`/\`splitEachN\` which are landed in PR #64).

## Test plan

- [x] \`cmake --build . --target shell unittest\` clean
- [x] New parity test passes (10/10)
- [x] Full suite green (762/14)