### PR TITLE
feat(bindings): tgeometry parity — full cross-type surface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ set(EXTENSION_SOURCES
     src/temporal/spanset_functions.cpp
     src/geo/tgeometry.cpp
     src/geo/tgeometry_in_out.cpp
+    src/geo/tgeometry_ops.cpp
     src/index/rtree_module.cpp
     src/index/rtree_index_create_physical.cpp
     src/index/rtree_index_scan.cpp

--- a/src/geo/tgeometry.cpp
+++ b/src/geo/tgeometry.cpp
@@ -1,9 +1,15 @@
 #include "geo/tgeometry.hpp"
+#include "geo/tgeompoint_functions.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/common/extension_type_info.hpp"
 #include <regex>
 #include <string>
 #include <temporal/span.hpp>
+#include "temporal/spanset.hpp"
+#include "temporal/set.hpp"
+#include "temporal/temporal_functions.hpp"
+#include "geo/stbox.hpp"
+#include "geo/geoset.hpp"
 #include<time_util.hpp>
 #include "geo_util.hpp"
 #include "spatial/spatial_types.hpp"
@@ -1255,11 +1261,233 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     auto tgeometry_gettimestamptz_function = ScalarFunction(
         "getTimestamp",
         {TGeometryTypes::TGEOMETRY()},
-        LogicalType::TIMESTAMP_TZ,  
+        LogicalType::TIMESTAMP_TZ,
         Tinstant_timestamptz);
     loader.RegisterFunction( tgeometry_gettimestamptz_function);
-    
 
+    // ===================================================================
+    // Foundational tgeometry surface — accessors, time/value-restrict,
+    // modifiers, and comparison. The MEOS C functions delegated to here
+    // are subtype-agnostic (they take Temporal *), so we reuse the same
+    // generic handlers wired for tgeompoint in temporal_functions.cpp.
+    // ===================================================================
+
+    const LogicalType TGEOM = TGeometryTypes::TGEOMETRY();
+    const LogicalType GEOM  = GeoTypes::GEOMETRY();
+    const LogicalType TSTZ  = LogicalType::TIMESTAMP_TZ;
+    const LogicalType IVAL  = LogicalType::INTERVAL;
+    const LogicalType BIGI  = LogicalType::BIGINT;
+
+    // ---- Accessors ----
+    loader.RegisterFunction(ScalarFunction(
+        "valueSet", {TGEOM}, SpatialSetType::geomset(),
+        TemporalFunctions::Temporal_valueset));
+    loader.RegisterFunction(ScalarFunction(
+        "valueN", {TGEOM, BIGI}, GEOM,
+        TemporalFunctions::Temporal_value_n));
+    loader.RegisterFunction(ScalarFunction(
+        "valueAtTimestamp", {TGEOM, TSTZ}, GEOM,
+        TemporalFunctions::Temporal_value_at_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "getTime", {TGEOM}, SpansetTypes::tstzspanset(),
+        TemporalFunctions::Temporal_time));
+    loader.RegisterFunction(ScalarFunction(
+        "duration", {TGEOM}, IVAL,
+        TemporalFunctions::Temporal_duration));
+    loader.RegisterFunction(ScalarFunction(
+        "duration", {TGEOM, LogicalType::BOOLEAN}, IVAL,
+        TemporalFunctions::Temporal_duration));
+    loader.RegisterFunction(ScalarFunction(
+        "lowerInc", {TGEOM}, LogicalType::BOOLEAN,
+        TemporalFunctions::Temporal_lower_inc));
+    loader.RegisterFunction(ScalarFunction(
+        "upperInc", {TGEOM}, LogicalType::BOOLEAN,
+        TemporalFunctions::Temporal_upper_inc));
+    loader.RegisterFunction(ScalarFunction(
+        "numInstants", {TGEOM}, LogicalType::INTEGER,
+        TemporalFunctions::Temporal_num_instants));
+    loader.RegisterFunction(ScalarFunction(
+        "instants", {TGEOM}, LogicalType::LIST(TGEOM),
+        TemporalFunctions::Temporal_instants));
+    loader.RegisterFunction(ScalarFunction(
+        "numSequences", {TGEOM}, LogicalType::INTEGER,
+        TemporalFunctions::Temporal_num_sequences));
+    loader.RegisterFunction(ScalarFunction(
+        "sequences", {TGEOM}, LogicalType::LIST(TGEOM),
+        TemporalFunctions::Temporal_sequences));
+    loader.RegisterFunction(ScalarFunction(
+        "startSequence", {TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_start_sequence));
+    loader.RegisterFunction(ScalarFunction(
+        "endSequence", {TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_end_sequence));
+    loader.RegisterFunction(ScalarFunction(
+        "sequenceN", {TGEOM, LogicalType::INTEGER}, TGEOM,
+        TemporalFunctions::Temporal_sequence_n));
+    loader.RegisterFunction(ScalarFunction(
+        "numTimestamps", {TGEOM}, LogicalType::INTEGER,
+        TemporalFunctions::Temporal_num_timestamps));
+    loader.RegisterFunction(ScalarFunction(
+        "timestamps", {TGEOM}, LogicalType::LIST(TSTZ),
+        TemporalFunctions::Temporal_timestamps));
+    loader.RegisterFunction(ScalarFunction(
+        "startTimestamp", {TGEOM}, TSTZ,
+        TemporalFunctions::Temporal_start_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "endTimestamp", {TGEOM}, TSTZ,
+        TemporalFunctions::Temporal_end_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "timestampN", {TGEOM, LogicalType::INTEGER}, TSTZ,
+        TemporalFunctions::Temporal_timestamptz_n));
+    loader.RegisterFunction(ScalarFunction(
+        "segments", {TGEOM}, LogicalType::LIST(TGEOM),
+        TemporalFunctions::Temporal_segments));
+
+    // ---- Time-domain restrict / minus ----
+    for (const auto &t : std::vector<std::pair<LogicalType, scalar_function_t>>{
+             {TSTZ,                       TemporalFunctions::Temporal_at_timestamptz},
+             {SetTypes::tstzset(),        TemporalFunctions::Temporal_at_tstzset},
+             {SpanTypes::TSTZSPAN(),      TemporalFunctions::Temporal_at_tstzspan},
+             {SpansetTypes::tstzspanset(), TemporalFunctions::Temporal_at_tstzspanset}}) {
+        loader.RegisterFunction(ScalarFunction(
+            "atTime", {TGEOM, t.first}, TGEOM, t.second));
+    }
+    for (const auto &t : std::vector<std::pair<LogicalType, scalar_function_t>>{
+             {TSTZ,                       TemporalFunctions::Temporal_minus_timestamptz},
+             {SetTypes::tstzset(),        TemporalFunctions::Temporal_minus_tstzset},
+             {SpanTypes::TSTZSPAN(),      TemporalFunctions::Temporal_minus_tstzspan},
+             {SpansetTypes::tstzspanset(), TemporalFunctions::Temporal_minus_tstzspanset}}) {
+        loader.RegisterFunction(ScalarFunction(
+            "minusTime", {TGEOM, t.first}, TGEOM, t.second));
+    }
+
+    // beforeTimestamp / afterTimestamp accept timestamptz and tstzspan
+    loader.RegisterFunction(ScalarFunction(
+        "beforeTimestamp", {TGEOM, TSTZ}, TGEOM,
+        TemporalFunctions::Temporal_before_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "afterTimestamp", {TGEOM, TSTZ}, TGEOM,
+        TemporalFunctions::Temporal_after_timestamptz));
+
+    // ---- Value restrict ----
+    // atValues / minusValues over a single geometry funnel through
+    // tgeompoint-side handlers (subtype-agnostic — they call MEOS's
+    // tgeo_at_geom etc. under the hood) and over a geomset go through
+    // the temporal-functions multi-value handlers.
+    loader.RegisterFunction(ScalarFunction(
+        "atValues", {TGEOM, GEOM}, TGEOM,
+        TgeompointFunctions::Tgeompoint_at_value));
+    loader.RegisterFunction(ScalarFunction(
+        "atValues", {TGEOM, SpatialSetType::geomset()}, TGEOM,
+        TemporalFunctions::Temporal_at_values));
+    loader.RegisterFunction(ScalarFunction(
+        "minusValues", {TGEOM, GEOM}, TGEOM,
+        TemporalFunctions::Temporal_minus_value));
+    loader.RegisterFunction(ScalarFunction(
+        "minusValues", {TGEOM, SpatialSetType::geomset()}, TGEOM,
+        TemporalFunctions::Temporal_minus_value));
+
+    // ---- Spatial restrict (atGeometry / minusGeometry / atStbox / minusStbox)
+    // Reuse tgeompoint's Tgeo_* handlers — they operate on Temporal * and
+    // delegate to the subtype-agnostic MEOS `tgeo_at_geom` etc.
+    loader.RegisterFunction(ScalarFunction(
+        "atGeometry", {TGEOM, GEOM}, TGEOM,
+        TgeompointFunctions::Tgeo_at_geom));
+    loader.RegisterFunction(ScalarFunction(
+        "minusGeometry", {TGEOM, GEOM}, TGEOM,
+        TgeompointFunctions::Tgeo_minus_geom));
+    loader.RegisterFunction(ScalarFunction(
+        "minusStbox", {TGEOM, StboxType::STBOX()}, TGEOM,
+        TgeompointFunctions::Tgeo_minus_stbox));
+
+    // ---- Modifiers (shift / scale / shiftScale / append / insert / update /
+    // delete / round) ----
+    loader.RegisterFunction(ScalarFunction(
+        "shiftTime", {TGEOM, IVAL}, TGEOM,
+        TemporalFunctions::Temporal_shift_time));
+    loader.RegisterFunction(ScalarFunction(
+        "scaleTime", {TGEOM, IVAL}, TGEOM,
+        TemporalFunctions::Temporal_scale_time));
+    loader.RegisterFunction(ScalarFunction(
+        "shiftScaleTime", {TGEOM, IVAL, IVAL}, TGEOM,
+        TemporalFunctions::Temporal_shift_scale_time));
+    loader.RegisterFunction(ScalarFunction(
+        "appendInstant", {TGEOM, TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_append_tinstant));
+    loader.RegisterFunction(ScalarFunction(
+        "appendSequence", {TGEOM, TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_append_tsequence));
+    loader.RegisterFunction(ScalarFunction(
+        "insert", {TGEOM, TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_insert));
+    loader.RegisterFunction(ScalarFunction(
+        "insert", {TGEOM, TGEOM, LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_insert));
+    loader.RegisterFunction(ScalarFunction(
+        "update", {TGEOM, TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_update));
+    loader.RegisterFunction(ScalarFunction(
+        "update", {TGEOM, TGEOM, LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_update));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, TSTZ}, TGEOM,
+        TemporalFunctions::Temporal_delete_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, TSTZ, LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_delete_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SetTypes::tstzset()}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzset));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SetTypes::tstzset(), LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzset));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SpanTypes::TSTZSPAN()}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzspan));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SpanTypes::TSTZSPAN(), LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzspan));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SpansetTypes::tstzspanset()}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzspanset));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SpansetTypes::tstzspanset(), LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzspanset));
+
+    // ---- Comparison (named functions + operators) ----
+    struct CmpEntry {
+        const char *name;
+        scalar_function_t fn;
+    };
+    const std::vector<CmpEntry> named_cmps = {
+        {"temporal_eq", TemporalFunctions::Temporal_eq},
+        {"temporal_ne", TemporalFunctions::Temporal_ne},
+        {"temporal_lt", TemporalFunctions::Temporal_lt},
+        {"temporal_le", TemporalFunctions::Temporal_le},
+        {"temporal_gt", TemporalFunctions::Temporal_gt},
+        {"temporal_ge", TemporalFunctions::Temporal_ge},
+    };
+    for (const auto &c : named_cmps) {
+        loader.RegisterFunction(ScalarFunction(
+            c.name, {TGEOM, TGEOM}, LogicalType::BOOLEAN, c.fn));
+    }
+    loader.RegisterFunction(ScalarFunction(
+        "temporal_cmp", {TGEOM, TGEOM}, LogicalType::INTEGER,
+        TemporalFunctions::Temporal_cmp));
+
+    // Operator forms — mirror the registrations tgeompoint.cpp does.
+    const std::vector<CmpEntry> op_cmps = {
+        {"=",  TemporalFunctions::Temporal_eq},
+        {"<>", TemporalFunctions::Temporal_ne},
+        {"<",  TemporalFunctions::Temporal_lt},
+        {"<=", TemporalFunctions::Temporal_le},
+        {">",  TemporalFunctions::Temporal_gt},
+        {">=", TemporalFunctions::Temporal_ge},
+    };
+    for (const auto &c : op_cmps) {
+        loader.RegisterFunction(ScalarFunction(
+            c.name, {TGEOM, TGEOM}, LogicalType::BOOLEAN, c.fn));
+    }
 }
 
 void TGeometryTypes::RegisterTypes(ExtensionLoader &loader) {

--- a/src/geo/tgeometry_ops.cpp
+++ b/src/geo/tgeometry_ops.cpp
@@ -7,6 +7,7 @@
 #include "common.hpp"
 #include "geo/tgeometry.hpp"
 #include "geo/tgeometry_ops.hpp"
+#include "geo/tgeompoint.hpp"
 #include "geo/stbox.hpp"
 #include "temporal/span.hpp"
 #include "temporal/temporal.hpp"
@@ -371,6 +372,146 @@ void TgeoTgeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
         });
 }
 
+// ====================================================================
+// Spatial functions — SRID accessor, setSRID, transform, expand*,
+// round, traversedArea, centroid, convexHull, and the
+// tgeometry <-> tgeompoint coercions.
+// ====================================================================
+
+inline string_t StboxToBlob(Vector &result, STBox *box) {
+    string_t out = StringVector::AddStringOrBlob(
+        result, reinterpret_cast<const char *>(box), sizeof(STBox));
+    free(box);
+    return out;
+}
+
+inline string_t GeoToBlobAsHex(Vector &result, GSERIALIZED *gs) {
+    if (!gs) return string_t();
+    size_t sz = 0;
+    uint8_t *ewkb = geo_as_ewkb(gs, NULL, &sz);
+    string_t out = StringVector::AddStringOrBlob(
+        result, reinterpret_cast<const char *>(ewkb), sz);
+    free(ewkb);
+    free(gs);
+    return out;
+}
+
+void TspatialSridExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, int32_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) {
+            Temporal *t = DecodeTemporalCopy(blob);
+            int32_t srid = tspatial_srid(t);
+            free(t);
+            return srid;
+        });
+}
+
+void TspatialSetSridExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::Execute<string_t, int32_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, int32_t srid) {
+            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *r = tspatial_set_srid(t, srid);
+            free(t);
+            if (!r) throw InvalidInputException("setSRID failed");
+            return TemporalToBlob(result, r);
+        });
+}
+
+void TspatialTransformExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::Execute<string_t, int32_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, int32_t srid) {
+            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *r = tspatial_transform(t, srid);
+            free(t);
+            if (!r) throw InvalidInputException("transform failed");
+            return TemporalToBlob(result, r);
+        });
+}
+
+void TspatialToStboxExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) {
+            Temporal *t = DecodeTemporalCopy(blob);
+            STBox *box = tspatial_to_stbox(t);
+            free(t);
+            return StboxToBlob(result, box);
+        });
+}
+
+void TgeometryToTgeompointExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) {
+            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *r = tgeometry_to_tgeompoint(t);
+            free(t);
+            if (!r) throw InvalidInputException("tgeompoint(tgeometry) failed");
+            return TemporalToBlob(result, r);
+        });
+}
+
+void TgeompointToTgeometryExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) {
+            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *r = tgeompoint_to_tgeometry(t);
+            free(t);
+            if (!r) throw InvalidInputException("tgeometry(tgeompoint) failed");
+            return TemporalToBlob(result, r);
+        });
+}
+
+void TgeoCentroidExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) -> string_t {
+            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *r = tgeo_centroid(t);
+            free(t);
+            if (!r) throw InvalidInputException("centroid failed");
+            return TemporalToBlob(result, r);
+        });
+}
+
+void TgeoConvexHullExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) -> string_t {
+            Temporal *t = DecodeTemporalCopy(blob);
+            GSERIALIZED *gs = tgeo_convex_hull(t);
+            free(t);
+            return GeoToBlobAsHex(result, gs);
+        });
+}
+
+void TgeoTraversedAreaExec(DataChunk &args, ExpressionState &, Vector &result) {
+    const idx_t cnt = args.size();
+    if (args.ColumnCount() >= 2) {
+        BinaryExecutor::Execute<string_t, bool, string_t>(
+            args.data[0], args.data[1], result, cnt,
+            [&](string_t blob, bool unary_union) -> string_t {
+                Temporal *t = DecodeTemporalCopy(blob);
+                GSERIALIZED *gs = tgeo_traversed_area(t, unary_union);
+                free(t);
+                return GeoToBlobAsHex(result, gs);
+            });
+    } else {
+        UnaryExecutor::Execute<string_t, string_t>(
+            args.data[0], result, cnt,
+            [&](string_t blob) -> string_t {
+                Temporal *t = DecodeTemporalCopy(blob);
+                GSERIALIZED *gs = tgeo_traversed_area(t, false);
+                free(t);
+                return GeoToBlobAsHex(result, gs);
+            });
+    }
+}
+
 } // namespace
 
 void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
@@ -606,6 +747,44 @@ void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
         {TGEOM, GEOM}, TFLOAT, TgeoGeoDistanceExec<tdistance_tgeo_geo>));
     loader.RegisterFunction(ScalarFunction("<->",
         {TGEOM, TGEOM}, TFLOAT, TgeoTgeoDistanceExec<tdistance_tgeo_tgeo>));
+
+    // -----------------------------------------------------------------
+    // Spatial functions: SRID accessor / setter, projection / transform,
+    // stbox cast, tgeometry <-> tgeompoint coercions, round, centroid,
+    // convexHull, traversedArea.
+    // -----------------------------------------------------------------
+    const LogicalType INT32 = LogicalType::INTEGER;
+
+    loader.RegisterFunction(ScalarFunction(
+        "SRID", {TGEOM}, INT32, TspatialSridExec));
+    loader.RegisterFunction(ScalarFunction(
+        "setSRID", {TGEOM, INT32}, TGEOM, TspatialSetSridExec));
+    loader.RegisterFunction(ScalarFunction(
+        "transform", {TGEOM, INT32}, TGEOM, TspatialTransformExec));
+
+    // tgeometry → stbox is a cast in the SQL surface; expose it as a
+    // function for now to keep the implementation a single template.
+    loader.RegisterFunction(ScalarFunction(
+        "stbox", {TGEOM}, STBOX, TspatialToStboxExec));
+
+    // tgeometry <-> tgeompoint coercion functions.
+    loader.RegisterFunction(ScalarFunction(
+        "tgeompoint", {TGEOM}, TgeompointType::TGEOMPOINT(),
+        TgeometryToTgeompointExec));
+    loader.RegisterFunction(ScalarFunction(
+        "tgeometry", {TgeompointType::TGEOMPOINT()}, TGEOM,
+        TgeompointToTgeometryExec));
+
+    // Centroid / convexHull / traversedArea — produce a non-temporal
+    // geometry summary of the trajectory.
+    loader.RegisterFunction(ScalarFunction(
+        "centroid", {TGEOM}, TGEOM, TgeoCentroidExec));
+    loader.RegisterFunction(ScalarFunction(
+        "convexHull", {TGEOM}, GEOM, TgeoConvexHullExec));
+    loader.RegisterFunction(ScalarFunction(
+        "traversedArea", {TGEOM}, GEOM, TgeoTraversedAreaExec));
+    loader.RegisterFunction(ScalarFunction(
+        "traversedArea", {TGEOM, LogicalType::BOOLEAN}, GEOM, TgeoTraversedAreaExec));
 }
 
 } // namespace duckdb

--- a/src/geo/tgeometry_ops.cpp
+++ b/src/geo/tgeometry_ops.cpp
@@ -1,0 +1,611 @@
+// Cross-type predicate registrations for tgeometry. The MEOS C functions
+// dispatched here all take Temporal * (subtype-agnostic), so this file is
+// purely registration-and-glue; the heavy lifting stays in libmeos.
+
+#include "meos_wrapper_simple.hpp"
+
+#include "common.hpp"
+#include "geo/tgeometry.hpp"
+#include "geo/tgeometry_ops.hpp"
+#include "geo/stbox.hpp"
+#include "temporal/span.hpp"
+#include "temporal/temporal.hpp"
+#include "geo_util.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "spatial/spatial_types.hpp"
+
+extern "C" {
+    #include <meos.h>
+    #include <meos_geo.h>
+    #include <meos_internal.h>
+    #include <meos_internal_geo.h>
+}
+
+namespace duckdb {
+
+namespace {
+
+// ====================================================================
+// Argument-decoding helpers
+// ====================================================================
+
+inline Temporal *DecodeTemporalCopy(string_t blob) {
+    size_t sz = blob.GetSize();
+    Temporal *t = (Temporal *) malloc(sz);
+    memcpy(t, blob.GetData(), sz);
+    return t;
+}
+
+inline STBox *DecodeStboxCopy(string_t blob) {
+    STBox *b = (STBox *) malloc(sizeof(STBox));
+    memcpy(b, blob.GetData(), sizeof(STBox));
+    return b;
+}
+
+inline Span *DecodeSpanCopy(string_t blob) {
+    Span *s = (Span *) malloc(sizeof(Span));
+    memcpy(s, blob.GetData(), sizeof(Span));
+    return s;
+}
+
+// ====================================================================
+// Bool-returning binary BLOB×BLOB executors (boxops + posops)
+// ====================================================================
+
+template <bool (*FN)(const Temporal *, const STBox *)>
+void TspatialStboxBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t b_blob) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            STBox *b = DecodeStboxCopy(b_blob);
+            bool r = FN(t, b);
+            free(t); free(b);
+            return r;
+        });
+}
+
+template <bool (*FN)(const Temporal *, const STBox *)>
+void StboxTspatialBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
+    // The MEOS function takes (Temporal, STBox); for the (STBox, Temporal)
+    // SQL signature we just swap argument order — these predicates are
+    // commutative for box-only checks (overlaps, same, adjacent) and the
+    // non-commutative pairs (contains/contained) are already defined as a
+    // distinct MEOS pair.
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t b_blob, string_t t_blob) {
+            STBox *b = DecodeStboxCopy(b_blob);
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            bool r = FN(t, b);
+            free(t); free(b);
+            return r;
+        });
+}
+
+template <bool (*FN)(const Temporal *, const Temporal *)>
+void TspatialTspatialBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a, string_t b) {
+            Temporal *t1 = DecodeTemporalCopy(a);
+            Temporal *t2 = DecodeTemporalCopy(b);
+            bool r = FN(t1, t2);
+            free(t1); free(t2);
+            return r;
+        });
+}
+
+template <bool (*FN)(const Temporal *, const Span *)>
+void TemporalTstzspanBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t s_blob) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            Span *s = DecodeSpanCopy(s_blob);
+            bool r = FN(t, s);
+            free(t); free(s);
+            return r;
+        });
+}
+
+template <bool (*FN)(const Span *, const Temporal *)>
+void TstzspanTemporalBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t s_blob, string_t t_blob) {
+            Span *s = DecodeSpanCopy(s_blob);
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            bool r = FN(s, t);
+            free(t); free(s);
+            return r;
+        });
+}
+
+// ====================================================================
+// Spatial-relation int→bool helpers (e/a contains/disjoint/intersects/
+// touches and the dwithin family that adds a distance argument)
+// ====================================================================
+
+template <int (*FN)(const Temporal *, const GSERIALIZED *)>
+void TgeoGeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            int r = FN(t, gs);
+            free(t); free(gs);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+template <int (*FN)(const GSERIALIZED *, const Temporal *)>
+void GeoTgeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            int r = FN(gs, t);
+            free(t); free(gs);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+template <int (*FN)(const Temporal *, const Temporal *)>
+void TgeoTgeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) {
+            Temporal *t1 = DecodeTemporalCopy(a);
+            Temporal *t2 = DecodeTemporalCopy(b);
+            int r = FN(t1, t2);
+            free(t1); free(t2);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+template <int (*FN)(const Temporal *, const GSERIALIZED *, double)>
+void TgeoGeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, double dist, ValidityMask &mask, idx_t idx) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            int r = FN(t, gs, dist);
+            free(t); free(gs);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+template <int (*FN)(const GSERIALIZED *, const Temporal *, double)>
+void GeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            int r = FN(gs, t, dist);
+            free(t); free(gs);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+// dwithin's (GEOM, TGEOM, dist) signature reuses the (TGEOM, GEOM, dist)
+// MEOS function with arguments swapped — distance is symmetric.
+template <int (*FN)(const Temporal *, const GSERIALIZED *, double)>
+void GeoTgeoDistIntExec_FromTgeoGeo(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            int r = FN(t, gs, dist);
+            free(t); free(gs);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+template <int (*FN)(const Temporal *, const Temporal *, double)>
+void TgeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t a, string_t b, double dist, ValidityMask &mask, idx_t idx) {
+            Temporal *t1 = DecodeTemporalCopy(a);
+            Temporal *t2 = DecodeTemporalCopy(b);
+            int r = FN(t1, t2, dist);
+            free(t1); free(t2);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+// ====================================================================
+// Temporal-relation Temporal→Temporal helpers — `restr=false`,
+// `atvalue=false` are the SQL defaults that produce a temporal value
+// covering the whole input duration.
+// ====================================================================
+
+inline string_t TemporalToBlob(Vector &result, Temporal *t) {
+    size_t sz = temporal_mem_size(t);
+    string_t out = StringVector::AddStringOrBlob(
+        result, reinterpret_cast<const char *>(t), sz);
+    free(t);
+    return out;
+}
+
+template <Temporal *(*FN)(const Temporal *, const GSERIALIZED *, bool, bool)>
+void TgeoGeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            Temporal *r = FN(t, gs, false, false);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <Temporal *(*FN)(const GSERIALIZED *, const Temporal *, bool, bool)>
+void GeoTgeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            Temporal *r = FN(gs, t, false, false);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <Temporal *(*FN)(const Temporal *, const Temporal *, bool, bool)>
+void TgeoTgeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t1 = DecodeTemporalCopy(a);
+            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *r = FN(t1, t2, false, false);
+            free(t1); free(t2);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+// tDwithin variants take an extra distance argument.
+template <Temporal *(*FN)(const Temporal *, const GSERIALIZED *, double, bool, bool)>
+void TgeoGeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, double dist, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            Temporal *r = FN(t, gs, dist, false, false);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <Temporal *(*FN)(const GSERIALIZED *, const Temporal *, double, bool, bool)>
+void GeoTgeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            Temporal *r = FN(gs, t, dist, false, false);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <Temporal *(*FN)(const Temporal *, const Temporal *, double, bool, bool)>
+void TgeoTgeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t a, string_t b, double dist, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t1 = DecodeTemporalCopy(a);
+            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *r = FN(t1, t2, dist, false, false);
+            free(t1); free(t2);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+// ====================================================================
+// Distance helpers — `tdistance(...)` and `<->`
+// ====================================================================
+
+template <Temporal *(*FN)(const Temporal *, const GSERIALIZED *)>
+void TgeoGeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            Temporal *r = FN(t, gs);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <Temporal *(*FN)(const Temporal *, const Temporal *)>
+void TgeoTgeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t1 = DecodeTemporalCopy(a);
+            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *r = FN(t1, t2);
+            free(t1); free(t2);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+} // namespace
+
+void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
+    const LogicalType TGEOM = TGeometryTypes::TGEOMETRY();
+    const LogicalType GEOM  = GeoTypes::GEOMETRY();
+    const LogicalType STBOX = StboxType::STBOX();
+    const LogicalType TSTZSPAN = SpanTypes::TSTZSPAN();
+    const LogicalType BOOL = LogicalType::BOOLEAN;
+    const LogicalType DBL = LogicalType::DOUBLE;
+    const LogicalType TFLOAT = TemporalTypes::TFLOAT();
+
+    // -----------------------------------------------------------------
+    // Box predicates: temporal_(overlaps|contains|contained|same|adjacent)
+    // and the equivalent operators (&&, @>, <@, ~=, -|-).
+    // -----------------------------------------------------------------
+    struct BoxOp {
+        const char *fn_name;
+        const char *op_name;
+        bool (*tspatial_stbox)(const Temporal *, const STBox *);
+        bool (*tspatial_tspatial)(const Temporal *, const Temporal *);
+        bool (*temporal_tstzspan)(const Temporal *, const Span *);
+        bool (*tstzspan_temporal)(const Span *, const Temporal *);
+    };
+    const BoxOp box_ops[] = {
+        {"temporal_overlaps", "&&",
+         overlaps_tspatial_stbox, overlaps_tspatial_tspatial,
+         overlaps_temporal_tstzspan, overlaps_tstzspan_temporal},
+        {"temporal_contains", "@>",
+         contains_tspatial_stbox, contains_tspatial_tspatial,
+         contains_temporal_tstzspan, contains_tstzspan_temporal},
+        {"temporal_contained", "<@",
+         contained_tspatial_stbox, contained_tspatial_tspatial,
+         contained_temporal_tstzspan, contained_tstzspan_temporal},
+        {"temporal_same",     "~=",
+         same_tspatial_stbox, same_tspatial_tspatial,
+         same_temporal_tstzspan, same_tstzspan_temporal},
+        {"temporal_adjacent", "-|-",
+         adjacent_tspatial_stbox, adjacent_tspatial_tspatial,
+         adjacent_temporal_tstzspan, adjacent_tstzspan_temporal},
+    };
+
+    // Build per-overload registrations through static dispatch on the
+    // function pointer values supplied above. We can't bind those to
+    // template parameters at runtime, so we register each predicate
+    // explicitly below using the macros.
+#define BOX_REG(NAME, OP, F_TSPAT_STBOX, F_TSPAT_TSPAT, F_TEMP_TSTZSPAN, F_TSTZSPAN_TEMP) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, STBOX},   BOOL, \
+            TspatialStboxBoolExec<F_TSPAT_STBOX>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {STBOX, TGEOM},   BOOL, \
+            StboxTspatialBoolExec<F_TSPAT_STBOX>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TGEOM},   BOOL, \
+            TspatialTspatialBoolExec<F_TSPAT_TSPAT>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TSTZSPAN},BOOL, \
+            TemporalTstzspanBoolExec<F_TEMP_TSTZSPAN>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TSTZSPAN, TGEOM},BOOL, \
+            TstzspanTemporalBoolExec<F_TSTZSPAN_TEMP>)); \
+        loader.RegisterFunction(ScalarFunction(OP,   {TGEOM, STBOX},   BOOL, \
+            TspatialStboxBoolExec<F_TSPAT_STBOX>)); \
+        loader.RegisterFunction(ScalarFunction(OP,   {STBOX, TGEOM},   BOOL, \
+            StboxTspatialBoolExec<F_TSPAT_STBOX>)); \
+        loader.RegisterFunction(ScalarFunction(OP,   {TGEOM, TGEOM},   BOOL, \
+            TspatialTspatialBoolExec<F_TSPAT_TSPAT>)); \
+        loader.RegisterFunction(ScalarFunction(OP,   {TGEOM, TSTZSPAN},BOOL, \
+            TemporalTstzspanBoolExec<F_TEMP_TSTZSPAN>)); \
+        loader.RegisterFunction(ScalarFunction(OP,   {TSTZSPAN, TGEOM},BOOL, \
+            TstzspanTemporalBoolExec<F_TSTZSPAN_TEMP>)); \
+    } while (0)
+
+    BOX_REG("temporal_overlaps", "&&",
+            overlaps_tspatial_stbox, overlaps_tspatial_tspatial,
+            overlaps_temporal_tstzspan, overlaps_tstzspan_temporal);
+    BOX_REG("temporal_contains", "@>",
+            contains_tspatial_stbox, contains_tspatial_tspatial,
+            contains_temporal_tstzspan, contains_tstzspan_temporal);
+    BOX_REG("temporal_contained", "<@",
+            contained_tspatial_stbox, contained_tspatial_tspatial,
+            contained_temporal_tstzspan, contained_tstzspan_temporal);
+    BOX_REG("temporal_same", "~=",
+            same_tspatial_stbox, same_tspatial_tspatial,
+            same_temporal_tstzspan, same_tstzspan_temporal);
+    BOX_REG("temporal_adjacent", "-|-",
+            adjacent_tspatial_stbox, adjacent_tspatial_tspatial,
+            adjacent_temporal_tstzspan, adjacent_tstzspan_temporal);
+#undef BOX_REG
+
+    // -----------------------------------------------------------------
+    // Position predicates (left / right / below / above / front / back /
+    // before / after and their over-* variants). Only tgeometry × stbox
+    // and tgeometry × tgeometry — there are no time-axis positions for
+    // a tstzspan input that aren't already covered by the time-domain
+    // predicates wired in `temporal.cpp` for arbitrary temporals.
+    // -----------------------------------------------------------------
+#define POS_REG(NAME, F_TSPAT_STBOX, F_TSPAT_TSPAT) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, STBOX}, BOOL, \
+            TspatialStboxBoolExec<F_TSPAT_STBOX>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {STBOX, TGEOM}, BOOL, \
+            StboxTspatialBoolExec<F_TSPAT_STBOX>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TGEOM}, BOOL, \
+            TspatialTspatialBoolExec<F_TSPAT_TSPAT>)); \
+    } while (0)
+
+    POS_REG("temporal_left",       left_tspatial_stbox,       left_tspatial_tspatial);
+    POS_REG("temporal_overleft",   overleft_tspatial_stbox,   overleft_tspatial_tspatial);
+    POS_REG("temporal_right",      right_tspatial_stbox,      right_tspatial_tspatial);
+    POS_REG("temporal_overright",  overright_tspatial_stbox,  overright_tspatial_tspatial);
+    POS_REG("temporal_below",      below_tspatial_stbox,      below_tspatial_tspatial);
+    POS_REG("temporal_overbelow",  overbelow_tspatial_stbox,  overbelow_tspatial_tspatial);
+    POS_REG("temporal_above",      above_tspatial_stbox,      above_tspatial_tspatial);
+    POS_REG("temporal_overabove",  overabove_tspatial_stbox,  overabove_tspatial_tspatial);
+    POS_REG("temporal_front",      front_tspatial_stbox,      front_tspatial_tspatial);
+    POS_REG("temporal_overfront",  overfront_tspatial_stbox,  overfront_tspatial_tspatial);
+    POS_REG("temporal_back",       back_tspatial_stbox,       back_tspatial_tspatial);
+    POS_REG("temporal_overback",   overback_tspatial_stbox,   overback_tspatial_tspatial);
+    POS_REG("temporal_before",     before_tspatial_stbox,     before_tspatial_tspatial);
+    POS_REG("temporal_overbefore", overbefore_tspatial_stbox, overbefore_tspatial_tspatial);
+    POS_REG("temporal_after",      after_tspatial_stbox,      after_tspatial_tspatial);
+    POS_REG("temporal_overafter",  overafter_tspatial_stbox,  overafter_tspatial_tspatial);
+#undef POS_REG
+
+    // Time-axis position predicates also accept a tstzspan operand on the
+    // non-tspatial side — these reuse the generic temporal_* MEOS exports
+    // rather than the tspatial_* ones since they don't touch the spatial
+    // axes.
+#define TIME_POS_REG(NAME, F_TEMP_TSTZSPAN, F_TSTZSPAN_TEMP) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TSTZSPAN}, BOOL, \
+            TemporalTstzspanBoolExec<F_TEMP_TSTZSPAN>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TSTZSPAN, TGEOM}, BOOL, \
+            TstzspanTemporalBoolExec<F_TSTZSPAN_TEMP>)); \
+    } while (0)
+    TIME_POS_REG("temporal_before",     before_temporal_tstzspan,     before_tstzspan_temporal);
+    TIME_POS_REG("temporal_overbefore", overbefore_temporal_tstzspan, overbefore_tstzspan_temporal);
+    TIME_POS_REG("temporal_after",      after_temporal_tstzspan,      after_tstzspan_temporal);
+    TIME_POS_REG("temporal_overafter",  overafter_temporal_tstzspan,  overafter_tstzspan_temporal);
+#undef TIME_POS_REG
+
+    // -----------------------------------------------------------------
+    // Spatial relationships — ever (e*) and always (a*) versions for
+    // contains / disjoint / intersects / touches / dwithin.
+    // -----------------------------------------------------------------
+#define EA_REG_2(NAME, F_TGEO_GEO, F_GEO_TGEO, F_TGEO_TGEO) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {GEOM, TGEOM}, BOOL, \
+            GeoTgeoIntExec<F_GEO_TGEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, GEOM}, BOOL, \
+            TgeoGeoIntExec<F_TGEO_GEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TGEOM}, BOOL, \
+            TgeoTgeoIntExec<F_TGEO_TGEO>)); \
+    } while (0)
+    // disjoint / intersects / touches don't have a (geo, tgeo) MEOS export
+    // because they are commutative — eDisjoint(g, t) is just eDisjoint(t, g).
+#define EA_REG_2_COMMUT(NAME, F_TGEO_GEO, F_TGEO_TGEO) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {GEOM, TGEOM}, BOOL, \
+            TgeoGeoIntExec<F_TGEO_GEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, GEOM}, BOOL, \
+            TgeoGeoIntExec<F_TGEO_GEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TGEOM}, BOOL, \
+            TgeoTgeoIntExec<F_TGEO_TGEO>)); \
+    } while (0)
+
+    // contains is non-commutative — uses both directions.
+    EA_REG_2("eContains", econtains_tgeo_geo, econtains_geo_tgeo, econtains_tgeo_tgeo);
+    EA_REG_2("aContains", acontains_tgeo_geo, acontains_geo_tgeo, acontains_tgeo_tgeo);
+
+    EA_REG_2_COMMUT("eDisjoint",   edisjoint_tgeo_geo,   edisjoint_tgeo_tgeo);
+    EA_REG_2_COMMUT("aDisjoint",   adisjoint_tgeo_geo,   adisjoint_tgeo_tgeo);
+    EA_REG_2_COMMUT("eIntersects", eintersects_tgeo_geo, eintersects_tgeo_tgeo);
+    EA_REG_2_COMMUT("aIntersects", aintersects_tgeo_geo, aintersects_tgeo_tgeo);
+    EA_REG_2_COMMUT("eTouches",    etouches_tgeo_geo,    etouches_tgeo_tgeo);
+    EA_REG_2_COMMUT("aTouches",    atouches_tgeo_geo,    atouches_tgeo_tgeo);
+#undef EA_REG_2
+#undef EA_REG_2_COMMUT
+
+    // dwithin is symmetric in its first two arguments; MEOS only exports
+    // the (Temporal *, GSERIALIZED *) flavour, so the (geo, tgeo, dist)
+    // SQL form reuses it with arguments swapped at the call site.
+#define EA_DWITHIN_REG(NAME, F_TGEO_GEO, F_TGEO_TGEO) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {GEOM, TGEOM, DBL}, BOOL, \
+            GeoTgeoDistIntExec_FromTgeoGeo<F_TGEO_GEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, GEOM, DBL}, BOOL, \
+            TgeoGeoDistIntExec<F_TGEO_GEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TGEOM, DBL}, BOOL, \
+            TgeoTgeoDistIntExec<F_TGEO_TGEO>)); \
+    } while (0)
+    EA_DWITHIN_REG("eDwithin", edwithin_tgeo_geo, edwithin_tgeo_tgeo);
+    EA_DWITHIN_REG("aDwithin", adwithin_tgeo_geo, adwithin_tgeo_tgeo);
+#undef EA_DWITHIN_REG
+
+    // -----------------------------------------------------------------
+    // Temporal spatial relationships (`tContains`, `tDisjoint`,
+    // `tIntersects`, `tTouches`, `tDwithin`) — return a temporal
+    // boolean whose truth value tracks the relation over time.
+    // -----------------------------------------------------------------
+#define TREL_REG(NAME, F_TGEO_GEO, F_GEO_TGEO, F_TGEO_TGEO) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {GEOM, TGEOM}, TemporalTypes::TBOOL(), \
+            GeoTgeoTempExec<F_GEO_TGEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, GEOM}, TemporalTypes::TBOOL(), \
+            TgeoGeoTempExec<F_TGEO_GEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TGEOM}, TemporalTypes::TBOOL(), \
+            TgeoTgeoTempExec<F_TGEO_TGEO>)); \
+    } while (0)
+
+    TREL_REG("tContains",   tcontains_tgeo_geo,   tcontains_geo_tgeo,   tcontains_tgeo_tgeo);
+    TREL_REG("tDisjoint",   tdisjoint_tgeo_geo,   tdisjoint_geo_tgeo,   tdisjoint_tgeo_tgeo);
+    TREL_REG("tIntersects", tintersects_tgeo_geo, tintersects_geo_tgeo, tintersects_tgeo_tgeo);
+    TREL_REG("tTouches",    ttouches_tgeo_geo,    ttouches_geo_tgeo,    ttouches_tgeo_tgeo);
+#undef TREL_REG
+
+    // tDwithin takes the extra distance argument.
+    loader.RegisterFunction(ScalarFunction("tDwithin",
+        {GEOM, TGEOM, DBL}, TemporalTypes::TBOOL(),
+        GeoTgeoDistTempExec<tdwithin_geo_tgeo>));
+    loader.RegisterFunction(ScalarFunction("tDwithin",
+        {TGEOM, GEOM, DBL}, TemporalTypes::TBOOL(),
+        TgeoGeoDistTempExec<tdwithin_tgeo_geo>));
+    loader.RegisterFunction(ScalarFunction("tDwithin",
+        {TGEOM, TGEOM, DBL}, TemporalTypes::TBOOL(),
+        TgeoTgeoDistTempExec<tdwithin_tgeo_tgeo>));
+
+    // -----------------------------------------------------------------
+    // Distance — `tdistance(...)` and `<->`.
+    // -----------------------------------------------------------------
+    loader.RegisterFunction(ScalarFunction("tdistance",
+        {TGEOM, GEOM}, TFLOAT, TgeoGeoDistanceExec<tdistance_tgeo_geo>));
+    loader.RegisterFunction(ScalarFunction("tdistance",
+        {TGEOM, TGEOM}, TFLOAT, TgeoTgeoDistanceExec<tdistance_tgeo_tgeo>));
+    loader.RegisterFunction(ScalarFunction("<->",
+        {TGEOM, GEOM}, TFLOAT, TgeoGeoDistanceExec<tdistance_tgeo_geo>));
+    loader.RegisterFunction(ScalarFunction("<->",
+        {TGEOM, TGEOM}, TFLOAT, TgeoTgeoDistanceExec<tdistance_tgeo_tgeo>));
+}
+
+} // namespace duckdb

--- a/src/include/geo/tgeometry_ops.hpp
+++ b/src/include/geo/tgeometry_ops.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+// Cross-type predicate / operator registrations for tgeometry — boxops
+// (overlaps / contains / contained / same / adjacent), position predicates
+// (left / right / below / above / front / back / before / after and their
+// over-* variants), spatial relationships (e / a / t variants of contains
+// / disjoint / intersects / touches / dwithin), and the temporal distance
+// operator family. Mirrors the corresponding cross-type surface that
+// MobilityDB ships in 060/062/064/070/072_tgeo_*.in.sql.
+struct TGeometryOps {
+    static void RegisterScalarFunctions(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -11,6 +11,7 @@
 #include "geo/tgeompoint.hpp"
 #include "duckdb.hpp"
 #include "geo/tgeometry.hpp"
+#include "geo/tgeometry_ops.hpp"
 #include "temporal/span.hpp"
 #include "temporal/span_aggregates.hpp"
 #include "duckdb/common/exception.hpp"
@@ -254,6 +255,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	TGeometryTypes::RegisterTypes(loader);
 	TGeometryTypes::RegisterCastFunctions(loader);
 	TGeometryTypes::RegisterScalarInOutFunctions(loader);
+	TGeometryOps::RegisterScalarFunctions(loader);
 
 	SetTypes::RegisterTypes(loader);
 	SetTypes::RegisterCastFunctions(loader);

--- a/test/sql/parity/040_tgeometry_foundations.test
+++ b/test/sql/parity/040_tgeometry_foundations.test
@@ -1,0 +1,154 @@
+# name: test/sql/parity/040_tgeometry_foundations.test
+# description: Foundational tgeometry surface — accessors, time/value
+#              restrict, modifiers, and comparison. Mirrors the analogous
+#              tgeompoint surface registered in src/geo/tgeompoint.cpp,
+#              reusing the same generic Temporal handlers from
+#              src/temporal/temporal_functions.cpp where the C MEOS
+#              functions are subtype-agnostic.
+#
+#              Geometry values are emitted in EWKB-hex display rather than
+#              WKT, so the expected outputs encode the input coordinates
+#              verbatim.
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# Accessors
+# =============================================================================
+
+query I
+SELECT numInstants(t::tgeometry) FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+1
+
+query I
+SELECT numInstants(t::tgeometry) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+2
+
+query I
+SELECT startTimestamp(t::tgeometry)::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+2000-01-01 00:00:00+00
+
+query I
+SELECT endTimestamp(t::tgeometry)::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+2000-01-03 00:00:00+00
+
+query I
+SELECT duration(t::tgeometry)::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+2 days
+
+query I
+SELECT lowerInc(t::tgeometry) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true
+
+# tgeometry defaults to STEP interpolation, which requires both inclusive
+# bounds — so the sequence form `[..., ...)` would be rejected at parse
+# time. Use a closed sequence and assert upperInc = true instead.
+query I
+SELECT upperInc(t::tgeometry) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true
+
+query I
+SELECT len(timestamps(t::tgeometry)) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+2
+
+# =============================================================================
+# Time-domain restrict
+# =============================================================================
+
+query I
+SELECT atTime(t::tgeometry, TIMESTAMPTZ '2000-01-01')::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+010100000000000000000000000000000000000000@2000-01-01 00:00:00+00
+
+query I
+SELECT beforeTimestamp(t::tgeometry, TIMESTAMPTZ '2000-01-02')::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+[010100000000000000000000000000000000000000@2000-01-01 00:00:00+00, 010100000000000000000000000000000000000000@2000-01-02 00:00:00+00)
+
+# =============================================================================
+# Modifiers (shift / scale / shiftScale)
+# =============================================================================
+
+query I
+SELECT shiftTime(t::tgeometry, INTERVAL '1 day')::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+[010100000000000000000000000000000000000000@2000-01-02 00:00:00+00, 010100000000000000000000400000000000000040@2000-01-04 00:00:00+00]
+
+query I
+SELECT scaleTime(t::tgeometry, INTERVAL '1 day')::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+[010100000000000000000000000000000000000000@2000-01-01 00:00:00+00, 010100000000000000000000400000000000000040@2000-01-02 00:00:00+00]
+
+# =============================================================================
+# Spatial restrict
+# =============================================================================
+
+query I
+SELECT atGeometry(
+  t::tgeometry,
+  ST_GeomFromText('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'))::VARCHAR
+FROM (VALUES ('Point(0.5 0.5)@2000-01-01')) t(t);
+----
+0101000000000000000000E03F000000000000E03F@2000-01-01 00:00:00+00
+
+# =============================================================================
+# Comparison (named functions and operators)
+# =============================================================================
+
+query I
+SELECT temporal_eq(t::tgeometry, t::tgeometry) FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+true
+
+query I
+SELECT t1::tgeometry = t2::tgeometry FROM (VALUES
+  ('Point(0 0)@2000-01-01', 'Point(0 0)@2000-01-01')) t(t1, t2);
+----
+true
+
+query I
+SELECT t1::tgeometry <> t2::tgeometry FROM (VALUES
+  ('Point(0 0)@2000-01-01', 'Point(1 1)@2000-01-01')) t(t1, t2);
+----
+true
+
+query I
+SELECT temporal_cmp(t::tgeometry, t::tgeometry) FROM (VALUES
+  ('Point(0 0)@2000-01-01')) t(t);
+----
+0
+
+# =============================================================================
+# tempSubtype + interp + memSize
+# =============================================================================
+
+query I
+SELECT tempSubtype(t::tgeometry) FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+Instant
+
+query I
+SELECT tempSubtype(t::tgeometry) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+Sequence

--- a/test/sql/parity/040_tgeometry_parity.test
+++ b/test/sql/parity/040_tgeometry_parity.test
@@ -1,13 +1,19 @@
-# name: test/sql/parity/040_tgeometry_foundations.test
-# description: Foundational tgeometry surface — accessors, time/value
-#              restrict, modifiers, and comparison. Mirrors the analogous
-#              tgeompoint surface registered in src/geo/tgeompoint.cpp,
-#              reusing the same generic Temporal handlers from
-#              src/temporal/temporal_functions.cpp where the C MEOS
-#              functions are subtype-agnostic.
+# name: test/sql/parity/040_tgeometry_parity.test
+# description: tgeometry parity — foundational accessors / time/value
+#              restrict / modifiers / comparison, plus the cross-type
+#              predicate surface (boxops, posops, spatial-relationships,
+#              temporal-spatial-relationships, and the tdistance / <->
+#              distance family).
 #
-#              Geometry values are emitted in EWKB-hex display rather than
-#              WKT, so the expected outputs encode the input coordinates
+#              Most MEOS C functions reached here are subtype-agnostic —
+#              the registrations reuse the generic TemporalFunctions::*
+#              handlers from src/temporal/temporal_functions.cpp where
+#              they exist, and src/geo/tgeometry_ops.cpp adds templated
+#              wrappers around the tspatial_* / tgeo_* MEOS exports for
+#              the cross-type surface.
+#
+#              Geometry values are emitted in EWKB-hex display rather
+#              than WKT, so expected outputs encode input coordinates
 #              verbatim.
 # group: [sql]
 
@@ -152,3 +158,116 @@ SELECT tempSubtype(t::tgeometry) FROM (VALUES
   ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
 ----
 Sequence
+
+# =============================================================================
+# Box predicates: temporal_overlaps / contains / contained / same / adjacent
+# (named functions + the matching &&, @>, <@, ~=, -|- operators)
+# =============================================================================
+
+query I
+SELECT t1::tgeometry && t2::tgeometry FROM (VALUES
+  ('Point(0 0)@2000-01-01', 'Point(0 0)@2000-01-01')) t(t1, t2);
+----
+true
+
+query I
+SELECT temporal_contains(t::tgeometry, '[2000-01-01, 2000-01-02]'::tstzspan) FROM
+  (VALUES ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true
+
+query I
+SELECT temporal_same(t::tgeometry, t::tgeometry) FROM (VALUES
+  ('Point(0 0)@2000-01-01')) t(t);
+----
+true
+
+# =============================================================================
+# Position predicates
+# =============================================================================
+
+query I
+SELECT temporal_left(t1::tgeometry, t2::tgeometry) FROM (VALUES
+  ('Point(0 0)@2000-01-01', 'Point(5 5)@2000-01-01')) t(t1, t2);
+----
+true
+
+query I
+SELECT temporal_below(t1::tgeometry, t2::tgeometry) FROM (VALUES
+  ('Point(0 0)@2000-01-01', 'Point(0 5)@2000-01-01')) t(t1, t2);
+----
+true
+
+query I
+SELECT temporal_before(t::tgeometry, '[2000-01-05, 2000-01-06]'::tstzspan) FROM
+  (VALUES ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true
+
+# =============================================================================
+# Spatial relationships (ever / always)
+# =============================================================================
+
+query I
+SELECT eContains(
+  ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))'),
+  t::tgeometry)
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+query I
+SELECT eIntersects(
+  t::tgeometry,
+  ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))'))
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+query I
+SELECT eDwithin(t::tgeometry, ST_Point(0, 0), 5.0)
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+# eDwithin is symmetric in its first two arguments — geo, tgeo and
+# tgeo, geo both reach the same MEOS tgeo_geo function.
+query I
+SELECT eDwithin(ST_Point(0, 0), t::tgeometry, 5.0)
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+# =============================================================================
+# Temporal spatial relationships (return tbool)
+# =============================================================================
+
+query I
+SELECT tIntersects(
+  t::tgeometry,
+  ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))'))::VARCHAR
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+t@2000-01-01 00:00:00+00
+
+query I
+SELECT tDwithin(t::tgeometry, ST_Point(10, 0), 5.0)::VARCHAR
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+f@2000-01-01 00:00:00+00
+
+# =============================================================================
+# Distance — tdistance + <->
+# =============================================================================
+
+query I
+SELECT tdistance(t1::tgeometry, t2::tgeometry)::VARCHAR
+FROM (VALUES ('Point(0 0)@2000-01-01', 'Point(3 4)@2000-01-01')) t(t1, t2);
+----
+5@2000-01-01 00:00:00+00
+
+query I
+SELECT (t1::tgeometry <-> t2::tgeometry)::VARCHAR
+FROM (VALUES ('Point(0 0)@2000-01-01', 'Point(3 4)@2000-01-01')) t(t1, t2);
+----
+5@2000-01-01 00:00:00+00

--- a/test/sql/parity/040_tgeometry_parity.test
+++ b/test/sql/parity/040_tgeometry_parity.test
@@ -271,3 +271,42 @@ SELECT (t1::tgeometry <-> t2::tgeometry)::VARCHAR
 FROM (VALUES ('Point(0 0)@2000-01-01', 'Point(3 4)@2000-01-01')) t(t1, t2);
 ----
 5@2000-01-01 00:00:00+00
+
+# =============================================================================
+# Spatial functions: SRID accessor / setter, transform, stbox, coercions,
+# centroid, convexHull, traversedArea.
+# =============================================================================
+
+query I
+SELECT SRID(t::tgeometry) FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+0
+
+query I
+SELECT SRID(setSRID(t::tgeometry, 4326)) FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+4326
+
+query I
+SELECT stbox(t::tgeometry)::VARCHAR FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+STBOX XT(((0,0),(0,0)),[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00])
+
+# tgeometry → tgeompoint round-trip via the explicit coercion pair.
+query I
+SELECT tempSubtype(tgeompoint(t::tgeometry)) FROM (VALUES
+  ('Point(0 0)@2000-01-01')) t(t);
+----
+Instant
+
+query I
+SELECT (convexHull(t::tgeometry) IS NOT NULL) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true
+
+query I
+SELECT (traversedArea(t::tgeometry) IS NOT NULL) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true


### PR DESCRIPTION
## Summary

First PR in the `tgeometry` parity sweep. Mirrors the **temporal-generic** portion of the `tgeompoint` surface (50+ new overloads) so users can do basic accessing, restricting, modifying, and comparing on `tgeometry` values.

| Category | Functions |
|---|---|
| Accessors | `valueSet`, `valueN`, `valueAtTimestamp`, `getTime`, `duration`, `lowerInc`, `upperInc`, `numInstants`, `instants`, `numSequences`, `sequences`, `startSequence`, `endSequence`, `sequenceN`, `numTimestamps`, `timestamps`, `startTimestamp`, `endTimestamp`, `timestampN`, `segments` |
| Time-domain restrict | `atTime` / `minusTime` over `(timestamptz, tstzset, tstzspan, tstzspanset)`; `beforeTimestamp`, `afterTimestamp` |
| Value restrict | `atValues` / `minusValues` over `(geometry, geomset)` |
| Spatial restrict | `atGeometry`, `minusGeometry`, `minusStbox` |
| Modifiers | `shiftTime`, `scaleTime`, `shiftScaleTime`, `appendInstant`, `appendSequence`, `insert`, `update`, `deleteTime` over multiple time-argument shapes |
| Comparison | `temporal_eq` / `ne` / `lt` / `le` / `gt` / `ge` / `cmp` + the matching `=`, `<>`, `<`, `<=`, `>`, `>=` operators |

## Implementation note

Most MEOS C functions reached here are **subtype-agnostic** — they take `Temporal *` and don't care whether the underlying value is a point, polygon, or any other geometry. So the registrations reuse the existing generic `TemporalFunctions::*` handlers that `tgeompoint.cpp` already uses, with the LogicalType swapped from `TGEOMPOINT()` → `TGEOMETRY()` and the value type from POINT → `GEOMETRY()`.

The spatial-restrict functions (`atGeometry` / `minusGeometry` / `minusStbox`) reuse the `TgeompointFunctions::Tgeo_*` handlers — those are already named for the generic tgeo case (call MEOS's `tgeo_at_geom` / `tgeo_minus_geom` / `tgeo_minus_stbox`).

## Out of scope (planned follow-ups)

- **`tgeometry` × `geometry` comparison** + **distance** + **spatial-rels** + **temporal-spatial-rels** (the bigger 060 / 064 / 070 / 072 SQL files; ~400 SQL functions/operators total).
- **`tgeometry` tile family + analytics + aggregates + GiST / SP-GiST**.
- **`tgeography`** parity (entirely separate type registration; does not currently exist in MobilityDuck).

## Test plan

- [x] `test/sql/parity/040_tgeometry_foundations.test` — 19 assertions covering each category.
- [x] No regression in any other parity test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)