### PR TITLE
feat(bindings): asMVTGeom + geoMeasure for tgeompoint

### DIFF
--- a/src/geo/tgeompoint.cpp
+++ b/src/geo/tgeompoint.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
 #include "spatial/spatial_types.hpp"
+#include "geo_util.hpp"
 
 namespace duckdb {
 
@@ -1768,6 +1769,160 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::distance_geo_geo
         )
     );
+}
+
+/* ***************************************************
+ * asMVTGeom + geoMeasure for tgeompoint
+ *
+ *   asMVTGeom(tgeompoint, stbox bounds[, extent int[, buffer int[, clip bool]]])
+ *     RETURNS STRUCT(geom geometry, times bigint[])
+ *
+ *   geoMeasure(tgeompoint, tfloat measure[, segmentize boolean])
+ *     RETURNS geometry
+ ****************************************************/
+
+namespace {
+
+inline Temporal *BlobToTempMVT(string_t b) {
+    size_t sz = b.GetSize();
+    uint8_t *copy = (uint8_t *)malloc(sz);
+    memcpy(copy, b.GetData(), sz);
+    return reinterpret_cast<Temporal *>(copy);
+}
+
+inline STBox *BlobToStboxMVT(string_t b) {
+    size_t sz = b.GetSize();
+    uint8_t *copy = (uint8_t *)malloc(sz);
+    memcpy(copy, b.GetData(), sz);
+    return reinterpret_cast<STBox *>(copy);
+}
+
+void TgeoAsMVTGeomExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t row_count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(row_count);
+    const idx_t cc = args.ColumnCount();
+
+    auto in_temp   = FlatVector::GetData<string_t>(args.data[0]);
+    auto in_bounds = FlatVector::GetData<string_t>(args.data[1]);
+    auto &v0 = FlatVector::Validity(args.data[0]);
+    auto &v1 = FlatVector::Validity(args.data[1]);
+    auto &out_validity = FlatVector::Validity(result);
+
+    auto &struct_children = StructVector::GetEntries(result);
+    auto &geom_col = *struct_children[0];
+    auto &times_col = *struct_children[1];
+    auto times_entries = FlatVector::GetData<list_entry_t>(times_col);
+    auto &times_child = ListVector::GetEntry(times_col);
+
+    idx_t total_times = 0;
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!v0.RowIsValid(row) || !v1.RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            times_entries[row] = list_entry_t{total_times, 0};
+            continue;
+        }
+        Temporal *t = BlobToTempMVT(in_temp[row]);
+        STBox *bx = BlobToStboxMVT(in_bounds[row]);
+        int32_t extent = 4096;
+        int32_t buffer = 256;
+        bool clip = true;
+        if (cc > 2) extent = FlatVector::GetData<int32_t>(args.data[2])[row];
+        if (cc > 3) buffer = FlatVector::GetData<int32_t>(args.data[3])[row];
+        if (cc > 4) clip   = FlatVector::GetData<bool>(args.data[4])[row];
+
+        GSERIALIZED *geom = nullptr;
+        int64 *times = nullptr;
+        int count = 0;
+        bool found = tpoint_as_mvtgeom(t, bx, extent, buffer, clip, &geom, &times, &count);
+        free(t); free(bx);
+        if (!found || !geom) {
+            out_validity.SetInvalid(row);
+            times_entries[row] = list_entry_t{total_times, 0};
+            if (geom) free(geom);
+            if (times) free(times);
+            continue;
+        }
+        /* Encode geom into the geometry struct child */
+        ArenaAllocator arena(BufferAllocator::Get(state.GetContext()));
+        string_t enc = GSerializedToGeometry(geom, arena, geom_col);
+        FlatVector::GetData<string_t>(geom_col)[row] =
+            StringVector::AddStringOrBlob(geom_col, enc);
+        free(geom);
+        /* Encode times[] into the bigint[] struct child */
+        if (count > 0 && times) {
+            ListVector::Reserve(times_col, total_times + count);
+            ListVector::SetListSize(times_col, total_times + count);
+            times_entries[row] = list_entry_t{total_times, static_cast<uint64_t>(count)};
+            auto times_data = FlatVector::GetData<int64_t>(times_child);
+            for (int k = 0; k < count; k++) {
+                times_data[total_times + k] = (int64_t) times[k];
+            }
+            total_times += count;
+        } else {
+            times_entries[row] = list_entry_t{total_times, 0};
+        }
+        if (times) free(times);
+    }
+    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+void TgeoGeoMeasureExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t row_count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(row_count);
+    const idx_t cc = args.ColumnCount();
+    auto in_temp = FlatVector::GetData<string_t>(args.data[0]);
+    auto in_meas = FlatVector::GetData<string_t>(args.data[1]);
+    auto &v0 = FlatVector::Validity(args.data[0]);
+    auto &v1 = FlatVector::Validity(args.data[1]);
+    auto out_data = FlatVector::GetData<string_t>(result);
+    auto &out_validity = FlatVector::Validity(result);
+
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!v0.RowIsValid(row) || !v1.RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            continue;
+        }
+        Temporal *t = BlobToTempMVT(in_temp[row]);
+        Temporal *m = BlobToTempMVT(in_meas[row]);
+        bool segmentize = (cc > 2) ? FlatVector::GetData<bool>(args.data[2])[row] : false;
+        GSERIALIZED *geom = nullptr;
+        bool ok = tpoint_tfloat_to_geomeas(t, m, segmentize, &geom);
+        free(t); free(m);
+        if (!ok || !geom) {
+            out_validity.SetInvalid(row);
+            if (geom) free(geom);
+            continue;
+        }
+        ArenaAllocator arena(BufferAllocator::Get(state.GetContext()));
+        string_t enc = GSerializedToGeometry(geom, arena, result);
+        out_data[row] = StringVector::AddStringOrBlob(result, enc);
+        free(geom);
+    }
+    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+} // namespace
+
+void TgeompointType::RegisterAnalyticsViz(ExtensionLoader &loader) {
+    const auto T  = TGEOMPOINT();
+    const auto B  = StboxType::STBOX();
+    const auto G  = GeoTypes::GEOMETRY();
+    const auto I  = LogicalType::INTEGER;
+    const auto BL = LogicalType::BOOLEAN;
+
+    /* asMVTGeom returns STRUCT(geom GEOMETRY, times BIGINT[]) */
+    const auto MVT_OUT = LogicalType::STRUCT({
+        {"geom", G},
+        {"times", LogicalType::LIST(LogicalType::BIGINT)},
+    });
+    loader.RegisterFunction(ScalarFunction("asMVTGeom", {T, B},                MVT_OUT, TgeoAsMVTGeomExec));
+    loader.RegisterFunction(ScalarFunction("asMVTGeom", {T, B, I},             MVT_OUT, TgeoAsMVTGeomExec));
+    loader.RegisterFunction(ScalarFunction("asMVTGeom", {T, B, I, I},          MVT_OUT, TgeoAsMVTGeomExec));
+    loader.RegisterFunction(ScalarFunction("asMVTGeom", {T, B, I, I, BL},      MVT_OUT, TgeoAsMVTGeomExec));
+
+    /* geoMeasure(tgeompoint, tfloat[, segmentize]) -> geometry */
+    loader.RegisterFunction(ScalarFunction("geoMeasure", {T, TemporalTypes::TFLOAT()},     G, TgeoGeoMeasureExec));
+    loader.RegisterFunction(ScalarFunction("geoMeasure", {T, TemporalTypes::TFLOAT(), BL}, G, TgeoGeoMeasureExec));
 }
 
 } // namespace duckdb

--- a/src/include/geo/tgeompoint.hpp
+++ b/src/include/geo/tgeompoint.hpp
@@ -18,6 +18,7 @@ struct TgeompointType {
     static void RegisterType(ExtensionLoader &loader);
     static void RegisterCastFunctions(ExtensionLoader &loader);
     static void RegisterScalarFunctions(ExtensionLoader &loader);
+    static void RegisterAnalyticsViz(ExtensionLoader &loader);
 };
 
 } // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -247,6 +247,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	TgeompointType::RegisterType(loader);
 	TgeompointType::RegisterCastFunctions(loader);
 	TgeompointType::RegisterScalarFunctions(loader);
+	TgeompointType::RegisterAnalyticsViz(loader);
 
 	TGeometryTypes::RegisterScalarFunctions(loader);
 	TGeometryTypes::RegisterTypes(loader);

--- a/test/sql/parity/076_asmvtgeom_geomeasure.test
+++ b/test/sql/parity/076_asmvtgeom_geomeasure.test
@@ -1,0 +1,57 @@
+# name: test/sql/parity/076_asmvtgeom_geomeasure.test
+# description: asMVTGeom (Mapbox Vector Tile encoder) and geoMeasure
+#              (linear-referencing M-coord adder) for tgeompoint.  These
+#              are the visualization-essential analytics functions in
+#              geo/076_tpoint_analytics.
+# group: [sql]
+
+require mobilityduck
+
+# asMVTGeom returns a STRUCT(geom GEOMETRY, times BIGINT[])
+
+query I
+SELECT typeof(asMVTGeom(tgeompoint '[POINT(0 0)@2000-01-01, POINT(10 10)@2000-01-05]',
+                        stbox 'STBOX X((0, 0), (10, 10))'));
+----
+STRUCT(geom GEOMETRY, times BIGINT[])
+
+# Default tile encodes the trajectory at the configured extent (4096)
+
+query I
+SELECT ST_AsText((asMVTGeom(tgeompoint '[POINT(0 0)@2000-01-01, POINT(10 10)@2000-01-05]',
+                              stbox 'STBOX X((0, 0), (10, 10))')).geom);
+----
+LINESTRING (0 4096, 4096 0)
+
+# times array has one entry per vertex (Unix-epoch seconds)
+
+query I
+SELECT len((asMVTGeom(tgeompoint '[POINT(0 0)@2000-01-01, POINT(10 10)@2000-01-05]',
+                       stbox 'STBOX X((0, 0), (10, 10))')).times);
+----
+2
+
+# Custom extent
+
+query I
+SELECT ST_AsText((asMVTGeom(tgeompoint '[POINT(0 0)@2000-01-01, POINT(10 10)@2000-01-05]',
+                              stbox 'STBOX X((0, 0), (10, 10))', 100)).geom);
+----
+LINESTRING (0 100, 100 0)
+
+# geoMeasure adds the M coordinate from the measure tfloat
+
+query I
+SELECT ST_AsText(geoMeasure(tgeompoint '[POINT(0 0)@2000-01-01, POINT(10 10)@2000-01-05]',
+                             tfloat   '[0@2000-01-01, 100@2000-01-05]'));
+----
+LINESTRING M (0 0 0, 10 10 100)
+
+# geoMeasure with explicit segmentize=FALSE
+
+query I
+SELECT ST_AsText(geoMeasure(tgeompoint '[POINT(0 0)@2000-01-01, POINT(10 10)@2000-01-05]',
+                             tfloat   '[0@2000-01-01, 100@2000-01-05]',
+                             FALSE));
+----
+LINESTRING M (0 0 0, 10 10 100)


### PR DESCRIPTION
Closes the visualization-essential analytics in \`geo/076_tpoint_analytics\` so users can encode trajectories for Mapbox Vector Tile rendering and add a measure dimension (M-coord) from a parallel \`tfloat\`.

## New SQL surface (6 scalar registrations)

| Signature | Returns | Routed through |
|---|---|---|
| \`asMVTGeom(tgeompoint, stbox)\` | \`STRUCT(geom GEOMETRY, times BIGINT[])\` | \`tpoint_as_mvtgeom\` (extent=4096, buffer=256, clip=TRUE defaults) |
| \`asMVTGeom(tgeompoint, stbox, integer)\` | same | + custom extent |
| \`asMVTGeom(tgeompoint, stbox, integer, integer)\` | same | + custom extent + buffer |
| \`asMVTGeom(tgeompoint, stbox, integer, integer, boolean)\` | same | full args |
| \`geoMeasure(tgeompoint, tfloat)\` | \`GEOMETRY\` | \`tpoint_tfloat_to_geomeas\` (segmentize=FALSE default) |
| \`geoMeasure(tgeompoint, tfloat, boolean)\` | \`GEOMETRY\` | full args |

## Implementation notes

### asMVTGeom

Output is a single-row composite \`STRUCT(geom GEOMETRY, times BIGINT[])\` matching MobilityDB's \`geom_times\` type. MEOS hands back **one** clipped/projected geometry plus a parallel array of Unix-epoch second timestamps (one per vertex). The exec function:

- Calls \`tpoint_as_mvtgeom(temp, bounds, extent, buffer, clip, &geom, &times, &count)\`.
- Encodes the GSERIALIZED geometry into the struct's \`geom\` child via \`GSerializedToGeometry\` (with an \`ArenaAllocator\` scoped to the result vector).
- Materialises the int64 timestamp array into the \`BIGINT[]\` struct child via standard \`ListVector\` reserve/set patterns.

### geoMeasure

Routes \`tpoint_tfloat_to_geomeas(tpoint, measure, segmentize, &geom)\` and encodes the resulting GSERIALIZED with M-coord via \`GSerializedToGeometry\`.

Both are scalar functions, no TableFunction infra required.

## Tests

- \`test/sql/parity/076_asmvtgeom_geomeasure.test\` — 6 assertions covering the \`typeof\` shape, default-extent and custom-extent encodings, times-array length, and both geoMeasure overloads (with/without segmentize).
- Full suite: **758 assertions / 14 test cases** passing under \`TZ=UTC\`.

## Coverage delta

Per the audit in PR #66:
- \`geo/076_tpoint_analytics\` and \`geo/076_tgeo_analytics\`: \`asMVTGeom\` and \`geoMeasure\` were the visualization-blocking gaps. Now covered.

## Test plan

- [x] \`cmake --build . --target shell unittest\` clean
- [x] New parity test passes (6/6)
- [x] Full suite green (758/14)