### PR TITLE
feat(bindings): SkipList-state aggregates — full *Agg surface (RFC #827)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(EXTENSION_SOURCES
     src/temporal/span.cpp
     src/temporal/span_functions.cpp
     src/temporal/span_aggregates.cpp
+    src/temporal/temporal_aggregates.cpp
     src/geo/geoset.cpp
     src/temporal/spanset.cpp
     src/temporal/spanset_functions.cpp

--- a/src/include/temporal/temporal_aggregates.hpp
+++ b/src/include/temporal/temporal_aggregates.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+// SkipList-state temporal aggregates (tcount / tand / tor / tmin / tmax /
+// tsum / tavg / tcentroid). Registered separately from the fixed-state
+// extent() aggregates (in span_aggregates.cpp) because they need a
+// destructor and reach into MEOS skiplist internals.
+struct TemporalAggregates {
+    static void RegisterAggregateFunctions(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -13,6 +13,7 @@
 #include "geo/tgeometry.hpp"
 #include "temporal/span.hpp"
 #include "temporal/span_aggregates.hpp"
+#include "temporal/temporal_aggregates.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar_function.hpp"
@@ -245,6 +246,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	SpanTypes::RegisterTypes(loader);
 	SpanTypes::RegisterCastFunctions(loader);
 	SpanAggregates::RegisterAggregateFunctions(loader);
+	TemporalAggregates::RegisterAggregateFunctions(loader);
 
 	TgeompointType::RegisterType(loader);
 	TgeompointType::RegisterCastFunctions(loader);

--- a/src/temporal/span_aggregates.cpp
+++ b/src/temporal/span_aggregates.cpp
@@ -1,7 +1,14 @@
 #include "meos_wrapper_simple.hpp"
 
+#include "common.hpp"
 #include "temporal/span.hpp"
+#include "temporal/set.hpp"
+#include "temporal/spanset.hpp"
+#include "temporal/tbox.hpp"
+#include "geo/stbox.hpp"
+#include "temporal/temporal.hpp"
 #include "temporal/span_aggregates.hpp"
+#include "time_util.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
@@ -12,55 +19,47 @@ namespace duckdb {
 
 namespace {
 
-// State for the extent(span) aggregate. The MEOS Span is a fixed-size
-// struct, so we can hold it inline in the aggregate state.
+// =====================================================================
+// Span-typed extent: state = Span. Inputs span/set/spanset/scalars all
+// fold into the same shape, only the transition function differs.
+// =====================================================================
+
 struct SpanExtentState {
     Span span;
     bool isset;
 };
 
-struct SpanExtentFunction {
+template <auto TRANSFN>
+struct SpanExtentFromSpanLike {
     template <class STATE>
-    static void Initialize(STATE &state) {
-        state.isset = false;
-    }
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
 
-    static bool IgnoreNull() {
-        return true;
-    }
-
-    // Operation receives the input blob; we decode to Span and call MEOS
-    // span_extent_transfn, which expands state's bounds in place when
-    // state is non-null and otherwise returns a fresh palloc'd copy.
     template <class INPUT_TYPE, class STATE, class OP>
     static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
-        // INPUT_TYPE is string_t for blob-encoded spans.
-        const Span *input_span = reinterpret_cast<const Span *>(input.GetData());
+        // INPUT_TYPE is string_t — span / set / spanset blob.
+        const auto *in = reinterpret_cast<const std::remove_pointer_t<
+            decltype(TRANSFN(static_cast<Span *>(nullptr), nullptr))> *>(input.GetData());
         if (!state.isset) {
-            // First call: initialize state with a copy of the input.
-            memcpy(&state.span, input_span, sizeof(Span));
-            state.isset = true;
+            // Use a temporary state of NULL: TRANSFN palloc-copies into a fresh
+            // Span. Copy it back inline and free.
+            Span *fresh = TRANSFN(nullptr, in);
+            if (fresh) {
+                memcpy(&state.span, fresh, sizeof(Span));
+                free(fresh);
+                state.isset = true;
+            }
         } else {
-            // Subsequent calls: expand state in place.
-            // span_extent_transfn(state, s) calls span_expand(s, state).
-            (void) span_extent_transfn(&state.span, input_span);
+            (void) TRANSFN(&state.span, in);
         }
     }
-
     template <class INPUT_TYPE, class STATE, class OP>
-    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
-                                  idx_t /*count*/) {
-        // extent is idempotent in the value dimension, so a single
-        // application is equivalent to applying the same value `count`
-        // times.
-        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
     }
-
     template <class STATE, class OP>
     static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
-        if (!source.isset) {
-            return;
-        }
+        if (!source.isset) return;
         if (!target.isset) {
             memcpy(&target.span, &source.span, sizeof(Span));
             target.isset = true;
@@ -68,31 +67,400 @@ struct SpanExtentFunction {
             (void) span_extent_transfn(&target.span, &source.span);
         }
     }
-
     template <class T, class STATE>
-    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
-        if (!state.isset) {
-            finalize_data.ReturnNull();
-            return;
-        }
-        target = finalize_data.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
     }
 };
+
+// Original span extent retained — span_extent_transfn expands in place even
+// for the NULL-state case, so we keep the dedicated implementation for it
+// to avoid double-allocating.
+struct SpanExtentFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Span *input_span = reinterpret_cast<const Span *>(input.GetData());
+        if (!state.isset) {
+            memcpy(&state.span, input_span, sizeof(Span));
+            state.isset = true;
+        } else {
+            (void) span_extent_transfn(&state.span, input_span);
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.span, &source.span, sizeof(Span));
+            target.isset = true;
+        } else {
+            (void) span_extent_transfn(&target.span, &source.span);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    }
+};
+
+// =====================================================================
+// Scalar inputs (int / bigint / float / date / timestamptz). For each
+// the MEOS transfn signature is (Span *, value) -> Span *.
+// =====================================================================
+
+template <class IN, Span *(*TRANSFN)(Span *, IN)>
+struct ScalarSpanExtentFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        Span *fresh = TRANSFN(state.isset ? &state.span : nullptr, input);
+        if (!state.isset && fresh) {
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.span, &source.span, sizeof(Span));
+            target.isset = true;
+        } else {
+            (void) span_extent_transfn(&target.span, &source.span);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    }
+};
+
+// Wrappers to convert DuckDB-side timestamp/date to MEOS-side before calling
+// the transition function, so the aggregate sees consistent inputs.
+inline Span *DateExtentDuckDB(Span *state, date_t d) {
+    return date_extent_transfn(state, ToMeosDate(d));
+}
+inline Span *TstzExtentDuckDB(Span *state, timestamp_tz_t t) {
+    return timestamptz_extent_transfn(state, (TimestampTz) DuckDBToMeosTimestamp(t).value);
+}
+inline Span *Int32Extent(Span *state, int32_t v) { return int_extent_transfn(state, v); }
+inline Span *Int64Extent(Span *state, int64_t v) { return bigint_extent_transfn(state, v); }
+inline Span *DoubleExtent(Span *state, double v) { return float_extent_transfn(state, v); }
+
+// =====================================================================
+// TBox extent: state = TBox. Both numeric tbox-shaped inputs (tbox itself,
+// tnumber via tnumber_extent_transfn) feed in here.
+// =====================================================================
+
+struct TBoxExtentState {
+    TBox box;
+    bool isset;
+};
+
+// Generic TBox-state aggregator, parametrised by the function that takes
+// (state, inputBlob) and returns a fresh-or-state TBox*. Both
+// `tnumber_extent_transfn(TBox*, const Temporal*)` and a "tbox extent"
+// (built on `tbox_expand`) match this signature once we wrap them.
+typedef TBox *(*TBoxTransFn)(TBox * /*state*/, const void * /*input ptr*/);
+
+template <TBoxTransFn TRANSFN>
+struct TBoxExtentFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        TBox *result = TRANSFN(state.isset ? &state.box : nullptr, input.GetData());
+        if (!state.isset && result) {
+            memcpy(&state.box, result, sizeof(TBox));
+            free(result);
+            state.isset = true;
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.box, &source.box, sizeof(TBox));
+            target.isset = true;
+        } else {
+            tbox_expand(&source.box, &target.box);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.box), sizeof(TBox)));
+    }
+};
+
+// Wrap MEOS extent-style functions to a uniform signature.
+TBox *TboxExtentFromTBox(TBox *state, const void *input) {
+    const TBox *box_in = reinterpret_cast<const TBox *>(input);
+    if (!state) {
+        TBox *fresh = (TBox *) malloc(sizeof(TBox));
+        memcpy(fresh, box_in, sizeof(TBox));
+        return fresh;
+    }
+    tbox_expand(box_in, state);
+    return state;
+}
+
+TBox *TboxExtentFromTNumber(TBox *state, const void *input) {
+    const Temporal *t = reinterpret_cast<const Temporal *>(input);
+    return tnumber_extent_transfn(state, t);
+}
+
+// =====================================================================
+// STBox extent: state = STBox.
+// =====================================================================
+
+struct STBoxExtentState {
+    STBox box;
+    bool isset;
+};
+
+typedef STBox *(*STBoxTransFn)(STBox * /*state*/, const void * /*input ptr*/);
+
+template <STBoxTransFn TRANSFN>
+struct STBoxExtentFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        STBox *result = TRANSFN(state.isset ? &state.box : nullptr, input.GetData());
+        if (!state.isset && result) {
+            memcpy(&state.box, result, sizeof(STBox));
+            free(result);
+            state.isset = true;
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.box, &source.box, sizeof(STBox));
+            target.isset = true;
+        } else {
+            stbox_expand(&source.box, &target.box);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.box), sizeof(STBox)));
+    }
+};
+
+STBox *StboxExtentFromSTBox(STBox *state, const void *input) {
+    const STBox *box_in = reinterpret_cast<const STBox *>(input);
+    if (!state) {
+        STBox *fresh = (STBox *) malloc(sizeof(STBox));
+        memcpy(fresh, box_in, sizeof(STBox));
+        return fresh;
+    }
+    stbox_expand(box_in, state);
+    return state;
+}
+
+STBox *StboxExtentFromTSpatial(STBox *state, const void *input) {
+    const Temporal *t = reinterpret_cast<const Temporal *>(input);
+    return tspatial_extent_transfn(state, t);
+}
+
+// =====================================================================
+// Span-typed extent over Temporal: temporal_extent_transfn yields the
+// time span (tstzspan) for tbool/ttext etc.
+// =====================================================================
+
+Span *TstzSpanExtentFromTemporal(Span *state, const void *input) {
+    const Temporal *t = reinterpret_cast<const Temporal *>(input);
+    return temporal_extent_transfn(state, t);
+}
+
+struct GenericSpanExtentState : SpanExtentState {};
+
+template <Span *(*TRANSFN)(Span *, const void *)>
+struct GenericSpanFromBlobFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        Span *fresh = TRANSFN(state.isset ? &state.span : nullptr, input.GetData());
+        if (!state.isset && fresh) {
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.span, &source.span, sizeof(Span));
+            target.isset = true;
+        } else {
+            (void) span_extent_transfn(&target.span, &source.span);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    }
+};
+
+Span *SpanExtentFromSet(Span *state, const void *input) {
+    const Set *s = reinterpret_cast<const Set *>(input);
+    return set_extent_transfn(state, s);
+}
+Span *SpanExtentFromSpanSet(Span *state, const void *input) {
+    const SpanSet *ss = reinterpret_cast<const SpanSet *>(input);
+    return spanset_extent_transfn(state, ss);
+}
+
+// =====================================================================
+// Aggregate-construction helpers
+// =====================================================================
 
 static AggregateFunction MakeExtentSpanAggregate(const LogicalType &span_type) {
     return AggregateFunction::UnaryAggregate<SpanExtentState, string_t, string_t, SpanExtentFunction>(
         span_type, span_type);
 }
 
+template <class T, Span *(*TRANSFN)(Span *, T)>
+static AggregateFunction MakeExtentScalarAggregate(const LogicalType &input_type, const LogicalType &out_span) {
+    return AggregateFunction::UnaryAggregate<SpanExtentState, T, string_t, ScalarSpanExtentFn<T, TRANSFN>>(
+        input_type, out_span);
+}
+
+template <Span *(*TRANSFN)(Span *, const void *)>
+static AggregateFunction MakeExtentBlobToSpanAggregate(const LogicalType &input_type,
+                                                       const LogicalType &out_span) {
+    return AggregateFunction::UnaryAggregate<SpanExtentState, string_t, string_t,
+                                             GenericSpanFromBlobFn<TRANSFN>>(input_type, out_span);
+}
+
+template <TBoxTransFn TRANSFN>
+static AggregateFunction MakeExtentTboxAggregate(const LogicalType &input_type) {
+    return AggregateFunction::UnaryAggregate<TBoxExtentState, string_t, string_t, TBoxExtentFn<TRANSFN>>(
+        input_type, TboxType::TBOX());
+}
+
+template <STBoxTransFn TRANSFN>
+static AggregateFunction MakeExtentStboxAggregate(const LogicalType &input_type) {
+    return AggregateFunction::UnaryAggregate<STBoxExtentState, string_t, string_t, STBoxExtentFn<TRANSFN>>(
+        input_type, StboxType::STBOX());
+}
+
 } // namespace
 
 void SpanAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
     AggregateFunctionSet extent_set("extent");
+
+    // ---- extent(span) for all 5 span types ----
     for (const auto &span_type : {SpanTypes::INTSPAN(), SpanTypes::BIGINTSPAN(),
                                   SpanTypes::FLOATSPAN(), SpanTypes::DATESPAN(),
                                   SpanTypes::TSTZSPAN()}) {
         extent_set.AddFunction(MakeExtentSpanAggregate(span_type));
     }
+
+    // ---- extent(scalar) -> typed span ----
+    extent_set.AddFunction(MakeExtentScalarAggregate<int32_t, Int32Extent>(
+        LogicalType::INTEGER, SpanTypes::INTSPAN()));
+    extent_set.AddFunction(MakeExtentScalarAggregate<int64_t, Int64Extent>(
+        LogicalType::BIGINT, SpanTypes::BIGINTSPAN()));
+    extent_set.AddFunction(MakeExtentScalarAggregate<double, DoubleExtent>(
+        LogicalType::DOUBLE, SpanTypes::FLOATSPAN()));
+    extent_set.AddFunction(MakeExtentScalarAggregate<date_t, DateExtentDuckDB>(
+        LogicalType::DATE, SpanTypes::DATESPAN()));
+    extent_set.AddFunction(MakeExtentScalarAggregate<timestamp_tz_t, TstzExtentDuckDB>(
+        LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()));
+
+    // ---- extent(set) -> typed span ----
+    struct SetSpanPair {
+        LogicalType in;
+        LogicalType out;
+    };
+    const std::vector<SetSpanPair> set_pairs = {
+        {SetTypes::intset(),     SpanTypes::INTSPAN()},
+        {SetTypes::bigintset(),  SpanTypes::BIGINTSPAN()},
+        {SetTypes::floatset(),   SpanTypes::FLOATSPAN()},
+        {SetTypes::dateset(),    SpanTypes::DATESPAN()},
+        {SetTypes::tstzset(),    SpanTypes::TSTZSPAN()},
+    };
+    for (const auto &p : set_pairs) {
+        extent_set.AddFunction(MakeExtentBlobToSpanAggregate<SpanExtentFromSet>(p.in, p.out));
+    }
+
+    // ---- extent(spanset) -> typed span ----
+    const std::vector<SetSpanPair> spanset_pairs = {
+        {SpansetTypes::intspanset(),    SpanTypes::INTSPAN()},
+        {SpansetTypes::bigintspanset(), SpanTypes::BIGINTSPAN()},
+        {SpansetTypes::floatspanset(),  SpanTypes::FLOATSPAN()},
+        {SpansetTypes::datespanset(),   SpanTypes::DATESPAN()},
+        {SpansetTypes::tstzspanset(),   SpanTypes::TSTZSPAN()},
+    };
+    for (const auto &p : spanset_pairs) {
+        extent_set.AddFunction(MakeExtentBlobToSpanAggregate<SpanExtentFromSpanSet>(p.in, p.out));
+    }
+
+    // ---- extent(tbox) -> tbox; extent(tnumber) -> tbox ----
+    extent_set.AddFunction(MakeExtentTboxAggregate<TboxExtentFromTBox>(TboxType::TBOX()));
+    extent_set.AddFunction(MakeExtentTboxAggregate<TboxExtentFromTNumber>(TemporalTypes::TINT()));
+    extent_set.AddFunction(MakeExtentTboxAggregate<TboxExtentFromTNumber>(TemporalTypes::TFLOAT()));
+
+    // ---- extent(stbox) -> stbox; extent(tgeompoint) -> stbox ----
+    extent_set.AddFunction(MakeExtentStboxAggregate<StboxExtentFromSTBox>(StboxType::STBOX()));
+    {
+        // tgeompoint is registered via TgeompointType::TGEOMPOINT().
+        // Avoid pulling in the header here by using a BLOB-aliased clone.
+        LogicalType tgeompoint_type(LogicalTypeId::BLOB);
+        tgeompoint_type.SetAlias("TGEOMPOINT");
+        extent_set.AddFunction(
+            MakeExtentStboxAggregate<StboxExtentFromTSpatial>(tgeompoint_type));
+    }
+
+    // ---- extent(tbool/ttext) -> tstzspan ----
+    extent_set.AddFunction(MakeExtentBlobToSpanAggregate<TstzSpanExtentFromTemporal>(
+        TemporalTypes::TBOOL(), SpanTypes::TSTZSPAN()));
+    extent_set.AddFunction(MakeExtentBlobToSpanAggregate<TstzSpanExtentFromTemporal>(
+        TemporalTypes::TTEXT(), SpanTypes::TSTZSPAN()));
+
     loader.RegisterFunction(std::move(extent_set));
 }
 

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -865,10 +865,19 @@ struct SetUnionFromScalarFn {
 inline Datum Int32ToDatum(int32_t v) { return (Datum) (int64_t) v; }
 inline Datum Int64ToDatum(int64_t v) { return (Datum) v; }
 inline Datum Float8ToDatum(double v) {
-    Datum d;
-    static_assert(sizeof(d) == sizeof(v), "Datum must be 64-bit");
-    memcpy(&d, &v, sizeof(d));
-    return d;
+    // Datum is `uintptr_t`. On native 64-bit builds the double fits by-value
+    // (bit-pattern reinterpret); on 32-bit builds (e.g. wasm32-emscripten)
+    // the Datum is 4 bytes, so we have to pass a pointer the way PG's
+    // Float8GetDatum does under !USE_FLOAT8_BYVAL. The pointed-at storage
+    // becomes part of the MEOS Set on insert and is freed by set_free.
+    if (sizeof(Datum) >= sizeof(double)) {
+        Datum d = 0;
+        memcpy(&d, &v, sizeof(double));
+        return d;
+    }
+    double *p = (double *) malloc(sizeof(double));
+    *p = v;
+    return (Datum) (uintptr_t) p;
 }
 inline Datum DateToDatum(date_t v) { return (Datum) (int64_t) ToMeosDate(v); }
 inline Datum TstzToDatum(timestamp_tz_t v) {

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -26,6 +26,10 @@
 #include "common.hpp"
 #include "temporal/temporal.hpp"
 #include "temporal/temporal_aggregates.hpp"
+#include "temporal/span.hpp"
+#include "temporal/spanset.hpp"
+#include "temporal/set.hpp"
+#include "time_util.hpp"
 #include "geo/tgeompoint.hpp"
 
 #include "duckdb/common/exception.hpp"
@@ -55,9 +59,28 @@ Datum datum_sum_double4(Datum, Datum);
 // Forward-decl: same signature as in meos/include/temporal/temporal_aggfuncs.h.
 SkipList *temporal_tagg_combinefn(SkipList *state1, SkipList *state2,
                                   datum_func2 func, bool crossings);
+SkipList *temporal_tagg_transfn(SkipList *state, const Temporal *temp,
+                                datum_func2 func, bool crossings);
+
+// Window-aggregate helpers — same signatures as in
+// meos/include/temporal/temporal_waggfuncs.h. (TSequence is already declared
+// by the MEOS public headers; we just refer to it.)
+TSequence **temporal_transform_wcount(const Temporal *temp,
+                                      const ::Interval *interval, int *count);
+SkipList *temporal_wagg_transform_transfn(SkipList *state, const Temporal *temp,
+                                          const ::Interval *interval, datum_func2 func,
+                                          TSequence ** (*transform)(const Temporal *, const ::Interval *, int *));
 }
 
 namespace {
+
+// Mirror of `struct GeoAggregateState` from MEOS's tgeo_aggfuncs.h. Used
+// only to peek at the `hasz` flag carried in `SkipList::extra` so we can
+// pick the correct datum_sum functor at combine time.
+struct GeoAggregateStateLayout {
+    int32_t srid;
+    bool hasz;
+};
 
 // Mirrors the elem-walk in MEOS skiplist_free, nulling out keys/values so
 // the subsequent skiplist_free only releases the structural memory.
@@ -167,9 +190,81 @@ struct TemporalSkipListAggFn {
 #define DECLARE_TAGG(NAME, TRANSFN, FINALFN, MERGE_FN, CROSSINGS) \
     using NAME = TemporalSkipListAggFn<TRANSFN, FINALFN, MERGE_FN, CROSSINGS>;
 
-DECLARE_TAGG(TandFn,         tbool_tand_transfn,        temporal_tagg_finalfn,  datum_and,           false)
-DECLARE_TAGG(TorFn,          tbool_tor_transfn,         temporal_tagg_finalfn,  datum_or,            false)
-DECLARE_TAGG(TcountTempFn,   temporal_tcount_transfn,   temporal_tagg_finalfn,  datum_sum_int32,     false)
+// TcountAgg variants over time-only inputs use distinct transfn signatures.
+// The blob-shaped ones (set / span / spanset) all funnel through a common
+// blob-casting wrapper; the scalar timestamptz one needs its own functor
+// since the input isn't a string_t blob.
+
+inline SkipList *TcountTstzsetTransfn(SkipList *state, const Temporal *blob) {
+    return tstzset_tcount_transfn(state, reinterpret_cast<const Set *>(blob));
+}
+inline SkipList *TcountTstzspanTransfn(SkipList *state, const Temporal *blob) {
+    return tstzspan_tcount_transfn(state, reinterpret_cast<const Span *>(blob));
+}
+inline SkipList *TcountTstzspansetTransfn(SkipList *state, const Temporal *blob) {
+    return tstzspanset_tcount_transfn(state, reinterpret_cast<const SpanSet *>(blob));
+}
+
+DECLARE_TAGG(TandFn,             tbool_tand_transfn,         temporal_tagg_finalfn,  datum_and,        false)
+DECLARE_TAGG(TorFn,              tbool_tor_transfn,          temporal_tagg_finalfn,  datum_or,         false)
+DECLARE_TAGG(TcountTempFn,       temporal_tcount_transfn,    temporal_tagg_finalfn,  datum_sum_int32,  false)
+DECLARE_TAGG(TcountTstzsetFn,    TcountTstzsetTransfn,       temporal_tagg_finalfn,  datum_sum_int32,  false)
+DECLARE_TAGG(TcountTstzspanFn,   TcountTstzspanTransfn,      temporal_tagg_finalfn,  datum_sum_int32,  false)
+DECLARE_TAGG(TcountTstzspansetFn, TcountTstzspansetTransfn,  temporal_tagg_finalfn,  datum_sum_int32,  false)
+
+// TcountAgg(timestamptz) — input is a scalar TimestampTz, not a blob.
+struct TcountTstzFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.skiplist = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        timestamp_tz_t meos_t = DuckDBToMeosTimestamp(input);
+        state.skiplist = timestamptz_tcount_transfn(state.skiplist, (TimestampTz) meos_t.value);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.skiplist) return;
+        if (!target.skiplist) {
+            target.skiplist = source.skiplist;
+            source.skiplist = nullptr;
+            return;
+        }
+        SkipList *result = temporal_tagg_combinefn(target.skiplist, source.skiplist,
+                                                   &datum_sum_int32, /*crossings=*/false);
+        SafeFreeLoserSkiplist(result, target.skiplist, source.skiplist);
+        target.skiplist = result;
+        source.skiplist = nullptr;
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.skiplist) { fd.ReturnNull(); return; }
+        Temporal *result = temporal_tagg_finalfn(state.skiplist);
+        SkipList *raw = state.skiplist;
+        state.skiplist = nullptr;
+        if (!result) {
+            skiplist_free(raw);
+            fd.ReturnNull();
+            return;
+        }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
 DECLARE_TAGG(TminTintFn,     tint_tmin_transfn,         temporal_tagg_finalfn,  datum_min_int32,     false)
 DECLARE_TAGG(TmaxTintFn,     tint_tmax_transfn,         temporal_tagg_finalfn,  datum_max_int32,     false)
 DECLARE_TAGG(TsumTintFn,     tint_tsum_transfn,         temporal_tagg_finalfn,  datum_sum_int32,     false)
@@ -209,16 +304,16 @@ struct TcentroidFn {
             return;
         }
         // Choose merge functor based on dimensionality stored in the
-        // skiplist's `extra` (a GeoAggregateState). Bit 0 of the first
-        // byte after the SkipList header is `hasz` per MEOS layout.
-        // Falling back to double3 (2D) if extra is null.
+        // skiplist's `extra` (a GeoAggregateState laid out as
+        // {int32 srid; bool hasz;}). Falling back to double3 (2D) if
+        // extra is null.
         datum_func2 func = &datum_sum_double3;
         const auto *extra = (target.skiplist && target.skiplist->extra)
                               ? target.skiplist->extra
                               : (source.skiplist ? source.skiplist->extra : nullptr);
         if (extra) {
-            // GeoAggregateState begins with `bool hasz;` — first byte.
-            if (*static_cast<const bool *>(extra)) {
+            const auto *gs = static_cast<const GeoAggregateStateLayout *>(extra);
+            if (gs->hasz) {
                 func = &datum_sum_double4;
             }
         }
@@ -257,6 +352,544 @@ static AggregateFunction MakeTaggAggregate(const LogicalType &input_type, const 
         SkipListState, string_t, string_t, OP, AggregateDestructorType::LEGACY>(input_type, return_type);
 }
 
+// =====================================================================
+// Window aggregates (W*Agg): binary aggregate over (Temporal, Interval).
+// State = SkipList *, transfn takes the extra Interval, combinefn is the
+// same as for the non-windowed variant.
+// =====================================================================
+
+template <
+    SkipList *(*TRANSFN)(SkipList *, const Temporal *, const ::Interval *),
+    Temporal *(*FINALFN)(SkipList *),
+    Datum (*MERGE_FN)(Datum, Datum),
+    bool CROSSINGS = false>
+struct WindowAggFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.skiplist = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class A_TYPE, class B_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const A_TYPE &input, const B_TYPE &interv,
+                          AggregateBinaryInput &) {
+        const Temporal *t = reinterpret_cast<const Temporal *>(input.GetData());
+        MeosInterval iv = IntervaltToInterval(interv);
+        state.skiplist = TRANSFN(state.skiplist, t, &iv);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.skiplist) return;
+        if (!target.skiplist) {
+            target.skiplist = source.skiplist;
+            source.skiplist = nullptr;
+            return;
+        }
+        SkipList *result = temporal_tagg_combinefn(target.skiplist, source.skiplist,
+                                                   MERGE_FN, CROSSINGS);
+        SafeFreeLoserSkiplist(result, target.skiplist, source.skiplist);
+        target.skiplist = result;
+        source.skiplist = nullptr;
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.skiplist) { fd.ReturnNull(); return; }
+        Temporal *result = FINALFN(state.skiplist);
+        SkipList *raw = state.skiplist;
+        state.skiplist = nullptr;
+        if (!result) {
+            skiplist_free(raw);
+            fd.ReturnNull();
+            return;
+        }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+// WcountAgg: input is transformed through `temporal_transform_wcount`
+// before being aggregated with `datum_sum_int32`. The result is always
+// a tint regardless of input subtype.
+struct WcountAggFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.skiplist = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class A_TYPE, class B_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const A_TYPE &input, const B_TYPE &interv,
+                          AggregateBinaryInput &) {
+        const Temporal *t = reinterpret_cast<const Temporal *>(input.GetData());
+        MeosInterval iv = IntervaltToInterval(interv);
+        state.skiplist = temporal_wagg_transform_transfn(
+            state.skiplist, t, &iv, &datum_sum_int32, &temporal_transform_wcount);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.skiplist) return;
+        if (!target.skiplist) {
+            target.skiplist = source.skiplist;
+            source.skiplist = nullptr;
+            return;
+        }
+        SkipList *result = temporal_tagg_combinefn(target.skiplist, source.skiplist,
+                                                   &datum_sum_int32, /*crossings=*/false);
+        SafeFreeLoserSkiplist(result, target.skiplist, source.skiplist);
+        target.skiplist = result;
+        source.skiplist = nullptr;
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.skiplist) { fd.ReturnNull(); return; }
+        Temporal *result = temporal_tagg_finalfn(state.skiplist);
+        SkipList *raw = state.skiplist;
+        state.skiplist = nullptr;
+        if (!result) {
+            skiplist_free(raw);
+            fd.ReturnNull();
+            return;
+        }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+// Concrete window aggregates.
+using WminTintFn   = WindowAggFn<tint_wmin_transfn,   temporal_tagg_finalfn, datum_min_int32,  false>;
+using WmaxTintFn   = WindowAggFn<tint_wmax_transfn,   temporal_tagg_finalfn, datum_max_int32,  false>;
+using WsumTintFn   = WindowAggFn<tint_wsum_transfn,   temporal_tagg_finalfn, datum_sum_int32,  false>;
+using WminTfloatFn = WindowAggFn<tfloat_wmin_transfn, temporal_tagg_finalfn, datum_min_float8, true>;
+using WmaxTfloatFn = WindowAggFn<tfloat_wmax_transfn, temporal_tagg_finalfn, datum_max_float8, true>;
+using WsumTfloatFn = WindowAggFn<tfloat_wsum_transfn, temporal_tagg_finalfn, datum_sum_float8, false>;
+using WavgFn       = WindowAggFn<tnumber_wavg_transfn, tnumber_tavg_finalfn,  datum_sum_double2, false>;
+
+template <class OP>
+static AggregateFunction MakeWindowAggregate(const LogicalType &input_type, const LogicalType &return_type) {
+    auto fn = AggregateFunction::BinaryAggregate<
+        SkipListState, string_t, interval_t, string_t, OP, AggregateDestructorType::LEGACY>(
+        input_type, LogicalType::INTERVAL, return_type);
+    fn.destructor = AggregateFunction::StateDestroy<SkipListState, OP>;
+    return fn;
+}
+
+// =====================================================================
+// MergeAgg: same SkipList state, but with no per-instant merge functor.
+// MEOS treats `func == NULL` as "concatenate values without conflict
+// resolution"; the resulting Temporal is the merged sequence/sequenceset.
+// =====================================================================
+
+inline SkipList *MergeTransfn(SkipList *state, const Temporal *temp) {
+    return temporal_tagg_transfn(state, temp, /*func=*/nullptr, /*crossings=*/false);
+}
+
+struct MergeAggFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.skiplist = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Temporal *t = reinterpret_cast<const Temporal *>(input.GetData());
+        state.skiplist = MergeTransfn(state.skiplist, t);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.skiplist) return;
+        if (!target.skiplist) {
+            target.skiplist = source.skiplist;
+            source.skiplist = nullptr;
+            return;
+        }
+        SkipList *result = temporal_tagg_combinefn(target.skiplist, source.skiplist,
+                                                   /*func=*/nullptr, /*crossings=*/false);
+        SafeFreeLoserSkiplist(result, target.skiplist, source.skiplist);
+        target.skiplist = result;
+        source.skiplist = nullptr;
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.skiplist) { fd.ReturnNull(); return; }
+        Temporal *result = temporal_tagg_finalfn(state.skiplist);
+        SkipList *raw = state.skiplist;
+        state.skiplist = nullptr;
+        if (!result) {
+            skiplist_free(raw);
+            fd.ReturnNull();
+            return;
+        }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+// =====================================================================
+// AppendInstantAgg / AppendSequenceAgg: state shape is `Temporal *`
+// (not a SkipList). The MEOS transfn mutates the state Temporal in
+// place and returns either the same pointer or a freshly-allocated
+// successor. Combine merges two states via the public `temporal_merge`.
+// =====================================================================
+
+struct TemporalState {
+    Temporal *value;
+};
+
+template <Temporal *(*COMBINE_MERGE)(const Temporal *, const Temporal *) = temporal_merge>
+struct TemporalStateCombineBase {
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.value) return;
+        if (!target.value) {
+            target.value = source.value;
+            source.value = nullptr;
+            return;
+        }
+        Temporal *merged = COMBINE_MERGE(target.value, source.value);
+        free(target.value);
+        free(source.value);
+        target.value = merged;
+        source.value = nullptr;
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.value) { fd.ReturnNull(); return; }
+        Temporal *result = temporal_compact(state.value);
+        free(state.value);
+        state.value = nullptr;
+        if (!result) { fd.ReturnNull(); return; }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.value) {
+            free(state.value);
+            state.value = nullptr;
+        }
+    }
+};
+
+// AppendInstantAgg(temporal) — uses default LINEAR-or-discrete interpretation
+// inferred from the temporal subtype, no maxdist / maxt thresholds.
+struct AppendInstantAggFn : TemporalStateCombineBase<> {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.value = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Temporal *t = reinterpret_cast<const Temporal *>(input.GetData());
+        // The MEOS transfn expects a TInstant *; an aggregate input that
+        // is already a sequence falls through to AppendSequenceAgg.
+        const TInstant *inst = reinterpret_cast<const TInstant *>(t);
+        // INTERP_NONE lets MEOS pick the natural interpretation for the
+        // base type (DISCRETE for tbool/ttext, LINEAR for tnumber/tgeo).
+        state.value = temporal_app_tinst_transfn(
+            state.value, inst, INTERP_NONE, /*maxdist=*/0.0, /*maxt=*/nullptr);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+};
+
+// AppendSequenceAgg(temporal) — input is already a TSequence.
+struct AppendSequenceAggFn : TemporalStateCombineBase<> {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.value = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Temporal *t = reinterpret_cast<const Temporal *>(input.GetData());
+        const TSequence *seq = reinterpret_cast<const TSequence *>(t);
+        state.value = temporal_app_tseq_transfn(state.value, seq);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+};
+
+template <class OP>
+static AggregateFunction MakeTemporalStateAggregate(const LogicalType &type) {
+    return AggregateFunction::UnaryAggregateDestructor<
+        TemporalState, string_t, string_t, OP, AggregateDestructorType::LEGACY>(type, type);
+}
+
+// =====================================================================
+// SpanUnionAgg: state shape is `SpanSet *`. Each input span/spanset is
+// folded into the state via MEOS's union transfns. Final state is the
+// state itself (no separate finalfn — `spanset_union_finalfn` is a
+// passthrough at this point).
+// =====================================================================
+
+struct SpanSetState {
+    SpanSet *value;
+};
+
+template <class STATE>
+inline void SpanSetCombine(STATE &source, STATE &target) {
+    if (!source.value) return;
+    if (!target.value) {
+        target.value = source.value;
+        source.value = nullptr;
+        return;
+    }
+    // spanset_union_transfn either mutates target.value in place (returns
+    // the same pointer) or frees it and returns a fresh allocation; in
+    // both cases the old target should not be freed by us. The source is
+    // a const input — we own it independently and must free it.
+    target.value = spanset_union_transfn(target.value, source.value);
+    free(source.value);
+    source.value = nullptr;
+}
+
+template <class T, class STATE>
+inline void SpanSetFinalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+    if (!state.value) { fd.ReturnNull(); return; }
+    // spanset_union_finalfn frees the state internally on the success
+    // path, so clear the pointer first to prevent Destroy from
+    // double-freeing if anything below throws.
+    SpanSet *result = spanset_union_finalfn(state.value);
+    state.value = nullptr;
+    if (!result) { fd.ReturnNull(); return; }
+    size_t size = (size_t) spanset_mem_size(result);
+    target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+    free(result);
+}
+
+template <class STATE>
+inline void SpanSetDestroy(STATE &state) {
+    if (state.value) {
+        free(state.value);
+        state.value = nullptr;
+    }
+}
+
+// SpanUnionAgg(<typed-span>) — input is a Span blob.
+struct SpanUnionFromSpanFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.value = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Span *s = reinterpret_cast<const Span *>(input.GetData());
+        state.value = span_union_transfn(state.value, s);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        SpanSetCombine(const_cast<STATE &>(source_const), target);
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        SpanSetFinalize(state, target, fd);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) { SpanSetDestroy(state); }
+};
+
+// SpanUnionAgg(<typed-spanset>) — input is a SpanSet blob.
+struct SpanUnionFromSpanSetFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.value = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const SpanSet *ss = reinterpret_cast<const SpanSet *>(input.GetData());
+        state.value = spanset_union_transfn(state.value, ss);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        SpanSetCombine(const_cast<STATE &>(source_const), target);
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        SpanSetFinalize(state, target, fd);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) { SpanSetDestroy(state); }
+};
+
+template <class OP>
+static AggregateFunction MakeSpanSetAggregate(const LogicalType &input_type, const LogicalType &return_type) {
+    return AggregateFunction::UnaryAggregateDestructor<
+        SpanSetState, string_t, string_t, OP, AggregateDestructorType::LEGACY>(input_type, return_type);
+}
+
+// =====================================================================
+// SetUnionAgg: state shape is `Set *`. Inputs come in two flavours —
+// scalars (folded via `value_union_transfn`) and sets (folded via
+// `set_union_transfn`).
+// =====================================================================
+
+struct SetAggState {
+    Set *value;
+};
+
+template <class STATE>
+inline void SetCombine(STATE &source, STATE &target) {
+    if (!source.value) return;
+    if (!target.value) {
+        target.value = source.value;
+        source.value = nullptr;
+        return;
+    }
+    // Same ownership story as SpanSetCombine: transfn handles target;
+    // source is a separate allocation we own.
+    target.value = set_union_transfn(target.value, source.value);
+    free(source.value);
+    source.value = nullptr;
+}
+
+template <class T, class STATE>
+inline void SetFinalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+    if (!state.value) { fd.ReturnNull(); return; }
+    // set_union_finalfn frees the state internally on the success path.
+    Set *result = set_union_finalfn(state.value);
+    state.value = nullptr;
+    if (!result) { fd.ReturnNull(); return; }
+    size_t size = (size_t) set_mem_size(result);
+    target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+    free(result);
+}
+
+template <class STATE>
+inline void SetDestroy(STATE &state) {
+    if (state.value) {
+        free(state.value);
+        state.value = nullptr;
+    }
+}
+
+// SetUnionAgg(<typed-set>) — input is a Set blob.
+struct SetUnionFromSetFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.value = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        Set *s = const_cast<Set *>(reinterpret_cast<const Set *>(input.GetData()));
+        state.value = set_union_transfn(state.value, s);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        SetCombine(const_cast<STATE &>(source_const), target);
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        SetFinalize(state, target, fd);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) { SetDestroy(state); }
+};
+
+// SetUnionAgg(<scalar>) — input is a primitive value lifted to a Datum.
+template <class IN, Datum (*TO_DATUM)(IN), meosType BASETYPE>
+struct SetUnionFromScalarFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.value = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        state.value = value_union_transfn(state.value, TO_DATUM(input), BASETYPE);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        SetCombine(const_cast<STATE &>(source_const), target);
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        SetFinalize(state, target, fd);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) { SetDestroy(state); }
+};
+
+// Datum casting helpers — MobilityDuck doesn't pull in PG's `postgres.h`,
+// so we cast explicitly. For floats this is a bit-pattern reinterpret; for
+// integer / date / tstz a sign-extending widening to int64 covers both 64-
+// and 32-bit Datum builds.
+inline Datum Int32ToDatum(int32_t v) { return (Datum) (int64_t) v; }
+inline Datum Int64ToDatum(int64_t v) { return (Datum) v; }
+inline Datum Float8ToDatum(double v) {
+    Datum d;
+    static_assert(sizeof(d) == sizeof(v), "Datum must be 64-bit");
+    memcpy(&d, &v, sizeof(d));
+    return d;
+}
+inline Datum DateToDatum(date_t v) { return (Datum) (int64_t) ToMeosDate(v); }
+inline Datum TstzToDatum(timestamp_tz_t v) {
+    return (Datum) (int64_t) DuckDBToMeosTimestamp(v).value;
+}
+
+template <class OP>
+static AggregateFunction MakeSetAggregate(const LogicalType &input_type, const LogicalType &return_type) {
+    return AggregateFunction::UnaryAggregateDestructor<
+        SetAggState, string_t, string_t, OP, AggregateDestructorType::LEGACY>(input_type, return_type);
+}
+
+template <class IN, Datum (*TO_DATUM)(IN), meosType BASETYPE>
+static AggregateFunction MakeSetUnionScalarAggregate(const LogicalType &input_type,
+                                                     const LogicalType &return_type) {
+    return AggregateFunction::UnaryAggregateDestructor<
+        SetAggState, IN, string_t,
+        SetUnionFromScalarFn<IN, TO_DATUM, BASETYPE>,
+        AggregateDestructorType::LEGACY>(input_type, return_type);
+}
+
 } // namespace
 
 void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
@@ -281,7 +914,7 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(set));
     }
 
-    // ---- TcountAgg over each temporal type → tint ----
+    // ---- TcountAgg over each temporal type and over time-only inputs → tint ----
     {
         AggregateFunctionSet set("TcountAgg");
         for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
@@ -289,6 +922,16 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
             set.AddFunction(MakeTaggAggregate<TcountTempFn>(t, TemporalTypes::TINT()));
         }
         set.AddFunction(MakeTaggAggregate<TcountTempFn>(TgeompointType::TGEOMPOINT(), TemporalTypes::TINT()));
+
+        // Time-only inputs.
+        set.AddFunction(AggregateFunction::UnaryAggregateDestructor<
+            SkipListState, timestamp_tz_t, string_t, TcountTstzFn,
+            AggregateDestructorType::LEGACY>(
+            LogicalType::TIMESTAMP_TZ, TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TcountTstzsetFn>(    SetTypes::tstzset(),         TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TcountTstzspanFn>(   SpanTypes::TSTZSPAN(),       TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TcountTstzspansetFn>(SpansetTypes::tstzspanset(), TemporalTypes::TINT()));
+
         loader.RegisterFunction(std::move(set));
     }
 
@@ -329,6 +972,132 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
         AggregateFunctionSet set("TcentroidAgg");
         set.AddFunction(MakeTaggAggregate<TcentroidFn>(
             TgeompointType::TGEOMPOINT(), TgeompointType::TGEOMPOINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- MergeAgg over each temporal type → same type ----
+    {
+        AggregateFunctionSet set("MergeAgg");
+        for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
+                              TemporalTypes::TFLOAT(), TemporalTypes::TTEXT()}) {
+            set.AddFunction(MakeTaggAggregate<MergeAggFn>(t, t));
+        }
+        set.AddFunction(MakeTaggAggregate<MergeAggFn>(
+            TgeompointType::TGEOMPOINT(), TgeompointType::TGEOMPOINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- AppendInstantAgg over each temporal type → same type ----
+    {
+        AggregateFunctionSet set("AppendInstantAgg");
+        for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
+                              TemporalTypes::TFLOAT(), TemporalTypes::TTEXT()}) {
+            set.AddFunction(MakeTemporalStateAggregate<AppendInstantAggFn>(t));
+        }
+        set.AddFunction(MakeTemporalStateAggregate<AppendInstantAggFn>(TgeompointType::TGEOMPOINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- AppendSequenceAgg over each temporal type → same type ----
+    {
+        AggregateFunctionSet set("AppendSequenceAgg");
+        for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
+                              TemporalTypes::TFLOAT(), TemporalTypes::TTEXT()}) {
+            set.AddFunction(MakeTemporalStateAggregate<AppendSequenceAggFn>(t));
+        }
+        set.AddFunction(MakeTemporalStateAggregate<AppendSequenceAggFn>(TgeompointType::TGEOMPOINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- SpanUnionAgg(span | spanset) -> typed spanset ----
+    struct SpanInputPair {
+        LogicalType in;
+        LogicalType out;
+    };
+    {
+        AggregateFunctionSet set("SpanUnionAgg");
+        const std::vector<SpanInputPair> span_pairs = {
+            {SpanTypes::INTSPAN(),     SpansetTypes::intspanset()},
+            {SpanTypes::BIGINTSPAN(),  SpansetTypes::bigintspanset()},
+            {SpanTypes::FLOATSPAN(),   SpansetTypes::floatspanset()},
+            {SpanTypes::DATESPAN(),    SpansetTypes::datespanset()},
+            {SpanTypes::TSTZSPAN(),    SpansetTypes::tstzspanset()},
+        };
+        for (const auto &p : span_pairs) {
+            set.AddFunction(MakeSpanSetAggregate<SpanUnionFromSpanFn>(p.in, p.out));
+        }
+        const std::vector<SpanInputPair> spanset_pairs = {
+            {SpansetTypes::intspanset(),    SpansetTypes::intspanset()},
+            {SpansetTypes::bigintspanset(), SpansetTypes::bigintspanset()},
+            {SpansetTypes::floatspanset(),  SpansetTypes::floatspanset()},
+            {SpansetTypes::datespanset(),   SpansetTypes::datespanset()},
+            {SpansetTypes::tstzspanset(),   SpansetTypes::tstzspanset()},
+        };
+        for (const auto &p : spanset_pairs) {
+            set.AddFunction(MakeSpanSetAggregate<SpanUnionFromSpanSetFn>(p.in, p.out));
+        }
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- Window aggregates: WminAgg / WmaxAgg / WsumAgg / WcountAgg / WavgAgg ----
+    {
+        AggregateFunctionSet set("WminAgg");
+        set.AddFunction(MakeWindowAggregate<WminTintFn>(TemporalTypes::TINT(),     TemporalTypes::TINT()));
+        set.AddFunction(MakeWindowAggregate<WminTfloatFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(set));
+    }
+    {
+        AggregateFunctionSet set("WmaxAgg");
+        set.AddFunction(MakeWindowAggregate<WmaxTintFn>(TemporalTypes::TINT(),     TemporalTypes::TINT()));
+        set.AddFunction(MakeWindowAggregate<WmaxTfloatFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(set));
+    }
+    {
+        AggregateFunctionSet set("WsumAgg");
+        set.AddFunction(MakeWindowAggregate<WsumTintFn>(TemporalTypes::TINT(),     TemporalTypes::TINT()));
+        set.AddFunction(MakeWindowAggregate<WsumTfloatFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(set));
+    }
+    {
+        AggregateFunctionSet set("WcountAgg");
+        set.AddFunction(MakeWindowAggregate<WcountAggFn>(TemporalTypes::TINT(),    TemporalTypes::TINT()));
+        set.AddFunction(MakeWindowAggregate<WcountAggFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+    {
+        AggregateFunctionSet set("WavgAgg");
+        set.AddFunction(MakeWindowAggregate<WavgFn>(TemporalTypes::TINT(),    TemporalTypes::TFLOAT()));
+        set.AddFunction(MakeWindowAggregate<WavgFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- SetUnionAgg(<scalar | typed-set>) -> typed set ----
+    {
+        AggregateFunctionSet set("SetUnionAgg");
+        // Scalar inputs.
+        set.AddFunction(MakeSetUnionScalarAggregate<int32_t, Int32ToDatum, T_INT4>(
+            LogicalType::INTEGER, SetTypes::intset()));
+        set.AddFunction(MakeSetUnionScalarAggregate<int64_t, Int64ToDatum, T_INT8>(
+            LogicalType::BIGINT, SetTypes::bigintset()));
+        set.AddFunction(MakeSetUnionScalarAggregate<double, Float8ToDatum, T_FLOAT8>(
+            LogicalType::DOUBLE, SetTypes::floatset()));
+        set.AddFunction(MakeSetUnionScalarAggregate<date_t, DateToDatum, T_DATE>(
+            LogicalType::DATE, SetTypes::dateset()));
+        set.AddFunction(MakeSetUnionScalarAggregate<timestamp_tz_t, TstzToDatum, T_TIMESTAMPTZ>(
+            LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()));
+
+        // Set inputs.
+        const std::vector<SpanInputPair> set_pairs = {
+            {SetTypes::intset(),     SetTypes::intset()},
+            {SetTypes::bigintset(),  SetTypes::bigintset()},
+            {SetTypes::floatset(),   SetTypes::floatset()},
+            {SetTypes::textset(),    SetTypes::textset()},
+            {SetTypes::dateset(),    SetTypes::dateset()},
+            {SetTypes::tstzset(),    SetTypes::tstzset()},
+        };
+        for (const auto &p : set_pairs) {
+            set.AddFunction(MakeSetAggregate<SetUnionFromSetFn>(p.in, p.out));
+        }
         loader.RegisterFunction(std::move(set));
     }
 }

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -1,6 +1,9 @@
-// SkipList-state temporal aggregates: tcount, tand, tor, tmin, tmax, tsum,
-// tavg, tcentroid. These differ from the fixed-state `extent()` aggregates
-// in two ways:
+// SkipList-state temporal aggregates: TcountAgg, TandAgg, TorAgg, TminAgg,
+// TmaxAgg, TsumAgg, TavgAgg, TcentroidAgg. Names follow MobilityDB RFC #827:
+// every SkipList aggregate is exposed under a Pascal-cased *Agg identifier,
+// disambiguating it from the same-stem scalar accessors (Tmin(tbox), etc.)
+// in case-folding catalogs like DuckDB. These differ from the fixed-state
+// `extent()` aggregates in two ways:
 //
 //   1. State holds a `SkipList *` pointer; the skiplist owns variable-size
 //      heap-allocated Temporal* values, so the aggregate needs a destructor.
@@ -257,21 +260,30 @@ static AggregateFunction MakeTaggAggregate(const LogicalType &input_type, const 
 } // namespace
 
 void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
-    // ---- tand / tor on tbool ----
+    // SkipList aggregates are registered under the Pascal-cased *Agg names
+    // proposed in MobilityDB RFC #827. These avoid the case-folding
+    // collision DuckDB's catalog hits when an aggregate and a scalar share
+    // a canonical lowercase name (e.g. previously `tmin` aggregate vs the
+    // existing `Tmin(tbox)` scalar). The MobilityDB upstream PR #828 adds
+    // the matching aliases on the PG side; the original aggregate names
+    // (`tand`, `tcount`, etc.) remain valid in PG for backward compat but
+    // collide in DuckDB and are intentionally not registered here.
+
+    // ---- TandAgg / TorAgg on tbool ----
     {
-        AggregateFunctionSet set("tand");
+        AggregateFunctionSet set("TandAgg");
         set.AddFunction(MakeTaggAggregate<TandFn>(TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
         loader.RegisterFunction(std::move(set));
     }
     {
-        AggregateFunctionSet set("tor");
+        AggregateFunctionSet set("TorAgg");
         set.AddFunction(MakeTaggAggregate<TorFn>(TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
         loader.RegisterFunction(std::move(set));
     }
 
-    // ---- tcount over each temporal type → tint ----
+    // ---- TcountAgg over each temporal type → tint ----
     {
-        AggregateFunctionSet set("tcount");
+        AggregateFunctionSet set("TcountAgg");
         for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
                               TemporalTypes::TFLOAT(), TemporalTypes::TTEXT()}) {
             set.AddFunction(MakeTaggAggregate<TcountTempFn>(t, TemporalTypes::TINT()));
@@ -280,38 +292,41 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(set));
     }
 
-    // ---- tmin / tmax — DEFERRED ----
-    //
-    // The MobilityDB SQL surface has two semantically-different functions
-    // sharing a case-insensitive name: scalar `Tmin(tbox|stbox) -> timestamptz`
-    // (already registered in tbox.cpp / stbox.cpp) and aggregate
-    // `tMin(tint|tfloat|ttext) -> Temporal`. PostgreSQL dispatches by the
-    // argument-types tuple, but DuckDB's catalog folds both onto a single
-    // canonical lowercase name `tmin` and rejects mixing scalar + aggregate
-    // overloads on the same name (catalog raises "GetAlterInfo not
-    // implemented for this type"). Resolving this requires either renaming
-    // the existing box scalars or registering the aggregate under a
-    // disambiguated name. Out of scope for this PR.
-
-    // ---- tsum on tint, tfloat ----
+    // ---- TminAgg / TmaxAgg on tint, tfloat, ttext ----
     {
-        AggregateFunctionSet set("tsum");
+        AggregateFunctionSet set("TminAgg");
+        set.AddFunction(MakeTaggAggregate<TminTintFn>(TemporalTypes::TINT(),    TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TminTfloatFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        set.AddFunction(MakeTaggAggregate<TminTtextFn>(TemporalTypes::TTEXT(),   TemporalTypes::TTEXT()));
+        loader.RegisterFunction(std::move(set));
+    }
+    {
+        AggregateFunctionSet set("TmaxAgg");
+        set.AddFunction(MakeTaggAggregate<TmaxTintFn>(TemporalTypes::TINT(),    TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TmaxTfloatFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        set.AddFunction(MakeTaggAggregate<TmaxTtextFn>(TemporalTypes::TTEXT(),   TemporalTypes::TTEXT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- TsumAgg on tint, tfloat ----
+    {
+        AggregateFunctionSet set("TsumAgg");
         set.AddFunction(MakeTaggAggregate<TsumTintFn>(TemporalTypes::TINT(),    TemporalTypes::TINT()));
         set.AddFunction(MakeTaggAggregate<TsumTfloatFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
         loader.RegisterFunction(std::move(set));
     }
 
-    // ---- tavg on tint, tfloat → tfloat ----
+    // ---- TavgAgg on tint, tfloat → tfloat ----
     {
-        AggregateFunctionSet set("tavg");
+        AggregateFunctionSet set("TavgAgg");
         set.AddFunction(MakeTaggAggregate<TavgFn>(TemporalTypes::TINT(),  TemporalTypes::TFLOAT()));
         set.AddFunction(MakeTaggAggregate<TavgFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
         loader.RegisterFunction(std::move(set));
     }
 
-    // ---- tcentroid on tgeompoint → tgeompoint ----
+    // ---- TcentroidAgg on tgeompoint → tgeompoint ----
     {
-        AggregateFunctionSet set("tcentroid");
+        AggregateFunctionSet set("TcentroidAgg");
         set.AddFunction(MakeTaggAggregate<TcentroidFn>(
             TgeompointType::TGEOMPOINT(), TgeompointType::TGEOMPOINT()));
         loader.RegisterFunction(std::move(set));

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -1,0 +1,321 @@
+// SkipList-state temporal aggregates: tcount, tand, tor, tmin, tmax, tsum,
+// tavg, tcentroid. These differ from the fixed-state `extent()` aggregates
+// in two ways:
+//
+//   1. State holds a `SkipList *` pointer; the skiplist owns variable-size
+//      heap-allocated Temporal* values, so the aggregate needs a destructor.
+//
+//   2. Combine merges two skiplists via MEOS's `temporal_tagg_combinefn`.
+//      That function is exported from libmeos but not declared in the
+//      installed public headers, so we forward-declare it here. Same goes
+//      for the `datum_*` per-aggregate merge functors.
+//
+// The MEOS combine semantics share Temporal* pointers between the two input
+// skiplists once both are non-empty: the returned skiplist holds the merged
+// elements while the "loser" skiplist still references the same pointers.
+// We can't call the standard `skiplist_free` on the loser without double-
+// freeing, so after combine we walk the loser's elements and NULL out their
+// keys/values before calling `skiplist_free` (which then only releases the
+// SkipList struct + freed[] array + elem array).
+
+#include "meos_wrapper_simple.hpp"
+
+#include "common.hpp"
+#include "temporal/temporal.hpp"
+#include "temporal/temporal_aggregates.hpp"
+#include "geo/tgeompoint.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+extern "C" {
+// Per-aggregate merge functions (exported from libmeos.a but not in the
+// public headers).
+Datum datum_and(Datum, Datum);
+Datum datum_or(Datum, Datum);
+Datum datum_min_int32(Datum, Datum);
+Datum datum_max_int32(Datum, Datum);
+Datum datum_sum_int32(Datum, Datum);
+Datum datum_min_float8(Datum, Datum);
+Datum datum_max_float8(Datum, Datum);
+Datum datum_sum_float8(Datum, Datum);
+Datum datum_min_text(Datum, Datum);
+Datum datum_max_text(Datum, Datum);
+Datum datum_sum_double2(Datum, Datum);
+Datum datum_sum_double3(Datum, Datum);
+Datum datum_sum_double4(Datum, Datum);
+
+// Forward-decl: same signature as in meos/include/temporal/temporal_aggfuncs.h.
+SkipList *temporal_tagg_combinefn(SkipList *state1, SkipList *state2,
+                                  datum_func2 func, bool crossings);
+}
+
+namespace {
+
+// Mirrors the elem-walk in MEOS skiplist_free, nulling out keys/values so
+// the subsequent skiplist_free only releases the structural memory.
+void NullSkiplistElements(SkipList *list) {
+    if (!list || !list->elems) return;
+    int cur = 0;
+    while (cur != -1) {
+        SkipListElem *elem = &list->elems[cur];
+        elem->key = nullptr;
+        elem->value = nullptr;
+        cur = elem->next[0];
+    }
+}
+
+void SafeFreeLoserSkiplist(SkipList *result, SkipList *a, SkipList *b) {
+    SkipList *loser = (result == a) ? b : a;
+    if (loser) {
+        NullSkiplistElements(loser);
+        skiplist_free(loser);
+    }
+}
+
+// Aggregate state — one pointer.
+struct SkipListState {
+    SkipList *skiplist;
+};
+
+// Generic SkipList aggregate over Temporal inputs.
+//
+//   TRANSFN     — MEOS transition function (state, blob_decoded_temporal).
+//   FINALFN     — MEOS finalize function (state -> Temporal *).
+//   MERGE_FN    — datum_func2 used by combinefn.
+//   CROSSINGS   — pass to combinefn (true for tfloat min/max).
+template <SkipList *(*TRANSFN)(SkipList *, const Temporal *),
+          Temporal *(*FINALFN)(SkipList *),
+          Datum (*MERGE_FN)(Datum, Datum),
+          bool CROSSINGS = false>
+struct TemporalSkipListAggFn {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.skiplist = nullptr;
+    }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        // Decode input blob to Temporal *. The MEOS transfn copies the
+        // value into the skiplist, so the transient blob memory is fine.
+        const Temporal *t = reinterpret_cast<const Temporal *>(input.GetData());
+        state.skiplist = TRANSFN(state.skiplist, t);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.skiplist) return;
+        if (!target.skiplist) {
+            target.skiplist = source.skiplist;
+            source.skiplist = nullptr;
+            return;
+        }
+        SkipList *result = temporal_tagg_combinefn(target.skiplist, source.skiplist,
+                                                   MERGE_FN, CROSSINGS);
+        SafeFreeLoserSkiplist(result, target.skiplist, source.skiplist);
+        target.skiplist = result;
+        source.skiplist = nullptr;
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.skiplist) {
+            fd.ReturnNull();
+            return;
+        }
+        Temporal *result = FINALFN(state.skiplist);
+        // MEOS finalfns release the skiplist themselves on the success
+        // path; on the empty-skiplist path they leave it intact and
+        // return NULL. Either way, we can no longer safely call
+        // skiplist_free on this pointer.
+        SkipList *raw = state.skiplist;
+        state.skiplist = nullptr;
+        if (!result) {
+            // Empty input → skiplist still allocated; release it now.
+            skiplist_free(raw);
+            fd.ReturnNull();
+            return;
+        }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+// Macro to declare a concrete aggregate type with a fixed return-type alias.
+#define DECLARE_TAGG(NAME, TRANSFN, FINALFN, MERGE_FN, CROSSINGS) \
+    using NAME = TemporalSkipListAggFn<TRANSFN, FINALFN, MERGE_FN, CROSSINGS>;
+
+DECLARE_TAGG(TandFn,         tbool_tand_transfn,        temporal_tagg_finalfn,  datum_and,           false)
+DECLARE_TAGG(TorFn,          tbool_tor_transfn,         temporal_tagg_finalfn,  datum_or,            false)
+DECLARE_TAGG(TcountTempFn,   temporal_tcount_transfn,   temporal_tagg_finalfn,  datum_sum_int32,     false)
+DECLARE_TAGG(TminTintFn,     tint_tmin_transfn,         temporal_tagg_finalfn,  datum_min_int32,     false)
+DECLARE_TAGG(TmaxTintFn,     tint_tmax_transfn,         temporal_tagg_finalfn,  datum_max_int32,     false)
+DECLARE_TAGG(TsumTintFn,     tint_tsum_transfn,         temporal_tagg_finalfn,  datum_sum_int32,     false)
+DECLARE_TAGG(TminTfloatFn,   tfloat_tmin_transfn,       temporal_tagg_finalfn,  datum_min_float8,    true)
+DECLARE_TAGG(TmaxTfloatFn,   tfloat_tmax_transfn,       temporal_tagg_finalfn,  datum_max_float8,    true)
+DECLARE_TAGG(TsumTfloatFn,   tfloat_tsum_transfn,       temporal_tagg_finalfn,  datum_sum_float8,    false)
+DECLARE_TAGG(TminTtextFn,    ttext_tmin_transfn,        temporal_tagg_finalfn,  datum_min_text,      false)
+DECLARE_TAGG(TmaxTtextFn,    ttext_tmax_transfn,        temporal_tagg_finalfn,  datum_max_text,      false)
+DECLARE_TAGG(TavgFn,         tnumber_tavg_transfn,      tnumber_tavg_finalfn,   datum_sum_double2,   false)
+
+// tcentroid: chooses sum_double3 (2D) vs sum_double4 (3D) based on input
+// dimension. We forward to the same templated functor via a runtime-chosen
+// merge func by branching at Combine time. To keep the templates simple we
+// use a small wrapper that overrides Combine.
+struct TcentroidFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.skiplist = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        // tpoint_tcentroid_transfn takes Temporal * (non-const), and copies.
+        Temporal *t = const_cast<Temporal *>(reinterpret_cast<const Temporal *>(input.GetData()));
+        state.skiplist = tpoint_tcentroid_transfn(state.skiplist, t);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.skiplist) return;
+        if (!target.skiplist) {
+            target.skiplist = source.skiplist;
+            source.skiplist = nullptr;
+            return;
+        }
+        // Choose merge functor based on dimensionality stored in the
+        // skiplist's `extra` (a GeoAggregateState). Bit 0 of the first
+        // byte after the SkipList header is `hasz` per MEOS layout.
+        // Falling back to double3 (2D) if extra is null.
+        datum_func2 func = &datum_sum_double3;
+        const auto *extra = (target.skiplist && target.skiplist->extra)
+                              ? target.skiplist->extra
+                              : (source.skiplist ? source.skiplist->extra : nullptr);
+        if (extra) {
+            // GeoAggregateState begins with `bool hasz;` — first byte.
+            if (*static_cast<const bool *>(extra)) {
+                func = &datum_sum_double4;
+            }
+        }
+        SkipList *result = temporal_tagg_combinefn(target.skiplist, source.skiplist, func, false);
+        SafeFreeLoserSkiplist(result, target.skiplist, source.skiplist);
+        target.skiplist = result;
+        source.skiplist = nullptr;
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.skiplist) { fd.ReturnNull(); return; }
+        Temporal *result = tpoint_tcentroid_finalfn(state.skiplist);
+        SkipList *raw = state.skiplist;
+        state.skiplist = nullptr;
+        if (!result) {
+            skiplist_free(raw);
+            fd.ReturnNull();
+            return;
+        }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+template <class OP>
+static AggregateFunction MakeTaggAggregate(const LogicalType &input_type, const LogicalType &return_type) {
+    return AggregateFunction::UnaryAggregateDestructor<
+        SkipListState, string_t, string_t, OP, AggregateDestructorType::LEGACY>(input_type, return_type);
+}
+
+} // namespace
+
+void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
+    // ---- tand / tor on tbool ----
+    {
+        AggregateFunctionSet set("tand");
+        set.AddFunction(MakeTaggAggregate<TandFn>(TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
+        loader.RegisterFunction(std::move(set));
+    }
+    {
+        AggregateFunctionSet set("tor");
+        set.AddFunction(MakeTaggAggregate<TorFn>(TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- tcount over each temporal type → tint ----
+    {
+        AggregateFunctionSet set("tcount");
+        for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
+                              TemporalTypes::TFLOAT(), TemporalTypes::TTEXT()}) {
+            set.AddFunction(MakeTaggAggregate<TcountTempFn>(t, TemporalTypes::TINT()));
+        }
+        set.AddFunction(MakeTaggAggregate<TcountTempFn>(TgeompointType::TGEOMPOINT(), TemporalTypes::TINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- tmin / tmax — DEFERRED ----
+    //
+    // The MobilityDB SQL surface has two semantically-different functions
+    // sharing a case-insensitive name: scalar `Tmin(tbox|stbox) -> timestamptz`
+    // (already registered in tbox.cpp / stbox.cpp) and aggregate
+    // `tMin(tint|tfloat|ttext) -> Temporal`. PostgreSQL dispatches by the
+    // argument-types tuple, but DuckDB's catalog folds both onto a single
+    // canonical lowercase name `tmin` and rejects mixing scalar + aggregate
+    // overloads on the same name (catalog raises "GetAlterInfo not
+    // implemented for this type"). Resolving this requires either renaming
+    // the existing box scalars or registering the aggregate under a
+    // disambiguated name. Out of scope for this PR.
+
+    // ---- tsum on tint, tfloat ----
+    {
+        AggregateFunctionSet set("tsum");
+        set.AddFunction(MakeTaggAggregate<TsumTintFn>(TemporalTypes::TINT(),    TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TsumTfloatFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- tavg on tint, tfloat → tfloat ----
+    {
+        AggregateFunctionSet set("tavg");
+        set.AddFunction(MakeTaggAggregate<TavgFn>(TemporalTypes::TINT(),  TemporalTypes::TFLOAT()));
+        set.AddFunction(MakeTaggAggregate<TavgFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- tcentroid on tgeompoint → tgeompoint ----
+    {
+        AggregateFunctionSet set("tcentroid");
+        set.AddFunction(MakeTaggAggregate<TcentroidFn>(
+            TgeompointType::TGEOMPOINT(), TgeompointType::TGEOMPOINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+}
+
+} // namespace duckdb

--- a/test/sql/parity/030_aggregates_extent.test
+++ b/test/sql/parity/030_aggregates_extent.test
@@ -1,0 +1,145 @@
+# name: test/sql/parity/030_aggregates_extent.test
+# description: extent() aggregate parity across span / set / spanset / scalar /
+#              tbox / stbox / temporal inputs.
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# extent(scalar)
+# =============================================================================
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (1::INTEGER),(5::INTEGER),(3::INTEGER)) t(v);
+----
+[1, 6)
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (1::BIGINT),(5::BIGINT),(3::BIGINT)) t(v);
+----
+[1, 6)
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (1.5::DOUBLE),(5.5::DOUBLE),(3.5::DOUBLE)) t(v);
+----
+[1.5, 5.5]
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (DATE '2001-01-01'),(DATE '2001-02-15'),(DATE '2001-01-15')) t(v);
+----
+[2001-01-01, 2001-02-16)
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (TIMESTAMPTZ '2001-01-01 00:00:00+00'),(TIMESTAMPTZ '2001-02-15 00:00:00+00')) t(v);
+----
+[2001-01-01 00:00:00+00, 2001-02-15 00:00:00+00]
+
+# =============================================================================
+# extent(span) — already covered by previous PR, verify still fine
+# =============================================================================
+
+query I
+SELECT extent(v::intspan)::VARCHAR FROM (VALUES ('[1,5)'), ('[3,8)')) t(v);
+----
+[1, 8)
+
+query I
+SELECT extent(v::floatspan)::VARCHAR FROM (VALUES ('[1.0,5.0]'), ('[3.0,8.0]')) t(v);
+----
+[1, 8]
+
+# =============================================================================
+# extent(set)
+# =============================================================================
+
+query I
+SELECT extent(v::intset)::VARCHAR FROM (VALUES ('{1,3,5}'), ('{2,4,7}')) t(v);
+----
+[1, 8)
+
+query I
+SELECT extent(v::tstzset)::VARCHAR FROM (VALUES
+  ('{2001-01-01, 2001-01-05}'), ('{2001-01-03, 2001-01-10}')) t(v);
+----
+[2001-01-01 00:00:00+00, 2001-01-10 00:00:00+00]
+
+# =============================================================================
+# extent(spanset)
+# =============================================================================
+
+query I
+SELECT extent(v::intspanset)::VARCHAR FROM (VALUES ('{[1,3),[5,7)}'), ('{[10,15)}')) t(v);
+----
+[1, 15)
+
+query I
+SELECT extent(v::tstzspanset)::VARCHAR FROM (VALUES
+  ('{[2001-01-01, 2001-01-03), [2001-01-05, 2001-01-07)}'),
+  ('{[2001-01-10, 2001-01-15)}')) t(v);
+----
+[2001-01-01 00:00:00+00, 2001-01-15 00:00:00+00)
+
+# =============================================================================
+# extent(tbox)
+# =============================================================================
+
+query I
+SELECT extent(v::tbox)::VARCHAR FROM (VALUES
+  ('TBOXINT XT([1, 5),[2000-01-01, 2000-01-05])'),
+  ('TBOXINT XT([3, 8),[2000-01-03, 2000-01-08])')) t(v);
+----
+TBOXINT XT([1, 8),[2000-01-01 00:00:00+00, 2000-01-08 00:00:00+00])
+
+# =============================================================================
+# extent(stbox)
+# =============================================================================
+
+query I
+SELECT extent(v::stbox)::VARCHAR FROM (VALUES
+  ('STBOX X((1,2),(3,4))'),
+  ('STBOX X((0,1),(5,6))')) t(v);
+----
+STBOX X((0,1),(5,6))
+
+# =============================================================================
+# extent(temporal)
+# =============================================================================
+
+query I
+SELECT extent(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+TBOXINT XT([1, 6),[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00])
+
+query I
+SELECT extent(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-05')) t(v);
+----
+TBOXFLOAT XT([1.5, 5.5],[2000-01-01 00:00:00+00, 2000-01-05 00:00:00+00])
+
+query I
+SELECT extent(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-05')) t(v);
+----
+[2000-01-01 00:00:00+00, 2000-01-05 00:00:00+00]
+
+query I
+SELECT extent(v::ttext)::VARCHAR FROM (VALUES ('"hi"@2000-01-01'),('"bye"@2000-01-05')) t(v);
+----
+[2000-01-01 00:00:00+00, 2000-01-05 00:00:00+00]
+
+query I
+SELECT extent(v::tgeompoint)::VARCHAR FROM (VALUES ('Point(1 2)@2000-01-01'),('Point(3 4)@2000-01-02')) t(v);
+----
+STBOX XT(((1,2),(3,4)),[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00])
+
+# =============================================================================
+# extent ignores NULLs
+# =============================================================================
+
+query I
+SELECT extent(v::INTEGER)::VARCHAR FROM (VALUES (1),(NULL),(5),(NULL),(3)) t(v);
+----
+[1, 6)
+
+query I
+SELECT extent(v::INTEGER)::VARCHAR FROM (VALUES (NULL::INTEGER)) t(v);
+----
+NULL

--- a/test/sql/parity/031_aggregates_skiplist.test
+++ b/test/sql/parity/031_aggregates_skiplist.test
@@ -1,0 +1,108 @@
+# name: test/sql/parity/031_aggregates_skiplist.test
+# description: SkipList-state temporal aggregates — tand, tor, tcount, tsum,
+#              tavg, tcentroid. tmin/tmax aggregate variants are deferred
+#              this PR (they collide with the existing scalar Tmin(tbox) /
+#              Tmax(tbox) functions under DuckDB's case-insensitive name
+#              resolution).
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# tand / tor on tbool
+# =============================================================================
+
+query I
+SELECT tand(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('true@2000-01-02')) t(v);
+----
+{t@2000-01-01 00:00:00+00, t@2000-01-02 00:00:00+00}
+
+query I
+SELECT tor(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
+----
+{t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00}
+
+# Single-row aggregate degenerates to identity over the input.
+query I
+SELECT tand(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01')) t(v);
+----
+{t@2000-01-01 00:00:00+00}
+
+# =============================================================================
+# tcount over each temporal type → tint
+# =============================================================================
+
+query I
+SELECT tcount(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
+
+query I
+SELECT tcount(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
+
+query I
+SELECT tcount(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
+
+query I
+SELECT tcount(v::ttext)::VARCHAR FROM (VALUES ('"hi"@2000-01-01'),('"bye"@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
+
+# =============================================================================
+# tsum on tint, tfloat
+# =============================================================================
+
+query I
+SELECT tsum(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 5@2000-01-02 00:00:00+00}
+
+query I
+SELECT tsum(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('2.5@2000-01-02')) t(v);
+----
+{1.5@2000-01-01 00:00:00+00, 2.5@2000-01-02 00:00:00+00}
+
+# =============================================================================
+# tavg on tint, tfloat → tfloat
+# =============================================================================
+
+query I
+SELECT tavg(v::tint)::VARCHAR FROM (VALUES ('2@2000-01-01'),('4@2000-01-02')) t(v);
+----
+{2@2000-01-01 00:00:00+00, 4@2000-01-02 00:00:00+00}
+
+query I
+SELECT tavg(v::tfloat)::VARCHAR FROM (VALUES ('2.0@2000-01-01'),('4.0@2000-01-02')) t(v);
+----
+{2@2000-01-01 00:00:00+00, 4@2000-01-02 00:00:00+00}
+
+# =============================================================================
+# tcentroid on tgeompoint
+#
+# Output is the EWKB-hex display format MobilityDuck uses for geometry, not
+# WKT — both points encode the input coordinates verbatim.
+# =============================================================================
+
+query I
+SELECT tcentroid(v::tgeompoint)::VARCHAR FROM (VALUES
+  ('Point(0 0)@2000-01-01'),('Point(2 4)@2000-01-02')) t(v);
+----
+{010100000000000000000000000000000000000000@2000-01-01 00:00:00+00, 010100000000000000000000400000000000001040@2000-01-02 00:00:00+00}
+
+# =============================================================================
+# Empty / NULL handling
+# =============================================================================
+
+query I
+SELECT tand(v::tbool)::VARCHAR FROM (VALUES (NULL::VARCHAR)) t(v) WHERE v IS NOT NULL;
+----
+NULL
+
+query I
+SELECT tcount(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),(NULL),('5@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}

--- a/test/sql/parity/031_aggregates_skiplist.test
+++ b/test/sql/parity/031_aggregates_skiplist.test
@@ -1,94 +1,118 @@
 # name: test/sql/parity/031_aggregates_skiplist.test
-# description: SkipList-state temporal aggregates — tand, tor, tcount, tsum,
-#              tavg, tcentroid. tmin/tmax aggregate variants are deferred
-#              this PR (they collide with the existing scalar Tmin(tbox) /
-#              Tmax(tbox) functions under DuckDB's case-insensitive name
-#              resolution).
+# description: SkipList-state temporal aggregates — TandAgg, TorAgg, TcountAgg,
+#              TminAgg, TmaxAgg, TsumAgg, TavgAgg, TcentroidAgg. Names follow
+#              MobilityDB RFC #827 — every SkipList aggregate is exposed
+#              under a Pascal-cased *Agg identifier. The MobilityDB upstream
+#              PR #828 adds the matching aliases on the PG side.
 # group: [sql]
 
 require mobilityduck
 
 # =============================================================================
-# tand / tor on tbool
+# TandAgg / TorAgg on tbool
 # =============================================================================
 
 query I
-SELECT tand(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('true@2000-01-02')) t(v);
+SELECT TandAgg(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('true@2000-01-02')) t(v);
 ----
 {t@2000-01-01 00:00:00+00, t@2000-01-02 00:00:00+00}
 
 query I
-SELECT tor(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
+SELECT TorAgg(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
 ----
 {t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00}
 
 # Single-row aggregate degenerates to identity over the input.
 query I
-SELECT tand(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01')) t(v);
+SELECT TandAgg(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01')) t(v);
 ----
 {t@2000-01-01 00:00:00+00}
 
 # =============================================================================
-# tcount over each temporal type → tint
+# TcountAgg over each temporal type → tint
 # =============================================================================
 
 query I
-SELECT tcount(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+SELECT TcountAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
 
 query I
-SELECT tcount(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
+SELECT TcountAgg(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
 
 query I
-SELECT tcount(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
+SELECT TcountAgg(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
 
 query I
-SELECT tcount(v::ttext)::VARCHAR FROM (VALUES ('"hi"@2000-01-01'),('"bye"@2000-01-02')) t(v);
+SELECT TcountAgg(v::ttext)::VARCHAR FROM (VALUES ('"hi"@2000-01-01'),('"bye"@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
 
 # =============================================================================
-# tsum on tint, tfloat
+# TminAgg / TmaxAgg on tint, tfloat, ttext
 # =============================================================================
 
 query I
-SELECT tsum(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+SELECT TminAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02'),('3@2000-01-03')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 5@2000-01-02 00:00:00+00, 3@2000-01-03 00:00:00+00}
+
+query I
+SELECT TmaxAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02'),('3@2000-01-03')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 5@2000-01-02 00:00:00+00, 3@2000-01-03 00:00:00+00}
+
+query I
+SELECT TminAgg(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
+----
+{1.5@2000-01-01 00:00:00+00, 5.5@2000-01-02 00:00:00+00}
+
+query I
+SELECT TmaxAgg(v::ttext)::VARCHAR FROM (VALUES ('"a"@2000-01-01'),('"z"@2000-01-02')) t(v);
+----
+{"a"@2000-01-01 00:00:00+00, "z"@2000-01-02 00:00:00+00}
+
+# =============================================================================
+# TsumAgg on tint, tfloat
+# =============================================================================
+
+query I
+SELECT TsumAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+00, 5@2000-01-02 00:00:00+00}
 
 query I
-SELECT tsum(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('2.5@2000-01-02')) t(v);
+SELECT TsumAgg(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('2.5@2000-01-02')) t(v);
 ----
 {1.5@2000-01-01 00:00:00+00, 2.5@2000-01-02 00:00:00+00}
 
 # =============================================================================
-# tavg on tint, tfloat → tfloat
+# TavgAgg on tint, tfloat → tfloat
 # =============================================================================
 
 query I
-SELECT tavg(v::tint)::VARCHAR FROM (VALUES ('2@2000-01-01'),('4@2000-01-02')) t(v);
+SELECT TavgAgg(v::tint)::VARCHAR FROM (VALUES ('2@2000-01-01'),('4@2000-01-02')) t(v);
 ----
 {2@2000-01-01 00:00:00+00, 4@2000-01-02 00:00:00+00}
 
 query I
-SELECT tavg(v::tfloat)::VARCHAR FROM (VALUES ('2.0@2000-01-01'),('4.0@2000-01-02')) t(v);
+SELECT TavgAgg(v::tfloat)::VARCHAR FROM (VALUES ('2.0@2000-01-01'),('4.0@2000-01-02')) t(v);
 ----
 {2@2000-01-01 00:00:00+00, 4@2000-01-02 00:00:00+00}
 
 # =============================================================================
-# tcentroid on tgeompoint
+# TcentroidAgg on tgeompoint
 #
 # Output is the EWKB-hex display format MobilityDuck uses for geometry, not
 # WKT — both points encode the input coordinates verbatim.
 # =============================================================================
 
 query I
-SELECT tcentroid(v::tgeompoint)::VARCHAR FROM (VALUES
+SELECT TcentroidAgg(v::tgeompoint)::VARCHAR FROM (VALUES
   ('Point(0 0)@2000-01-01'),('Point(2 4)@2000-01-02')) t(v);
 ----
 {010100000000000000000000000000000000000000@2000-01-01 00:00:00+00, 010100000000000000000000400000000000001040@2000-01-02 00:00:00+00}
@@ -98,11 +122,11 @@ SELECT tcentroid(v::tgeompoint)::VARCHAR FROM (VALUES
 # =============================================================================
 
 query I
-SELECT tand(v::tbool)::VARCHAR FROM (VALUES (NULL::VARCHAR)) t(v) WHERE v IS NOT NULL;
+SELECT TandAgg(v::tbool)::VARCHAR FROM (VALUES (NULL::VARCHAR)) t(v) WHERE v IS NOT NULL;
 ----
 NULL
 
 query I
-SELECT tcount(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),(NULL),('5@2000-01-02')) t(v);
+SELECT TcountAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),(NULL),('5@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}

--- a/test/sql/parity/031_aggregates_skiplist.test
+++ b/test/sql/parity/031_aggregates_skiplist.test
@@ -1,9 +1,11 @@
 # name: test/sql/parity/031_aggregates_skiplist.test
-# description: SkipList-state temporal aggregates — TandAgg, TorAgg, TcountAgg,
-#              TminAgg, TmaxAgg, TsumAgg, TavgAgg, TcentroidAgg. Names follow
-#              MobilityDB RFC #827 — every SkipList aggregate is exposed
-#              under a Pascal-cased *Agg identifier. The MobilityDB upstream
-#              PR #828 adds the matching aliases on the PG side.
+# description: SkipList-state aggregates — TandAgg, TorAgg, TcountAgg, TminAgg,
+#              TmaxAgg, TsumAgg, TavgAgg, TcentroidAgg, MergeAgg,
+#              AppendInstantAgg, AppendSequenceAgg, SpanUnionAgg, SetUnionAgg,
+#              and the window aggregates W{min,max,sum,count,avg}Agg. Names
+#              follow MobilityDB RFC #827 — every SkipList aggregate is
+#              exposed under a Pascal-cased *Agg identifier. The MobilityDB
+#              upstream PR #828 adds the matching aliases on the PG side.
 # group: [sql]
 
 require mobilityduck
@@ -116,6 +118,114 @@ SELECT TcentroidAgg(v::tgeompoint)::VARCHAR FROM (VALUES
   ('Point(0 0)@2000-01-01'),('Point(2 4)@2000-01-02')) t(v);
 ----
 {010100000000000000000000000000000000000000@2000-01-01 00:00:00+00, 010100000000000000000000400000000000001040@2000-01-02 00:00:00+00}
+
+# =============================================================================
+# TcountAgg over time-only inputs (timestamptz / tstzset / tstzspan / tstzspanset)
+# =============================================================================
+
+query I
+SELECT TcountAgg(t::timestamptz)::VARCHAR FROM (VALUES
+  ('2000-01-01 00:00:00+00'::timestamptz), ('2000-01-02 00:00:00+00')) t(t);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
+
+query I
+SELECT TcountAgg(s::tstzset)::VARCHAR FROM (VALUES
+  ('{2000-01-01, 2000-01-02}'::tstzset), ('{2000-01-02, 2000-01-03}')) t(s);
+----
+{1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00, 1@2000-01-03 00:00:00+00}
+
+query I
+SELECT TcountAgg(s::tstzspan)::VARCHAR FROM (VALUES
+  ('[2000-01-01, 2000-01-03)'::tstzspan), ('[2000-01-02, 2000-01-04)')) t(s);
+----
+{[1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00, 1@2000-01-03 00:00:00+00, 1@2000-01-04 00:00:00+00)}
+
+query I
+SELECT TcountAgg(s::tstzspanset)::VARCHAR FROM (VALUES
+  ('{[2000-01-01, 2000-01-03)}'::tstzspanset), ('{[2000-01-02, 2000-01-04)}')) t(s);
+----
+{[1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00, 1@2000-01-03 00:00:00+00, 1@2000-01-04 00:00:00+00)}
+
+# =============================================================================
+# MergeAgg / AppendInstantAgg / AppendSequenceAgg
+# =============================================================================
+
+query I
+SELECT MergeAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 5@2000-01-02 00:00:00+00}
+
+query I
+SELECT AppendInstantAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+[1@2000-01-01 00:00:00+00, 5@2000-01-02 00:00:00+00]
+
+query I
+SELECT AppendSequenceAgg(v::tint)::VARCHAR FROM (VALUES
+  ('[1@2000-01-01, 2@2000-01-02]'::tint),
+  ('[5@2000-01-04, 6@2000-01-05]')) t(v);
+----
+{[1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00], [5@2000-01-04 00:00:00+00, 6@2000-01-05 00:00:00+00]}
+
+# =============================================================================
+# SpanUnionAgg / SetUnionAgg
+# =============================================================================
+
+query I
+SELECT SpanUnionAgg(s::intspan)::VARCHAR FROM (VALUES ('[1, 5)'), ('[3, 8)')) t(s);
+----
+{[1, 8)}
+
+query I
+SELECT SpanUnionAgg(s::intspanset)::VARCHAR FROM (VALUES
+  ('{[1, 3), [5, 7)}'), ('{[10, 15)}')) t(s);
+----
+{[1, 3), [5, 7), [10, 15)}
+
+query I
+SELECT SetUnionAgg(v::int)::VARCHAR FROM (VALUES (1), (3), (5), (3)) t(v);
+----
+{1, 3, 5}
+
+query I
+SELECT SetUnionAgg(v::intset)::VARCHAR FROM (VALUES ('{1, 3}'::intset), ('{2, 4}')) t(v);
+----
+{1, 2, 3, 4}
+
+query I
+SELECT SetUnionAgg(d::date)::VARCHAR FROM (VALUES ('2001-01-01'::date), ('2001-01-03')) t(d);
+----
+{2001-01-01, 2001-01-03}
+
+# =============================================================================
+# Window aggregates: WminAgg / WmaxAgg / WsumAgg / WcountAgg / WavgAgg
+# =============================================================================
+
+query I
+SELECT WminAgg(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02'),('3@2000-01-04')) t(v);
+----
+{[1@2000-01-01 00:00:00+00, 1@2000-01-03 00:00:00+00], (5@2000-01-03 00:00:00+00, 3@2000-01-04 00:00:00+00, 3@2000-01-06 00:00:00+00]}
+
+query I
+SELECT WmaxAgg(v::tfloat, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
+----
+{[1.5@2000-01-01 00:00:00+00, 1.5@2000-01-02 00:00:00+00), [5.5@2000-01-02 00:00:00+00, 5.5@2000-01-04 00:00:00+00]}
+
+query I
+SELECT WsumAgg(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+{[1@2000-01-01 00:00:00+00, 6@2000-01-02 00:00:00+00, 6@2000-01-03 00:00:00+00], (5@2000-01-03 00:00:00+00, 5@2000-01-04 00:00:00+00]}
+
+query I
+SELECT WcountAgg(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+{[1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00, 2@2000-01-03 00:00:00+00], (1@2000-01-03 00:00:00+00, 1@2000-01-04 00:00:00+00]}
+
+query I
+SELECT WavgAgg(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('2@2000-01-01'),('4@2000-01-02')) t(v);
+----
+Interp=Step;{[2@2000-01-01 00:00:00+00, 3@2000-01-02 00:00:00+00, 3@2000-01-03 00:00:00+00], (4@2000-01-03 00:00:00+00, 4@2000-01-04 00:00:00+00]}
 
 # =============================================================================
 # Empty / NULL handling


### PR DESCRIPTION
## Summary

Builds the harness for MEOS SkipList-state temporal aggregates and ships seven of them.

| Aggregate | Inputs | Output |
|---|---|---|
| `tand`, `tor` | `tbool` | `tbool` |
| `tcount` | `tbool`, `tint`, `tfloat`, `ttext`, `tgeompoint` | `tint` |
| `tsum` | `tint`, `tfloat` | same as input |
| `tavg` | `tint`, `tfloat` | `tfloat` |
| `tcentroid` | `tgeompoint` | `tgeompoint` |

## How the harness works

SkipList aggregates differ from the previously-shipped fixed-state `extent()` family in two ways:

1. **State holds a `SkipList *` pointer.** The skiplist owns variable-size heap-allocated `Temporal *` values, so the aggregate needs a destructor — registered via `UnaryAggregateDestructor` with `AggregateDestructorType::LEGACY`.

2. **Combine merges via `temporal_tagg_combinefn`.** That function is exported from `libmeos.a` but **not declared in the public MEOS headers**, so we forward-declare it here alongside the per-aggregate `datum_*` merge functors.

The MEOS combine semantics share `Temporal *` pointers between the two input skiplists when both are non-empty: the returned skiplist owns the merged elements while the "loser" skiplist still references the same pointers. To avoid a double-free I walk the loser's elements and NULL out their `key`/`value` fields before calling `skiplist_free` — which then only releases the structural memory.

## Deferred

- **`tmin` / `tmax` aggregates.** Collide with the existing scalar `Tmin(tbox|stbox) → timestamptz` / `Tmax(tbox|stbox) → timestamptz` registrations under DuckDB's case-insensitive name resolution. DuckDB rejects mixing scalar+aggregate overloads on the same canonical name (raises `Not implemented Error: GetAlterInfo not implemented for this type` at LOAD time). Resolving needs either renaming the four box scalars (e.g. `boxTmin`/`boxTmax`) or suffixing the aggregates (e.g. `tMin_agg`) — out of scope for this PR.
- **`merge`, `appendInstant`, `appendSequence`** — same harness pattern, just different transfn names; can ship next.
- **`spanUnion`, `setUnion`** — need a different state shape (span/set skiplist instead of temporal).
- **Window aggregates** (`wmin`, `wmax`, `wsum`, `wcount`, `wavg`) — need an extra `interval` argument.
- **`tcentroid` 3D dispatch** — currently always uses `datum_sum_double3` (2D). Will need a runtime check on the `STBox` flags for 3D inputs.
- **`tcount` over scalar `timestamptz` / `tstzset` / `tstzspan` / `tstzspanset`** — uses `timestamptz_tcount_transfn` and friends; different signature.

## Test plan

- [x] `test/sql/parity/031_aggregates_skiplist.test` — 14 assertions, one per registered aggregate plus NULL / empty handling.
- [x] No regression in the existing `030_aggregates_extent.test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)