### PR TITLE
feat(bindings): extend extent() aggregate across all fixed-state inputs

### DIFF
--- a/src/temporal/span_aggregates.cpp
+++ b/src/temporal/span_aggregates.cpp
@@ -1,7 +1,14 @@
 #include "meos_wrapper_simple.hpp"
 
+#include "common.hpp"
 #include "temporal/span.hpp"
+#include "temporal/set.hpp"
+#include "temporal/spanset.hpp"
+#include "temporal/tbox.hpp"
+#include "geo/stbox.hpp"
+#include "temporal/temporal.hpp"
 #include "temporal/span_aggregates.hpp"
+#include "time_util.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
@@ -12,55 +19,47 @@ namespace duckdb {
 
 namespace {
 
-// State for the extent(span) aggregate. The MEOS Span is a fixed-size
-// struct, so we can hold it inline in the aggregate state.
+// =====================================================================
+// Span-typed extent: state = Span. Inputs span/set/spanset/scalars all
+// fold into the same shape, only the transition function differs.
+// =====================================================================
+
 struct SpanExtentState {
     Span span;
     bool isset;
 };
 
-struct SpanExtentFunction {
+template <auto TRANSFN>
+struct SpanExtentFromSpanLike {
     template <class STATE>
-    static void Initialize(STATE &state) {
-        state.isset = false;
-    }
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
 
-    static bool IgnoreNull() {
-        return true;
-    }
-
-    // Operation receives the input blob; we decode to Span and call MEOS
-    // span_extent_transfn, which expands state's bounds in place when
-    // state is non-null and otherwise returns a fresh palloc'd copy.
     template <class INPUT_TYPE, class STATE, class OP>
     static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
-        // INPUT_TYPE is string_t for blob-encoded spans.
-        const Span *input_span = reinterpret_cast<const Span *>(input.GetData());
+        // INPUT_TYPE is string_t — span / set / spanset blob.
+        const auto *in = reinterpret_cast<const std::remove_pointer_t<
+            decltype(TRANSFN(static_cast<Span *>(nullptr), nullptr))> *>(input.GetData());
         if (!state.isset) {
-            // First call: initialize state with a copy of the input.
-            memcpy(&state.span, input_span, sizeof(Span));
-            state.isset = true;
+            // Use a temporary state of NULL: TRANSFN palloc-copies into a fresh
+            // Span. Copy it back inline and free.
+            Span *fresh = TRANSFN(nullptr, in);
+            if (fresh) {
+                memcpy(&state.span, fresh, sizeof(Span));
+                free(fresh);
+                state.isset = true;
+            }
         } else {
-            // Subsequent calls: expand state in place.
-            // span_extent_transfn(state, s) calls span_expand(s, state).
-            (void) span_extent_transfn(&state.span, input_span);
+            (void) TRANSFN(&state.span, in);
         }
     }
-
     template <class INPUT_TYPE, class STATE, class OP>
-    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
-                                  idx_t /*count*/) {
-        // extent is idempotent in the value dimension, so a single
-        // application is equivalent to applying the same value `count`
-        // times.
-        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
     }
-
     template <class STATE, class OP>
     static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
-        if (!source.isset) {
-            return;
-        }
+        if (!source.isset) return;
         if (!target.isset) {
             memcpy(&target.span, &source.span, sizeof(Span));
             target.isset = true;
@@ -68,31 +67,400 @@ struct SpanExtentFunction {
             (void) span_extent_transfn(&target.span, &source.span);
         }
     }
-
     template <class T, class STATE>
-    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
-        if (!state.isset) {
-            finalize_data.ReturnNull();
-            return;
-        }
-        target = finalize_data.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
     }
 };
+
+// Original span extent retained — span_extent_transfn expands in place even
+// for the NULL-state case, so we keep the dedicated implementation for it
+// to avoid double-allocating.
+struct SpanExtentFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Span *input_span = reinterpret_cast<const Span *>(input.GetData());
+        if (!state.isset) {
+            memcpy(&state.span, input_span, sizeof(Span));
+            state.isset = true;
+        } else {
+            (void) span_extent_transfn(&state.span, input_span);
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.span, &source.span, sizeof(Span));
+            target.isset = true;
+        } else {
+            (void) span_extent_transfn(&target.span, &source.span);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    }
+};
+
+// =====================================================================
+// Scalar inputs (int / bigint / float / date / timestamptz). For each
+// the MEOS transfn signature is (Span *, value) -> Span *.
+// =====================================================================
+
+template <class IN, Span *(*TRANSFN)(Span *, IN)>
+struct ScalarSpanExtentFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        Span *fresh = TRANSFN(state.isset ? &state.span : nullptr, input);
+        if (!state.isset && fresh) {
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.span, &source.span, sizeof(Span));
+            target.isset = true;
+        } else {
+            (void) span_extent_transfn(&target.span, &source.span);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    }
+};
+
+// Wrappers to convert DuckDB-side timestamp/date to MEOS-side before calling
+// the transition function, so the aggregate sees consistent inputs.
+inline Span *DateExtentDuckDB(Span *state, date_t d) {
+    return date_extent_transfn(state, ToMeosDate(d));
+}
+inline Span *TstzExtentDuckDB(Span *state, timestamp_tz_t t) {
+    return timestamptz_extent_transfn(state, (TimestampTz) DuckDBToMeosTimestamp(t).value);
+}
+inline Span *Int32Extent(Span *state, int32_t v) { return int_extent_transfn(state, v); }
+inline Span *Int64Extent(Span *state, int64_t v) { return bigint_extent_transfn(state, v); }
+inline Span *DoubleExtent(Span *state, double v) { return float_extent_transfn(state, v); }
+
+// =====================================================================
+// TBox extent: state = TBox. Both numeric tbox-shaped inputs (tbox itself,
+// tnumber via tnumber_extent_transfn) feed in here.
+// =====================================================================
+
+struct TBoxExtentState {
+    TBox box;
+    bool isset;
+};
+
+// Generic TBox-state aggregator, parametrised by the function that takes
+// (state, inputBlob) and returns a fresh-or-state TBox*. Both
+// `tnumber_extent_transfn(TBox*, const Temporal*)` and a "tbox extent"
+// (built on `tbox_expand`) match this signature once we wrap them.
+typedef TBox *(*TBoxTransFn)(TBox * /*state*/, const void * /*input ptr*/);
+
+template <TBoxTransFn TRANSFN>
+struct TBoxExtentFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        TBox *result = TRANSFN(state.isset ? &state.box : nullptr, input.GetData());
+        if (!state.isset && result) {
+            memcpy(&state.box, result, sizeof(TBox));
+            free(result);
+            state.isset = true;
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.box, &source.box, sizeof(TBox));
+            target.isset = true;
+        } else {
+            tbox_expand(&source.box, &target.box);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.box), sizeof(TBox)));
+    }
+};
+
+// Wrap MEOS extent-style functions to a uniform signature.
+TBox *TboxExtentFromTBox(TBox *state, const void *input) {
+    const TBox *box_in = reinterpret_cast<const TBox *>(input);
+    if (!state) {
+        TBox *fresh = (TBox *) malloc(sizeof(TBox));
+        memcpy(fresh, box_in, sizeof(TBox));
+        return fresh;
+    }
+    tbox_expand(box_in, state);
+    return state;
+}
+
+TBox *TboxExtentFromTNumber(TBox *state, const void *input) {
+    const Temporal *t = reinterpret_cast<const Temporal *>(input);
+    return tnumber_extent_transfn(state, t);
+}
+
+// =====================================================================
+// STBox extent: state = STBox.
+// =====================================================================
+
+struct STBoxExtentState {
+    STBox box;
+    bool isset;
+};
+
+typedef STBox *(*STBoxTransFn)(STBox * /*state*/, const void * /*input ptr*/);
+
+template <STBoxTransFn TRANSFN>
+struct STBoxExtentFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        STBox *result = TRANSFN(state.isset ? &state.box : nullptr, input.GetData());
+        if (!state.isset && result) {
+            memcpy(&state.box, result, sizeof(STBox));
+            free(result);
+            state.isset = true;
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.box, &source.box, sizeof(STBox));
+            target.isset = true;
+        } else {
+            stbox_expand(&source.box, &target.box);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.box), sizeof(STBox)));
+    }
+};
+
+STBox *StboxExtentFromSTBox(STBox *state, const void *input) {
+    const STBox *box_in = reinterpret_cast<const STBox *>(input);
+    if (!state) {
+        STBox *fresh = (STBox *) malloc(sizeof(STBox));
+        memcpy(fresh, box_in, sizeof(STBox));
+        return fresh;
+    }
+    stbox_expand(box_in, state);
+    return state;
+}
+
+STBox *StboxExtentFromTSpatial(STBox *state, const void *input) {
+    const Temporal *t = reinterpret_cast<const Temporal *>(input);
+    return tspatial_extent_transfn(state, t);
+}
+
+// =====================================================================
+// Span-typed extent over Temporal: temporal_extent_transfn yields the
+// time span (tstzspan) for tbool/ttext etc.
+// =====================================================================
+
+Span *TstzSpanExtentFromTemporal(Span *state, const void *input) {
+    const Temporal *t = reinterpret_cast<const Temporal *>(input);
+    return temporal_extent_transfn(state, t);
+}
+
+struct GenericSpanExtentState : SpanExtentState {};
+
+template <Span *(*TRANSFN)(Span *, const void *)>
+struct GenericSpanFromBlobFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        Span *fresh = TRANSFN(state.isset ? &state.span : nullptr, input.GetData());
+        if (!state.isset && fresh) {
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.span, &source.span, sizeof(Span));
+            target.isset = true;
+        } else {
+            (void) span_extent_transfn(&target.span, &source.span);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    }
+};
+
+Span *SpanExtentFromSet(Span *state, const void *input) {
+    const Set *s = reinterpret_cast<const Set *>(input);
+    return set_extent_transfn(state, s);
+}
+Span *SpanExtentFromSpanSet(Span *state, const void *input) {
+    const SpanSet *ss = reinterpret_cast<const SpanSet *>(input);
+    return spanset_extent_transfn(state, ss);
+}
+
+// =====================================================================
+// Aggregate-construction helpers
+// =====================================================================
 
 static AggregateFunction MakeExtentSpanAggregate(const LogicalType &span_type) {
     return AggregateFunction::UnaryAggregate<SpanExtentState, string_t, string_t, SpanExtentFunction>(
         span_type, span_type);
 }
 
+template <class T, Span *(*TRANSFN)(Span *, T)>
+static AggregateFunction MakeExtentScalarAggregate(const LogicalType &input_type, const LogicalType &out_span) {
+    return AggregateFunction::UnaryAggregate<SpanExtentState, T, string_t, ScalarSpanExtentFn<T, TRANSFN>>(
+        input_type, out_span);
+}
+
+template <Span *(*TRANSFN)(Span *, const void *)>
+static AggregateFunction MakeExtentBlobToSpanAggregate(const LogicalType &input_type,
+                                                       const LogicalType &out_span) {
+    return AggregateFunction::UnaryAggregate<SpanExtentState, string_t, string_t,
+                                             GenericSpanFromBlobFn<TRANSFN>>(input_type, out_span);
+}
+
+template <TBoxTransFn TRANSFN>
+static AggregateFunction MakeExtentTboxAggregate(const LogicalType &input_type) {
+    return AggregateFunction::UnaryAggregate<TBoxExtentState, string_t, string_t, TBoxExtentFn<TRANSFN>>(
+        input_type, TboxType::TBOX());
+}
+
+template <STBoxTransFn TRANSFN>
+static AggregateFunction MakeExtentStboxAggregate(const LogicalType &input_type) {
+    return AggregateFunction::UnaryAggregate<STBoxExtentState, string_t, string_t, STBoxExtentFn<TRANSFN>>(
+        input_type, StboxType::STBOX());
+}
+
 } // namespace
 
 void SpanAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
     AggregateFunctionSet extent_set("extent");
+
+    // ---- extent(span) for all 5 span types ----
     for (const auto &span_type : {SpanTypes::INTSPAN(), SpanTypes::BIGINTSPAN(),
                                   SpanTypes::FLOATSPAN(), SpanTypes::DATESPAN(),
                                   SpanTypes::TSTZSPAN()}) {
         extent_set.AddFunction(MakeExtentSpanAggregate(span_type));
     }
+
+    // ---- extent(scalar) -> typed span ----
+    extent_set.AddFunction(MakeExtentScalarAggregate<int32_t, Int32Extent>(
+        LogicalType::INTEGER, SpanTypes::INTSPAN()));
+    extent_set.AddFunction(MakeExtentScalarAggregate<int64_t, Int64Extent>(
+        LogicalType::BIGINT, SpanTypes::BIGINTSPAN()));
+    extent_set.AddFunction(MakeExtentScalarAggregate<double, DoubleExtent>(
+        LogicalType::DOUBLE, SpanTypes::FLOATSPAN()));
+    extent_set.AddFunction(MakeExtentScalarAggregate<date_t, DateExtentDuckDB>(
+        LogicalType::DATE, SpanTypes::DATESPAN()));
+    extent_set.AddFunction(MakeExtentScalarAggregate<timestamp_tz_t, TstzExtentDuckDB>(
+        LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()));
+
+    // ---- extent(set) -> typed span ----
+    struct SetSpanPair {
+        LogicalType in;
+        LogicalType out;
+    };
+    const std::vector<SetSpanPair> set_pairs = {
+        {SetTypes::intset(),     SpanTypes::INTSPAN()},
+        {SetTypes::bigintset(),  SpanTypes::BIGINTSPAN()},
+        {SetTypes::floatset(),   SpanTypes::FLOATSPAN()},
+        {SetTypes::dateset(),    SpanTypes::DATESPAN()},
+        {SetTypes::tstzset(),    SpanTypes::TSTZSPAN()},
+    };
+    for (const auto &p : set_pairs) {
+        extent_set.AddFunction(MakeExtentBlobToSpanAggregate<SpanExtentFromSet>(p.in, p.out));
+    }
+
+    // ---- extent(spanset) -> typed span ----
+    const std::vector<SetSpanPair> spanset_pairs = {
+        {SpansetTypes::intspanset(),    SpanTypes::INTSPAN()},
+        {SpansetTypes::bigintspanset(), SpanTypes::BIGINTSPAN()},
+        {SpansetTypes::floatspanset(),  SpanTypes::FLOATSPAN()},
+        {SpansetTypes::datespanset(),   SpanTypes::DATESPAN()},
+        {SpansetTypes::tstzspanset(),   SpanTypes::TSTZSPAN()},
+    };
+    for (const auto &p : spanset_pairs) {
+        extent_set.AddFunction(MakeExtentBlobToSpanAggregate<SpanExtentFromSpanSet>(p.in, p.out));
+    }
+
+    // ---- extent(tbox) -> tbox; extent(tnumber) -> tbox ----
+    extent_set.AddFunction(MakeExtentTboxAggregate<TboxExtentFromTBox>(TboxType::TBOX()));
+    extent_set.AddFunction(MakeExtentTboxAggregate<TboxExtentFromTNumber>(TemporalTypes::TINT()));
+    extent_set.AddFunction(MakeExtentTboxAggregate<TboxExtentFromTNumber>(TemporalTypes::TFLOAT()));
+
+    // ---- extent(stbox) -> stbox; extent(tgeompoint) -> stbox ----
+    extent_set.AddFunction(MakeExtentStboxAggregate<StboxExtentFromSTBox>(StboxType::STBOX()));
+    {
+        // tgeompoint is registered via TgeompointType::TGEOMPOINT().
+        // Avoid pulling in the header here by using a BLOB-aliased clone.
+        LogicalType tgeompoint_type(LogicalTypeId::BLOB);
+        tgeompoint_type.SetAlias("TGEOMPOINT");
+        extent_set.AddFunction(
+            MakeExtentStboxAggregate<StboxExtentFromTSpatial>(tgeompoint_type));
+    }
+
+    // ---- extent(tbool/ttext) -> tstzspan ----
+    extent_set.AddFunction(MakeExtentBlobToSpanAggregate<TstzSpanExtentFromTemporal>(
+        TemporalTypes::TBOOL(), SpanTypes::TSTZSPAN()));
+    extent_set.AddFunction(MakeExtentBlobToSpanAggregate<TstzSpanExtentFromTemporal>(
+        TemporalTypes::TTEXT(), SpanTypes::TSTZSPAN()));
+
     loader.RegisterFunction(std::move(extent_set));
 }
 

--- a/test/sql/parity/030_aggregates_extent.test
+++ b/test/sql/parity/030_aggregates_extent.test
@@ -1,0 +1,145 @@
+# name: test/sql/parity/030_aggregates_extent.test
+# description: extent() aggregate parity across span / set / spanset / scalar /
+#              tbox / stbox / temporal inputs.
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# extent(scalar)
+# =============================================================================
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (1::INTEGER),(5::INTEGER),(3::INTEGER)) t(v);
+----
+[1, 6)
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (1::BIGINT),(5::BIGINT),(3::BIGINT)) t(v);
+----
+[1, 6)
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (1.5::DOUBLE),(5.5::DOUBLE),(3.5::DOUBLE)) t(v);
+----
+[1.5, 5.5]
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (DATE '2001-01-01'),(DATE '2001-02-15'),(DATE '2001-01-15')) t(v);
+----
+[2001-01-01, 2001-02-16)
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (TIMESTAMPTZ '2001-01-01 00:00:00+00'),(TIMESTAMPTZ '2001-02-15 00:00:00+00')) t(v);
+----
+[2001-01-01 00:00:00+00, 2001-02-15 00:00:00+00]
+
+# =============================================================================
+# extent(span) — already covered by previous PR, verify still fine
+# =============================================================================
+
+query I
+SELECT extent(v::intspan)::VARCHAR FROM (VALUES ('[1,5)'), ('[3,8)')) t(v);
+----
+[1, 8)
+
+query I
+SELECT extent(v::floatspan)::VARCHAR FROM (VALUES ('[1.0,5.0]'), ('[3.0,8.0]')) t(v);
+----
+[1, 8]
+
+# =============================================================================
+# extent(set)
+# =============================================================================
+
+query I
+SELECT extent(v::intset)::VARCHAR FROM (VALUES ('{1,3,5}'), ('{2,4,7}')) t(v);
+----
+[1, 8)
+
+query I
+SELECT extent(v::tstzset)::VARCHAR FROM (VALUES
+  ('{2001-01-01, 2001-01-05}'), ('{2001-01-03, 2001-01-10}')) t(v);
+----
+[2001-01-01 00:00:00+00, 2001-01-10 00:00:00+00]
+
+# =============================================================================
+# extent(spanset)
+# =============================================================================
+
+query I
+SELECT extent(v::intspanset)::VARCHAR FROM (VALUES ('{[1,3),[5,7)}'), ('{[10,15)}')) t(v);
+----
+[1, 15)
+
+query I
+SELECT extent(v::tstzspanset)::VARCHAR FROM (VALUES
+  ('{[2001-01-01, 2001-01-03), [2001-01-05, 2001-01-07)}'),
+  ('{[2001-01-10, 2001-01-15)}')) t(v);
+----
+[2001-01-01 00:00:00+00, 2001-01-15 00:00:00+00)
+
+# =============================================================================
+# extent(tbox)
+# =============================================================================
+
+query I
+SELECT extent(v::tbox)::VARCHAR FROM (VALUES
+  ('TBOXINT XT([1, 5),[2000-01-01, 2000-01-05])'),
+  ('TBOXINT XT([3, 8),[2000-01-03, 2000-01-08])')) t(v);
+----
+TBOXINT XT([1, 8),[2000-01-01 00:00:00+00, 2000-01-08 00:00:00+00])
+
+# =============================================================================
+# extent(stbox)
+# =============================================================================
+
+query I
+SELECT extent(v::stbox)::VARCHAR FROM (VALUES
+  ('STBOX X((1,2),(3,4))'),
+  ('STBOX X((0,1),(5,6))')) t(v);
+----
+STBOX X((0,1),(5,6))
+
+# =============================================================================
+# extent(temporal)
+# =============================================================================
+
+query I
+SELECT extent(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+TBOXINT XT([1, 6),[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00])
+
+query I
+SELECT extent(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-05')) t(v);
+----
+TBOXFLOAT XT([1.5, 5.5],[2000-01-01 00:00:00+00, 2000-01-05 00:00:00+00])
+
+query I
+SELECT extent(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-05')) t(v);
+----
+[2000-01-01 00:00:00+00, 2000-01-05 00:00:00+00]
+
+query I
+SELECT extent(v::ttext)::VARCHAR FROM (VALUES ('"hi"@2000-01-01'),('"bye"@2000-01-05')) t(v);
+----
+[2000-01-01 00:00:00+00, 2000-01-05 00:00:00+00]
+
+query I
+SELECT extent(v::tgeompoint)::VARCHAR FROM (VALUES ('Point(1 2)@2000-01-01'),('Point(3 4)@2000-01-02')) t(v);
+----
+STBOX XT(((1,2),(3,4)),[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00])
+
+# =============================================================================
+# extent ignores NULLs
+# =============================================================================
+
+query I
+SELECT extent(v::INTEGER)::VARCHAR FROM (VALUES (1),(NULL),(5),(NULL),(3)) t(v);
+----
+[1, 6)
+
+query I
+SELECT extent(v::INTEGER)::VARCHAR FROM (VALUES (NULL::INTEGER)) t(v);
+----
+NULL


### PR DESCRIPTION
## Summary

Builds on PR #b8efad4 (extent for the 5 span types) and adds **15 more** overloads to the same \`extent\` aggregate set, covering everything in the MobilityDB \`extent(...)\` family that has fixed-size aggregate state.

| Category | Inputs | Returns |
|---|---|---|
| Numeric scalars | integer, bigint, double, date, timestamptz | typed span (intspan / bigintspan / floatspan / datespan / tstzspan) |
| Sets | intset, bigintset, floatset, dateset, tstzset | typed span |
| Spansets | intspanset, bigintspanset, floatspanset, datespanset, tstzspanset | typed span |
| Boxes | tbox, stbox | same box type |
| Temporal numbers | tint, tfloat | tbox |
| Temporal others | tbool, ttext | tstzspan |
| Temporal point | tgeompoint | stbox |

All variants share three small templated state types (\`Span\`, \`TBox\`, \`STBox\`) and dispatch on the appropriate MEOS \`*_extent_transfn\` for each input shape. Combine functions use \`span_extent_transfn\` / \`tbox_expand\` / \`stbox_expand\` so parallel-aggregate merge is correct.

## Out of scope (next aggregate PRs)

The remaining MobilityDB aggregates need a SkipList-based variable-size state (currently outside MobilityDuck's aggregate-state machinery): \`merge\`, \`appendInstant\`, \`appendSequence\`, \`tcount\`, \`tmin\`, \`tmax\`, \`tsum\`, \`tavg\`, \`tand\`, \`tor\`, \`tcentroid\`, \`spanUnion\`, \`setUnion\`, and the window aggregates \`wmin\` / \`wmax\` / \`wsum\` / \`wcount\` / \`wavg\`. They will get their own PR(s) once the SkipList serializer is in place.

## Test plan

- [x] \`test/sql/parity/030_aggregates_extent.test\` — 20 assertions across all categories plus NULL handling.
- [x] No regression in the existing \`001_set.test\` and \`025_temporal_tile_getters.test\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)