### PR TITLE
feat(bindings): tgeometry parity — full surface (cumulative)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ set(EXTENSION_SOURCES
     src/geo/tgeometry.cpp
     src/geo/tgeometry_in_out.cpp
     src/index/rtree_module.cpp
+    src/single_tile_getters.cpp
     src/index/rtree_index_create_physical.cpp
     src/index/rtree_index_scan.cpp
     src/index/rtree_optimize_scan.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ set(EXTENSION_SOURCES
     src/temporal/spanset_functions.cpp
     src/geo/tgeometry.cpp
     src/geo/tgeometry_in_out.cpp
+    src/geo/tgeometry_ops.cpp
     src/index/rtree_module.cpp
     src/index/rtree_index_create_physical.cpp
     src/index/rtree_index_scan.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(EXTENSION_SOURCES
     src/temporal/span.cpp
     src/temporal/span_functions.cpp
     src/temporal/span_aggregates.cpp
+    src/temporal/temporal_aggregates.cpp
     src/geo/geoset.cpp
     src/temporal/spanset.cpp
     src/temporal/spanset_functions.cpp

--- a/src/geo/tgeometry.cpp
+++ b/src/geo/tgeometry.cpp
@@ -1,9 +1,15 @@
 #include "geo/tgeometry.hpp"
+#include "geo/tgeompoint_functions.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/common/extension_type_info.hpp"
 #include <regex>
 #include <string>
 #include <temporal/span.hpp>
+#include "temporal/spanset.hpp"
+#include "temporal/set.hpp"
+#include "temporal/temporal_functions.hpp"
+#include "geo/stbox.hpp"
+#include "geo/geoset.hpp"
 #include<time_util.hpp>
 #include "geo_util.hpp"
 #include "spatial/spatial_types.hpp"
@@ -1255,11 +1261,233 @@ void TGeometryTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     auto tgeometry_gettimestamptz_function = ScalarFunction(
         "getTimestamp",
         {TGeometryTypes::TGEOMETRY()},
-        LogicalType::TIMESTAMP_TZ,  
+        LogicalType::TIMESTAMP_TZ,
         Tinstant_timestamptz);
     loader.RegisterFunction( tgeometry_gettimestamptz_function);
-    
 
+    // ===================================================================
+    // Foundational tgeometry surface — accessors, time/value-restrict,
+    // modifiers, and comparison. The MEOS C functions delegated to here
+    // are subtype-agnostic (they take Temporal *), so we reuse the same
+    // generic handlers wired for tgeompoint in temporal_functions.cpp.
+    // ===================================================================
+
+    const LogicalType TGEOM = TGeometryTypes::TGEOMETRY();
+    const LogicalType GEOM  = GeoTypes::GEOMETRY();
+    const LogicalType TSTZ  = LogicalType::TIMESTAMP_TZ;
+    const LogicalType IVAL  = LogicalType::INTERVAL;
+    const LogicalType BIGI  = LogicalType::BIGINT;
+
+    // ---- Accessors ----
+    loader.RegisterFunction(ScalarFunction(
+        "valueSet", {TGEOM}, SpatialSetType::geomset(),
+        TemporalFunctions::Temporal_valueset));
+    loader.RegisterFunction(ScalarFunction(
+        "valueN", {TGEOM, BIGI}, GEOM,
+        TemporalFunctions::Temporal_value_n));
+    loader.RegisterFunction(ScalarFunction(
+        "valueAtTimestamp", {TGEOM, TSTZ}, GEOM,
+        TemporalFunctions::Temporal_value_at_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "getTime", {TGEOM}, SpansetTypes::tstzspanset(),
+        TemporalFunctions::Temporal_time));
+    loader.RegisterFunction(ScalarFunction(
+        "duration", {TGEOM}, IVAL,
+        TemporalFunctions::Temporal_duration));
+    loader.RegisterFunction(ScalarFunction(
+        "duration", {TGEOM, LogicalType::BOOLEAN}, IVAL,
+        TemporalFunctions::Temporal_duration));
+    loader.RegisterFunction(ScalarFunction(
+        "lowerInc", {TGEOM}, LogicalType::BOOLEAN,
+        TemporalFunctions::Temporal_lower_inc));
+    loader.RegisterFunction(ScalarFunction(
+        "upperInc", {TGEOM}, LogicalType::BOOLEAN,
+        TemporalFunctions::Temporal_upper_inc));
+    loader.RegisterFunction(ScalarFunction(
+        "numInstants", {TGEOM}, LogicalType::INTEGER,
+        TemporalFunctions::Temporal_num_instants));
+    loader.RegisterFunction(ScalarFunction(
+        "instants", {TGEOM}, LogicalType::LIST(TGEOM),
+        TemporalFunctions::Temporal_instants));
+    loader.RegisterFunction(ScalarFunction(
+        "numSequences", {TGEOM}, LogicalType::INTEGER,
+        TemporalFunctions::Temporal_num_sequences));
+    loader.RegisterFunction(ScalarFunction(
+        "sequences", {TGEOM}, LogicalType::LIST(TGEOM),
+        TemporalFunctions::Temporal_sequences));
+    loader.RegisterFunction(ScalarFunction(
+        "startSequence", {TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_start_sequence));
+    loader.RegisterFunction(ScalarFunction(
+        "endSequence", {TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_end_sequence));
+    loader.RegisterFunction(ScalarFunction(
+        "sequenceN", {TGEOM, LogicalType::INTEGER}, TGEOM,
+        TemporalFunctions::Temporal_sequence_n));
+    loader.RegisterFunction(ScalarFunction(
+        "numTimestamps", {TGEOM}, LogicalType::INTEGER,
+        TemporalFunctions::Temporal_num_timestamps));
+    loader.RegisterFunction(ScalarFunction(
+        "timestamps", {TGEOM}, LogicalType::LIST(TSTZ),
+        TemporalFunctions::Temporal_timestamps));
+    loader.RegisterFunction(ScalarFunction(
+        "startTimestamp", {TGEOM}, TSTZ,
+        TemporalFunctions::Temporal_start_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "endTimestamp", {TGEOM}, TSTZ,
+        TemporalFunctions::Temporal_end_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "timestampN", {TGEOM, LogicalType::INTEGER}, TSTZ,
+        TemporalFunctions::Temporal_timestamptz_n));
+    loader.RegisterFunction(ScalarFunction(
+        "segments", {TGEOM}, LogicalType::LIST(TGEOM),
+        TemporalFunctions::Temporal_segments));
+
+    // ---- Time-domain restrict / minus ----
+    for (const auto &t : std::vector<std::pair<LogicalType, scalar_function_t>>{
+             {TSTZ,                       TemporalFunctions::Temporal_at_timestamptz},
+             {SetTypes::tstzset(),        TemporalFunctions::Temporal_at_tstzset},
+             {SpanTypes::TSTZSPAN(),      TemporalFunctions::Temporal_at_tstzspan},
+             {SpansetTypes::tstzspanset(), TemporalFunctions::Temporal_at_tstzspanset}}) {
+        loader.RegisterFunction(ScalarFunction(
+            "atTime", {TGEOM, t.first}, TGEOM, t.second));
+    }
+    for (const auto &t : std::vector<std::pair<LogicalType, scalar_function_t>>{
+             {TSTZ,                       TemporalFunctions::Temporal_minus_timestamptz},
+             {SetTypes::tstzset(),        TemporalFunctions::Temporal_minus_tstzset},
+             {SpanTypes::TSTZSPAN(),      TemporalFunctions::Temporal_minus_tstzspan},
+             {SpansetTypes::tstzspanset(), TemporalFunctions::Temporal_minus_tstzspanset}}) {
+        loader.RegisterFunction(ScalarFunction(
+            "minusTime", {TGEOM, t.first}, TGEOM, t.second));
+    }
+
+    // beforeTimestamp / afterTimestamp accept timestamptz and tstzspan
+    loader.RegisterFunction(ScalarFunction(
+        "beforeTimestamp", {TGEOM, TSTZ}, TGEOM,
+        TemporalFunctions::Temporal_before_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "afterTimestamp", {TGEOM, TSTZ}, TGEOM,
+        TemporalFunctions::Temporal_after_timestamptz));
+
+    // ---- Value restrict ----
+    // atValues / minusValues over a single geometry funnel through
+    // tgeompoint-side handlers (subtype-agnostic — they call MEOS's
+    // tgeo_at_geom etc. under the hood) and over a geomset go through
+    // the temporal-functions multi-value handlers.
+    loader.RegisterFunction(ScalarFunction(
+        "atValues", {TGEOM, GEOM}, TGEOM,
+        TgeompointFunctions::Tgeompoint_at_value));
+    loader.RegisterFunction(ScalarFunction(
+        "atValues", {TGEOM, SpatialSetType::geomset()}, TGEOM,
+        TemporalFunctions::Temporal_at_values));
+    loader.RegisterFunction(ScalarFunction(
+        "minusValues", {TGEOM, GEOM}, TGEOM,
+        TemporalFunctions::Temporal_minus_value));
+    loader.RegisterFunction(ScalarFunction(
+        "minusValues", {TGEOM, SpatialSetType::geomset()}, TGEOM,
+        TemporalFunctions::Temporal_minus_value));
+
+    // ---- Spatial restrict (atGeometry / minusGeometry / atStbox / minusStbox)
+    // Reuse tgeompoint's Tgeo_* handlers — they operate on Temporal * and
+    // delegate to the subtype-agnostic MEOS `tgeo_at_geom` etc.
+    loader.RegisterFunction(ScalarFunction(
+        "atGeometry", {TGEOM, GEOM}, TGEOM,
+        TgeompointFunctions::Tgeo_at_geom));
+    loader.RegisterFunction(ScalarFunction(
+        "minusGeometry", {TGEOM, GEOM}, TGEOM,
+        TgeompointFunctions::Tgeo_minus_geom));
+    loader.RegisterFunction(ScalarFunction(
+        "minusStbox", {TGEOM, StboxType::STBOX()}, TGEOM,
+        TgeompointFunctions::Tgeo_minus_stbox));
+
+    // ---- Modifiers (shift / scale / shiftScale / append / insert / update /
+    // delete / round) ----
+    loader.RegisterFunction(ScalarFunction(
+        "shiftTime", {TGEOM, IVAL}, TGEOM,
+        TemporalFunctions::Temporal_shift_time));
+    loader.RegisterFunction(ScalarFunction(
+        "scaleTime", {TGEOM, IVAL}, TGEOM,
+        TemporalFunctions::Temporal_scale_time));
+    loader.RegisterFunction(ScalarFunction(
+        "shiftScaleTime", {TGEOM, IVAL, IVAL}, TGEOM,
+        TemporalFunctions::Temporal_shift_scale_time));
+    loader.RegisterFunction(ScalarFunction(
+        "appendInstant", {TGEOM, TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_append_tinstant));
+    loader.RegisterFunction(ScalarFunction(
+        "appendSequence", {TGEOM, TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_append_tsequence));
+    loader.RegisterFunction(ScalarFunction(
+        "insert", {TGEOM, TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_insert));
+    loader.RegisterFunction(ScalarFunction(
+        "insert", {TGEOM, TGEOM, LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_insert));
+    loader.RegisterFunction(ScalarFunction(
+        "update", {TGEOM, TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_update));
+    loader.RegisterFunction(ScalarFunction(
+        "update", {TGEOM, TGEOM, LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_update));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, TSTZ}, TGEOM,
+        TemporalFunctions::Temporal_delete_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, TSTZ, LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_delete_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SetTypes::tstzset()}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzset));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SetTypes::tstzset(), LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzset));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SpanTypes::TSTZSPAN()}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzspan));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SpanTypes::TSTZSPAN(), LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzspan));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SpansetTypes::tstzspanset()}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzspanset));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SpansetTypes::tstzspanset(), LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzspanset));
+
+    // ---- Comparison (named functions + operators) ----
+    struct CmpEntry {
+        const char *name;
+        scalar_function_t fn;
+    };
+    const std::vector<CmpEntry> named_cmps = {
+        {"temporal_eq", TemporalFunctions::Temporal_eq},
+        {"temporal_ne", TemporalFunctions::Temporal_ne},
+        {"temporal_lt", TemporalFunctions::Temporal_lt},
+        {"temporal_le", TemporalFunctions::Temporal_le},
+        {"temporal_gt", TemporalFunctions::Temporal_gt},
+        {"temporal_ge", TemporalFunctions::Temporal_ge},
+    };
+    for (const auto &c : named_cmps) {
+        loader.RegisterFunction(ScalarFunction(
+            c.name, {TGEOM, TGEOM}, LogicalType::BOOLEAN, c.fn));
+    }
+    loader.RegisterFunction(ScalarFunction(
+        "temporal_cmp", {TGEOM, TGEOM}, LogicalType::INTEGER,
+        TemporalFunctions::Temporal_cmp));
+
+    // Operator forms — mirror the registrations tgeompoint.cpp does.
+    const std::vector<CmpEntry> op_cmps = {
+        {"=",  TemporalFunctions::Temporal_eq},
+        {"<>", TemporalFunctions::Temporal_ne},
+        {"<",  TemporalFunctions::Temporal_lt},
+        {"<=", TemporalFunctions::Temporal_le},
+        {">",  TemporalFunctions::Temporal_gt},
+        {">=", TemporalFunctions::Temporal_ge},
+    };
+    for (const auto &c : op_cmps) {
+        loader.RegisterFunction(ScalarFunction(
+            c.name, {TGEOM, TGEOM}, LogicalType::BOOLEAN, c.fn));
+    }
 }
 
 void TGeometryTypes::RegisterTypes(ExtensionLoader &loader) {

--- a/src/geo/tgeometry_ops.cpp
+++ b/src/geo/tgeometry_ops.cpp
@@ -7,6 +7,7 @@
 #include "common.hpp"
 #include "geo/tgeometry.hpp"
 #include "geo/tgeometry_ops.hpp"
+#include "geo/tgeompoint.hpp"
 #include "geo/stbox.hpp"
 #include "temporal/span.hpp"
 #include "temporal/temporal.hpp"
@@ -371,6 +372,146 @@ void TgeoTgeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
         });
 }
 
+// ====================================================================
+// Spatial functions — SRID accessor, setSRID, transform, expand*,
+// round, traversedArea, centroid, convexHull, and the
+// tgeometry <-> tgeompoint coercions.
+// ====================================================================
+
+inline string_t StboxToBlob(Vector &result, STBox *box) {
+    string_t out = StringVector::AddStringOrBlob(
+        result, reinterpret_cast<const char *>(box), sizeof(STBox));
+    free(box);
+    return out;
+}
+
+inline string_t GeoToBlobAsHex(Vector &result, GSERIALIZED *gs) {
+    if (!gs) return string_t();
+    size_t sz = 0;
+    uint8_t *ewkb = geo_as_ewkb(gs, NULL, &sz);
+    string_t out = StringVector::AddStringOrBlob(
+        result, reinterpret_cast<const char *>(ewkb), sz);
+    free(ewkb);
+    free(gs);
+    return out;
+}
+
+void TspatialSridExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, int32_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) {
+            Temporal *t = DecodeTemporalCopy(blob);
+            int32_t srid = tspatial_srid(t);
+            free(t);
+            return srid;
+        });
+}
+
+void TspatialSetSridExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::Execute<string_t, int32_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, int32_t srid) {
+            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *r = tspatial_set_srid(t, srid);
+            free(t);
+            if (!r) throw InvalidInputException("setSRID failed");
+            return TemporalToBlob(result, r);
+        });
+}
+
+void TspatialTransformExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::Execute<string_t, int32_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, int32_t srid) {
+            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *r = tspatial_transform(t, srid);
+            free(t);
+            if (!r) throw InvalidInputException("transform failed");
+            return TemporalToBlob(result, r);
+        });
+}
+
+void TspatialToStboxExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) {
+            Temporal *t = DecodeTemporalCopy(blob);
+            STBox *box = tspatial_to_stbox(t);
+            free(t);
+            return StboxToBlob(result, box);
+        });
+}
+
+void TgeometryToTgeompointExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) {
+            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *r = tgeometry_to_tgeompoint(t);
+            free(t);
+            if (!r) throw InvalidInputException("tgeompoint(tgeometry) failed");
+            return TemporalToBlob(result, r);
+        });
+}
+
+void TgeompointToTgeometryExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) {
+            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *r = tgeompoint_to_tgeometry(t);
+            free(t);
+            if (!r) throw InvalidInputException("tgeometry(tgeompoint) failed");
+            return TemporalToBlob(result, r);
+        });
+}
+
+void TgeoCentroidExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) -> string_t {
+            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *r = tgeo_centroid(t);
+            free(t);
+            if (!r) throw InvalidInputException("centroid failed");
+            return TemporalToBlob(result, r);
+        });
+}
+
+void TgeoConvexHullExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t blob) -> string_t {
+            Temporal *t = DecodeTemporalCopy(blob);
+            GSERIALIZED *gs = tgeo_convex_hull(t);
+            free(t);
+            return GeoToBlobAsHex(result, gs);
+        });
+}
+
+void TgeoTraversedAreaExec(DataChunk &args, ExpressionState &, Vector &result) {
+    const idx_t cnt = args.size();
+    if (args.ColumnCount() >= 2) {
+        BinaryExecutor::Execute<string_t, bool, string_t>(
+            args.data[0], args.data[1], result, cnt,
+            [&](string_t blob, bool unary_union) -> string_t {
+                Temporal *t = DecodeTemporalCopy(blob);
+                GSERIALIZED *gs = tgeo_traversed_area(t, unary_union);
+                free(t);
+                return GeoToBlobAsHex(result, gs);
+            });
+    } else {
+        UnaryExecutor::Execute<string_t, string_t>(
+            args.data[0], result, cnt,
+            [&](string_t blob) -> string_t {
+                Temporal *t = DecodeTemporalCopy(blob);
+                GSERIALIZED *gs = tgeo_traversed_area(t, false);
+                free(t);
+                return GeoToBlobAsHex(result, gs);
+            });
+    }
+}
+
 } // namespace
 
 void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
@@ -606,6 +747,44 @@ void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
         {TGEOM, GEOM}, TFLOAT, TgeoGeoDistanceExec<tdistance_tgeo_geo>));
     loader.RegisterFunction(ScalarFunction("<->",
         {TGEOM, TGEOM}, TFLOAT, TgeoTgeoDistanceExec<tdistance_tgeo_tgeo>));
+
+    // -----------------------------------------------------------------
+    // Spatial functions: SRID accessor / setter, projection / transform,
+    // stbox cast, tgeometry <-> tgeompoint coercions, round, centroid,
+    // convexHull, traversedArea.
+    // -----------------------------------------------------------------
+    const LogicalType INT32 = LogicalType::INTEGER;
+
+    loader.RegisterFunction(ScalarFunction(
+        "SRID", {TGEOM}, INT32, TspatialSridExec));
+    loader.RegisterFunction(ScalarFunction(
+        "setSRID", {TGEOM, INT32}, TGEOM, TspatialSetSridExec));
+    loader.RegisterFunction(ScalarFunction(
+        "transform", {TGEOM, INT32}, TGEOM, TspatialTransformExec));
+
+    // tgeometry → stbox is a cast in the SQL surface; expose it as a
+    // function for now to keep the implementation a single template.
+    loader.RegisterFunction(ScalarFunction(
+        "stbox", {TGEOM}, STBOX, TspatialToStboxExec));
+
+    // tgeometry <-> tgeompoint coercion functions.
+    loader.RegisterFunction(ScalarFunction(
+        "tgeompoint", {TGEOM}, TgeompointType::TGEOMPOINT(),
+        TgeometryToTgeompointExec));
+    loader.RegisterFunction(ScalarFunction(
+        "tgeometry", {TgeompointType::TGEOMPOINT()}, TGEOM,
+        TgeompointToTgeometryExec));
+
+    // Centroid / convexHull / traversedArea — produce a non-temporal
+    // geometry summary of the trajectory.
+    loader.RegisterFunction(ScalarFunction(
+        "centroid", {TGEOM}, TGEOM, TgeoCentroidExec));
+    loader.RegisterFunction(ScalarFunction(
+        "convexHull", {TGEOM}, GEOM, TgeoConvexHullExec));
+    loader.RegisterFunction(ScalarFunction(
+        "traversedArea", {TGEOM}, GEOM, TgeoTraversedAreaExec));
+    loader.RegisterFunction(ScalarFunction(
+        "traversedArea", {TGEOM, LogicalType::BOOLEAN}, GEOM, TgeoTraversedAreaExec));
 }
 
 } // namespace duckdb

--- a/src/geo/tgeometry_ops.cpp
+++ b/src/geo/tgeometry_ops.cpp
@@ -1,0 +1,611 @@
+// Cross-type predicate registrations for tgeometry. The MEOS C functions
+// dispatched here all take Temporal * (subtype-agnostic), so this file is
+// purely registration-and-glue; the heavy lifting stays in libmeos.
+
+#include "meos_wrapper_simple.hpp"
+
+#include "common.hpp"
+#include "geo/tgeometry.hpp"
+#include "geo/tgeometry_ops.hpp"
+#include "geo/stbox.hpp"
+#include "temporal/span.hpp"
+#include "temporal/temporal.hpp"
+#include "geo_util.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "spatial/spatial_types.hpp"
+
+extern "C" {
+    #include <meos.h>
+    #include <meos_geo.h>
+    #include <meos_internal.h>
+    #include <meos_internal_geo.h>
+}
+
+namespace duckdb {
+
+namespace {
+
+// ====================================================================
+// Argument-decoding helpers
+// ====================================================================
+
+inline Temporal *DecodeTemporalCopy(string_t blob) {
+    size_t sz = blob.GetSize();
+    Temporal *t = (Temporal *) malloc(sz);
+    memcpy(t, blob.GetData(), sz);
+    return t;
+}
+
+inline STBox *DecodeStboxCopy(string_t blob) {
+    STBox *b = (STBox *) malloc(sizeof(STBox));
+    memcpy(b, blob.GetData(), sizeof(STBox));
+    return b;
+}
+
+inline Span *DecodeSpanCopy(string_t blob) {
+    Span *s = (Span *) malloc(sizeof(Span));
+    memcpy(s, blob.GetData(), sizeof(Span));
+    return s;
+}
+
+// ====================================================================
+// Bool-returning binary BLOB×BLOB executors (boxops + posops)
+// ====================================================================
+
+template <bool (*FN)(const Temporal *, const STBox *)>
+void TspatialStboxBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t b_blob) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            STBox *b = DecodeStboxCopy(b_blob);
+            bool r = FN(t, b);
+            free(t); free(b);
+            return r;
+        });
+}
+
+template <bool (*FN)(const Temporal *, const STBox *)>
+void StboxTspatialBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
+    // The MEOS function takes (Temporal, STBox); for the (STBox, Temporal)
+    // SQL signature we just swap argument order — these predicates are
+    // commutative for box-only checks (overlaps, same, adjacent) and the
+    // non-commutative pairs (contains/contained) are already defined as a
+    // distinct MEOS pair.
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t b_blob, string_t t_blob) {
+            STBox *b = DecodeStboxCopy(b_blob);
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            bool r = FN(t, b);
+            free(t); free(b);
+            return r;
+        });
+}
+
+template <bool (*FN)(const Temporal *, const Temporal *)>
+void TspatialTspatialBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a, string_t b) {
+            Temporal *t1 = DecodeTemporalCopy(a);
+            Temporal *t2 = DecodeTemporalCopy(b);
+            bool r = FN(t1, t2);
+            free(t1); free(t2);
+            return r;
+        });
+}
+
+template <bool (*FN)(const Temporal *, const Span *)>
+void TemporalTstzspanBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t s_blob) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            Span *s = DecodeSpanCopy(s_blob);
+            bool r = FN(t, s);
+            free(t); free(s);
+            return r;
+        });
+}
+
+template <bool (*FN)(const Span *, const Temporal *)>
+void TstzspanTemporalBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t s_blob, string_t t_blob) {
+            Span *s = DecodeSpanCopy(s_blob);
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            bool r = FN(s, t);
+            free(t); free(s);
+            return r;
+        });
+}
+
+// ====================================================================
+// Spatial-relation int→bool helpers (e/a contains/disjoint/intersects/
+// touches and the dwithin family that adds a distance argument)
+// ====================================================================
+
+template <int (*FN)(const Temporal *, const GSERIALIZED *)>
+void TgeoGeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            int r = FN(t, gs);
+            free(t); free(gs);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+template <int (*FN)(const GSERIALIZED *, const Temporal *)>
+void GeoTgeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            int r = FN(gs, t);
+            free(t); free(gs);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+template <int (*FN)(const Temporal *, const Temporal *)>
+void TgeoTgeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) {
+            Temporal *t1 = DecodeTemporalCopy(a);
+            Temporal *t2 = DecodeTemporalCopy(b);
+            int r = FN(t1, t2);
+            free(t1); free(t2);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+template <int (*FN)(const Temporal *, const GSERIALIZED *, double)>
+void TgeoGeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, double dist, ValidityMask &mask, idx_t idx) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            int r = FN(t, gs, dist);
+            free(t); free(gs);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+template <int (*FN)(const GSERIALIZED *, const Temporal *, double)>
+void GeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            int r = FN(gs, t, dist);
+            free(t); free(gs);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+// dwithin's (GEOM, TGEOM, dist) signature reuses the (TGEOM, GEOM, dist)
+// MEOS function with arguments swapped — distance is symmetric.
+template <int (*FN)(const Temporal *, const GSERIALIZED *, double)>
+void GeoTgeoDistIntExec_FromTgeoGeo(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            int r = FN(t, gs, dist);
+            free(t); free(gs);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+template <int (*FN)(const Temporal *, const Temporal *, double)>
+void TgeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t a, string_t b, double dist, ValidityMask &mask, idx_t idx) {
+            Temporal *t1 = DecodeTemporalCopy(a);
+            Temporal *t2 = DecodeTemporalCopy(b);
+            int r = FN(t1, t2, dist);
+            free(t1); free(t2);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+// ====================================================================
+// Temporal-relation Temporal→Temporal helpers — `restr=false`,
+// `atvalue=false` are the SQL defaults that produce a temporal value
+// covering the whole input duration.
+// ====================================================================
+
+inline string_t TemporalToBlob(Vector &result, Temporal *t) {
+    size_t sz = temporal_mem_size(t);
+    string_t out = StringVector::AddStringOrBlob(
+        result, reinterpret_cast<const char *>(t), sz);
+    free(t);
+    return out;
+}
+
+template <Temporal *(*FN)(const Temporal *, const GSERIALIZED *, bool, bool)>
+void TgeoGeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            Temporal *r = FN(t, gs, false, false);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <Temporal *(*FN)(const GSERIALIZED *, const Temporal *, bool, bool)>
+void GeoTgeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            Temporal *r = FN(gs, t, false, false);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <Temporal *(*FN)(const Temporal *, const Temporal *, bool, bool)>
+void TgeoTgeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t1 = DecodeTemporalCopy(a);
+            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *r = FN(t1, t2, false, false);
+            free(t1); free(t2);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+// tDwithin variants take an extra distance argument.
+template <Temporal *(*FN)(const Temporal *, const GSERIALIZED *, double, bool, bool)>
+void TgeoGeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, double dist, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            Temporal *r = FN(t, gs, dist, false, false);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <Temporal *(*FN)(const GSERIALIZED *, const Temporal *, double, bool, bool)>
+void GeoTgeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            Temporal *r = FN(gs, t, dist, false, false);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <Temporal *(*FN)(const Temporal *, const Temporal *, double, bool, bool)>
+void TgeoTgeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](string_t a, string_t b, double dist, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t1 = DecodeTemporalCopy(a);
+            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *r = FN(t1, t2, dist, false, false);
+            free(t1); free(t2);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+// ====================================================================
+// Distance helpers — `tdistance(...)` and `<->`
+// ====================================================================
+
+template <Temporal *(*FN)(const Temporal *, const GSERIALIZED *)>
+void TgeoGeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = DecodeTemporalCopy(t_blob);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            Temporal *r = FN(t, gs);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+template <Temporal *(*FN)(const Temporal *, const Temporal *)>
+void TgeoTgeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t1 = DecodeTemporalCopy(a);
+            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *r = FN(t1, t2);
+            free(t1); free(t2);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+} // namespace
+
+void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
+    const LogicalType TGEOM = TGeometryTypes::TGEOMETRY();
+    const LogicalType GEOM  = GeoTypes::GEOMETRY();
+    const LogicalType STBOX = StboxType::STBOX();
+    const LogicalType TSTZSPAN = SpanTypes::TSTZSPAN();
+    const LogicalType BOOL = LogicalType::BOOLEAN;
+    const LogicalType DBL = LogicalType::DOUBLE;
+    const LogicalType TFLOAT = TemporalTypes::TFLOAT();
+
+    // -----------------------------------------------------------------
+    // Box predicates: temporal_(overlaps|contains|contained|same|adjacent)
+    // and the equivalent operators (&&, @>, <@, ~=, -|-).
+    // -----------------------------------------------------------------
+    struct BoxOp {
+        const char *fn_name;
+        const char *op_name;
+        bool (*tspatial_stbox)(const Temporal *, const STBox *);
+        bool (*tspatial_tspatial)(const Temporal *, const Temporal *);
+        bool (*temporal_tstzspan)(const Temporal *, const Span *);
+        bool (*tstzspan_temporal)(const Span *, const Temporal *);
+    };
+    const BoxOp box_ops[] = {
+        {"temporal_overlaps", "&&",
+         overlaps_tspatial_stbox, overlaps_tspatial_tspatial,
+         overlaps_temporal_tstzspan, overlaps_tstzspan_temporal},
+        {"temporal_contains", "@>",
+         contains_tspatial_stbox, contains_tspatial_tspatial,
+         contains_temporal_tstzspan, contains_tstzspan_temporal},
+        {"temporal_contained", "<@",
+         contained_tspatial_stbox, contained_tspatial_tspatial,
+         contained_temporal_tstzspan, contained_tstzspan_temporal},
+        {"temporal_same",     "~=",
+         same_tspatial_stbox, same_tspatial_tspatial,
+         same_temporal_tstzspan, same_tstzspan_temporal},
+        {"temporal_adjacent", "-|-",
+         adjacent_tspatial_stbox, adjacent_tspatial_tspatial,
+         adjacent_temporal_tstzspan, adjacent_tstzspan_temporal},
+    };
+
+    // Build per-overload registrations through static dispatch on the
+    // function pointer values supplied above. We can't bind those to
+    // template parameters at runtime, so we register each predicate
+    // explicitly below using the macros.
+#define BOX_REG(NAME, OP, F_TSPAT_STBOX, F_TSPAT_TSPAT, F_TEMP_TSTZSPAN, F_TSTZSPAN_TEMP) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, STBOX},   BOOL, \
+            TspatialStboxBoolExec<F_TSPAT_STBOX>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {STBOX, TGEOM},   BOOL, \
+            StboxTspatialBoolExec<F_TSPAT_STBOX>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TGEOM},   BOOL, \
+            TspatialTspatialBoolExec<F_TSPAT_TSPAT>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TSTZSPAN},BOOL, \
+            TemporalTstzspanBoolExec<F_TEMP_TSTZSPAN>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TSTZSPAN, TGEOM},BOOL, \
+            TstzspanTemporalBoolExec<F_TSTZSPAN_TEMP>)); \
+        loader.RegisterFunction(ScalarFunction(OP,   {TGEOM, STBOX},   BOOL, \
+            TspatialStboxBoolExec<F_TSPAT_STBOX>)); \
+        loader.RegisterFunction(ScalarFunction(OP,   {STBOX, TGEOM},   BOOL, \
+            StboxTspatialBoolExec<F_TSPAT_STBOX>)); \
+        loader.RegisterFunction(ScalarFunction(OP,   {TGEOM, TGEOM},   BOOL, \
+            TspatialTspatialBoolExec<F_TSPAT_TSPAT>)); \
+        loader.RegisterFunction(ScalarFunction(OP,   {TGEOM, TSTZSPAN},BOOL, \
+            TemporalTstzspanBoolExec<F_TEMP_TSTZSPAN>)); \
+        loader.RegisterFunction(ScalarFunction(OP,   {TSTZSPAN, TGEOM},BOOL, \
+            TstzspanTemporalBoolExec<F_TSTZSPAN_TEMP>)); \
+    } while (0)
+
+    BOX_REG("temporal_overlaps", "&&",
+            overlaps_tspatial_stbox, overlaps_tspatial_tspatial,
+            overlaps_temporal_tstzspan, overlaps_tstzspan_temporal);
+    BOX_REG("temporal_contains", "@>",
+            contains_tspatial_stbox, contains_tspatial_tspatial,
+            contains_temporal_tstzspan, contains_tstzspan_temporal);
+    BOX_REG("temporal_contained", "<@",
+            contained_tspatial_stbox, contained_tspatial_tspatial,
+            contained_temporal_tstzspan, contained_tstzspan_temporal);
+    BOX_REG("temporal_same", "~=",
+            same_tspatial_stbox, same_tspatial_tspatial,
+            same_temporal_tstzspan, same_tstzspan_temporal);
+    BOX_REG("temporal_adjacent", "-|-",
+            adjacent_tspatial_stbox, adjacent_tspatial_tspatial,
+            adjacent_temporal_tstzspan, adjacent_tstzspan_temporal);
+#undef BOX_REG
+
+    // -----------------------------------------------------------------
+    // Position predicates (left / right / below / above / front / back /
+    // before / after and their over-* variants). Only tgeometry × stbox
+    // and tgeometry × tgeometry — there are no time-axis positions for
+    // a tstzspan input that aren't already covered by the time-domain
+    // predicates wired in `temporal.cpp` for arbitrary temporals.
+    // -----------------------------------------------------------------
+#define POS_REG(NAME, F_TSPAT_STBOX, F_TSPAT_TSPAT) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, STBOX}, BOOL, \
+            TspatialStboxBoolExec<F_TSPAT_STBOX>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {STBOX, TGEOM}, BOOL, \
+            StboxTspatialBoolExec<F_TSPAT_STBOX>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TGEOM}, BOOL, \
+            TspatialTspatialBoolExec<F_TSPAT_TSPAT>)); \
+    } while (0)
+
+    POS_REG("temporal_left",       left_tspatial_stbox,       left_tspatial_tspatial);
+    POS_REG("temporal_overleft",   overleft_tspatial_stbox,   overleft_tspatial_tspatial);
+    POS_REG("temporal_right",      right_tspatial_stbox,      right_tspatial_tspatial);
+    POS_REG("temporal_overright",  overright_tspatial_stbox,  overright_tspatial_tspatial);
+    POS_REG("temporal_below",      below_tspatial_stbox,      below_tspatial_tspatial);
+    POS_REG("temporal_overbelow",  overbelow_tspatial_stbox,  overbelow_tspatial_tspatial);
+    POS_REG("temporal_above",      above_tspatial_stbox,      above_tspatial_tspatial);
+    POS_REG("temporal_overabove",  overabove_tspatial_stbox,  overabove_tspatial_tspatial);
+    POS_REG("temporal_front",      front_tspatial_stbox,      front_tspatial_tspatial);
+    POS_REG("temporal_overfront",  overfront_tspatial_stbox,  overfront_tspatial_tspatial);
+    POS_REG("temporal_back",       back_tspatial_stbox,       back_tspatial_tspatial);
+    POS_REG("temporal_overback",   overback_tspatial_stbox,   overback_tspatial_tspatial);
+    POS_REG("temporal_before",     before_tspatial_stbox,     before_tspatial_tspatial);
+    POS_REG("temporal_overbefore", overbefore_tspatial_stbox, overbefore_tspatial_tspatial);
+    POS_REG("temporal_after",      after_tspatial_stbox,      after_tspatial_tspatial);
+    POS_REG("temporal_overafter",  overafter_tspatial_stbox,  overafter_tspatial_tspatial);
+#undef POS_REG
+
+    // Time-axis position predicates also accept a tstzspan operand on the
+    // non-tspatial side — these reuse the generic temporal_* MEOS exports
+    // rather than the tspatial_* ones since they don't touch the spatial
+    // axes.
+#define TIME_POS_REG(NAME, F_TEMP_TSTZSPAN, F_TSTZSPAN_TEMP) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TSTZSPAN}, BOOL, \
+            TemporalTstzspanBoolExec<F_TEMP_TSTZSPAN>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TSTZSPAN, TGEOM}, BOOL, \
+            TstzspanTemporalBoolExec<F_TSTZSPAN_TEMP>)); \
+    } while (0)
+    TIME_POS_REG("temporal_before",     before_temporal_tstzspan,     before_tstzspan_temporal);
+    TIME_POS_REG("temporal_overbefore", overbefore_temporal_tstzspan, overbefore_tstzspan_temporal);
+    TIME_POS_REG("temporal_after",      after_temporal_tstzspan,      after_tstzspan_temporal);
+    TIME_POS_REG("temporal_overafter",  overafter_temporal_tstzspan,  overafter_tstzspan_temporal);
+#undef TIME_POS_REG
+
+    // -----------------------------------------------------------------
+    // Spatial relationships — ever (e*) and always (a*) versions for
+    // contains / disjoint / intersects / touches / dwithin.
+    // -----------------------------------------------------------------
+#define EA_REG_2(NAME, F_TGEO_GEO, F_GEO_TGEO, F_TGEO_TGEO) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {GEOM, TGEOM}, BOOL, \
+            GeoTgeoIntExec<F_GEO_TGEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, GEOM}, BOOL, \
+            TgeoGeoIntExec<F_TGEO_GEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TGEOM}, BOOL, \
+            TgeoTgeoIntExec<F_TGEO_TGEO>)); \
+    } while (0)
+    // disjoint / intersects / touches don't have a (geo, tgeo) MEOS export
+    // because they are commutative — eDisjoint(g, t) is just eDisjoint(t, g).
+#define EA_REG_2_COMMUT(NAME, F_TGEO_GEO, F_TGEO_TGEO) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {GEOM, TGEOM}, BOOL, \
+            TgeoGeoIntExec<F_TGEO_GEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, GEOM}, BOOL, \
+            TgeoGeoIntExec<F_TGEO_GEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TGEOM}, BOOL, \
+            TgeoTgeoIntExec<F_TGEO_TGEO>)); \
+    } while (0)
+
+    // contains is non-commutative — uses both directions.
+    EA_REG_2("eContains", econtains_tgeo_geo, econtains_geo_tgeo, econtains_tgeo_tgeo);
+    EA_REG_2("aContains", acontains_tgeo_geo, acontains_geo_tgeo, acontains_tgeo_tgeo);
+
+    EA_REG_2_COMMUT("eDisjoint",   edisjoint_tgeo_geo,   edisjoint_tgeo_tgeo);
+    EA_REG_2_COMMUT("aDisjoint",   adisjoint_tgeo_geo,   adisjoint_tgeo_tgeo);
+    EA_REG_2_COMMUT("eIntersects", eintersects_tgeo_geo, eintersects_tgeo_tgeo);
+    EA_REG_2_COMMUT("aIntersects", aintersects_tgeo_geo, aintersects_tgeo_tgeo);
+    EA_REG_2_COMMUT("eTouches",    etouches_tgeo_geo,    etouches_tgeo_tgeo);
+    EA_REG_2_COMMUT("aTouches",    atouches_tgeo_geo,    atouches_tgeo_tgeo);
+#undef EA_REG_2
+#undef EA_REG_2_COMMUT
+
+    // dwithin is symmetric in its first two arguments; MEOS only exports
+    // the (Temporal *, GSERIALIZED *) flavour, so the (geo, tgeo, dist)
+    // SQL form reuses it with arguments swapped at the call site.
+#define EA_DWITHIN_REG(NAME, F_TGEO_GEO, F_TGEO_TGEO) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {GEOM, TGEOM, DBL}, BOOL, \
+            GeoTgeoDistIntExec_FromTgeoGeo<F_TGEO_GEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, GEOM, DBL}, BOOL, \
+            TgeoGeoDistIntExec<F_TGEO_GEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TGEOM, DBL}, BOOL, \
+            TgeoTgeoDistIntExec<F_TGEO_TGEO>)); \
+    } while (0)
+    EA_DWITHIN_REG("eDwithin", edwithin_tgeo_geo, edwithin_tgeo_tgeo);
+    EA_DWITHIN_REG("aDwithin", adwithin_tgeo_geo, adwithin_tgeo_tgeo);
+#undef EA_DWITHIN_REG
+
+    // -----------------------------------------------------------------
+    // Temporal spatial relationships (`tContains`, `tDisjoint`,
+    // `tIntersects`, `tTouches`, `tDwithin`) — return a temporal
+    // boolean whose truth value tracks the relation over time.
+    // -----------------------------------------------------------------
+#define TREL_REG(NAME, F_TGEO_GEO, F_GEO_TGEO, F_TGEO_TGEO) \
+    do { \
+        loader.RegisterFunction(ScalarFunction(NAME, {GEOM, TGEOM}, TemporalTypes::TBOOL(), \
+            GeoTgeoTempExec<F_GEO_TGEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, GEOM}, TemporalTypes::TBOOL(), \
+            TgeoGeoTempExec<F_TGEO_GEO>)); \
+        loader.RegisterFunction(ScalarFunction(NAME, {TGEOM, TGEOM}, TemporalTypes::TBOOL(), \
+            TgeoTgeoTempExec<F_TGEO_TGEO>)); \
+    } while (0)
+
+    TREL_REG("tContains",   tcontains_tgeo_geo,   tcontains_geo_tgeo,   tcontains_tgeo_tgeo);
+    TREL_REG("tDisjoint",   tdisjoint_tgeo_geo,   tdisjoint_geo_tgeo,   tdisjoint_tgeo_tgeo);
+    TREL_REG("tIntersects", tintersects_tgeo_geo, tintersects_geo_tgeo, tintersects_tgeo_tgeo);
+    TREL_REG("tTouches",    ttouches_tgeo_geo,    ttouches_geo_tgeo,    ttouches_tgeo_tgeo);
+#undef TREL_REG
+
+    // tDwithin takes the extra distance argument.
+    loader.RegisterFunction(ScalarFunction("tDwithin",
+        {GEOM, TGEOM, DBL}, TemporalTypes::TBOOL(),
+        GeoTgeoDistTempExec<tdwithin_geo_tgeo>));
+    loader.RegisterFunction(ScalarFunction("tDwithin",
+        {TGEOM, GEOM, DBL}, TemporalTypes::TBOOL(),
+        TgeoGeoDistTempExec<tdwithin_tgeo_geo>));
+    loader.RegisterFunction(ScalarFunction("tDwithin",
+        {TGEOM, TGEOM, DBL}, TemporalTypes::TBOOL(),
+        TgeoTgeoDistTempExec<tdwithin_tgeo_tgeo>));
+
+    // -----------------------------------------------------------------
+    // Distance — `tdistance(...)` and `<->`.
+    // -----------------------------------------------------------------
+    loader.RegisterFunction(ScalarFunction("tdistance",
+        {TGEOM, GEOM}, TFLOAT, TgeoGeoDistanceExec<tdistance_tgeo_geo>));
+    loader.RegisterFunction(ScalarFunction("tdistance",
+        {TGEOM, TGEOM}, TFLOAT, TgeoTgeoDistanceExec<tdistance_tgeo_tgeo>));
+    loader.RegisterFunction(ScalarFunction("<->",
+        {TGEOM, GEOM}, TFLOAT, TgeoGeoDistanceExec<tdistance_tgeo_geo>));
+    loader.RegisterFunction(ScalarFunction("<->",
+        {TGEOM, TGEOM}, TFLOAT, TgeoTgeoDistanceExec<tdistance_tgeo_tgeo>));
+}
+
+} // namespace duckdb

--- a/src/geo/tgeometry_ops.cpp
+++ b/src/geo/tgeometry_ops.cpp
@@ -12,6 +12,7 @@
 #include "temporal/span.hpp"
 #include "temporal/temporal.hpp"
 #include "geo_util.hpp"
+#include "time_util.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/scalar_function.hpp"
@@ -785,6 +786,192 @@ void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
         "traversedArea", {TGEOM}, GEOM, TgeoTraversedAreaExec));
     loader.RegisterFunction(ScalarFunction(
         "traversedArea", {TGEOM, LogicalType::BOOLEAN}, GEOM, TgeoTraversedAreaExec));
+
+    // -----------------------------------------------------------------
+    // Tile / box emitters — spaceBoxes(tgeometry, x, y, z) and
+    // spaceTimeBoxes(tgeometry, x, y, z, interval). Both return
+    // LIST<stbox> with the bounding boxes that cover the input.
+    // -----------------------------------------------------------------
+    auto emit_stbox_list = [](Vector &result, idx_t row_idx, STBox *boxes, int count,
+                              idx_t &total_offset, list_entry_t *list_entries,
+                              Vector &child_vector, ValidityMask &result_validity) {
+        if (!boxes || count <= 0) {
+            if (boxes) free(boxes);
+            result_validity.SetInvalid(row_idx);
+            return;
+        }
+        ListVector::SetListSize(result, total_offset + count);
+        list_entries[row_idx] = list_entry_t{total_offset, static_cast<uint64_t>(count)};
+        auto *child_data = FlatVector::GetData<string_t>(child_vector);
+        const size_t stbox_bytes = sizeof(STBox);
+        for (int j = 0; j < count; ++j) {
+            child_data[total_offset + j] = StringVector::AddStringOrBlob(
+                child_vector, reinterpret_cast<const char *>(&boxes[j]), stbox_bytes);
+        }
+        free(boxes);
+        total_offset += count;
+    };
+
+    auto space_boxes_exec = [emit_stbox_list]
+        (DataChunk &args, ExpressionState &, Vector &result) {
+        const idx_t row_count = args.size();
+        for (idx_t c = 0; c < args.ColumnCount(); ++c) args.data[c].Flatten(row_count);
+
+        auto &result_validity = FlatVector::Validity(result);
+        auto list_entries = FlatVector::GetData<list_entry_t>(result);
+        auto &child_vector = ListVector::GetEntry(result);
+        child_vector.SetVectorType(VectorType::FLAT_VECTOR);
+        ListVector::Reserve(result, row_count);
+        idx_t total_offset = 0;
+
+        auto t_data = FlatVector::GetData<string_t>(args.data[0]);
+        auto x_data = FlatVector::GetData<double>(args.data[1]);
+        auto y_data = FlatVector::GetData<double>(args.data[2]);
+        auto z_data = FlatVector::GetData<double>(args.data[3]);
+        for (idx_t i = 0; i < row_count; ++i) {
+            if (FlatVector::IsNull(args.data[0], i) || FlatVector::IsNull(args.data[1], i) ||
+                FlatVector::IsNull(args.data[2], i) || FlatVector::IsNull(args.data[3], i)) {
+                result_validity.SetInvalid(i);
+                continue;
+            }
+            Temporal *t = DecodeTemporalCopy(t_data[i]);
+            GSERIALIZED *origin = geompoint_make3dz(0, 0.0, 0.0, 0.0);
+            int count = 0;
+            STBox *boxes = tgeo_space_boxes(
+                t, x_data[i], y_data[i], z_data[i], origin,
+                /*bitmatrix=*/true, /*border_inc=*/true, &count);
+            free(t); free(origin);
+            emit_stbox_list(result, i, boxes, count, total_offset, list_entries,
+                            child_vector, result_validity);
+        }
+    };
+
+    LogicalType list_stbox = LogicalType::LIST(STBOX);
+    loader.RegisterFunction(ScalarFunction(
+        "spaceBoxes", {TGEOM, DBL, DBL, DBL}, list_stbox, space_boxes_exec));
+
+    auto space_time_boxes_exec = [emit_stbox_list]
+        (DataChunk &args, ExpressionState &, Vector &result) {
+        const idx_t row_count = args.size();
+        for (idx_t c = 0; c < args.ColumnCount(); ++c) args.data[c].Flatten(row_count);
+
+        auto &result_validity = FlatVector::Validity(result);
+        auto list_entries = FlatVector::GetData<list_entry_t>(result);
+        auto &child_vector = ListVector::GetEntry(result);
+        child_vector.SetVectorType(VectorType::FLAT_VECTOR);
+        ListVector::Reserve(result, row_count);
+        idx_t total_offset = 0;
+
+        auto t_data = FlatVector::GetData<string_t>(args.data[0]);
+        auto x_data = FlatVector::GetData<double>(args.data[1]);
+        auto y_data = FlatVector::GetData<double>(args.data[2]);
+        auto z_data = FlatVector::GetData<double>(args.data[3]);
+        auto dur_data = FlatVector::GetData<interval_t>(args.data[4]);
+        for (idx_t i = 0; i < row_count; ++i) {
+            if (FlatVector::IsNull(args.data[0], i) || FlatVector::IsNull(args.data[1], i) ||
+                FlatVector::IsNull(args.data[2], i) || FlatVector::IsNull(args.data[3], i) ||
+                FlatVector::IsNull(args.data[4], i)) {
+                result_validity.SetInvalid(i);
+                continue;
+            }
+            Temporal *t = DecodeTemporalCopy(t_data[i]);
+            GSERIALIZED *origin = geompoint_make3dz(0, 0.0, 0.0, 0.0);
+            MeosInterval iv = IntervaltToInterval(dur_data[i]);
+            constexpr int64_t DEFAULT_TIME_ORIGIN_MEOS = 2LL * 86400LL * 1000000LL;
+            int count = 0;
+            STBox *boxes = tgeo_space_time_boxes(
+                t, x_data[i], y_data[i], z_data[i], &iv, origin,
+                (TimestampTz) DEFAULT_TIME_ORIGIN_MEOS,
+                /*bitmatrix=*/true, /*border_inc=*/true, &count);
+            free(t); free(origin);
+            emit_stbox_list(result, i, boxes, count, total_offset, list_entries,
+                            child_vector, result_validity);
+        }
+    };
+
+    loader.RegisterFunction(ScalarFunction(
+        "spaceTimeBoxes",
+        {TGEOM, DBL, DBL, DBL, LogicalType::INTERVAL},
+        list_stbox, space_time_boxes_exec));
+
+    // -----------------------------------------------------------------
+    // Analytics — Douglas-Peucker / max-distance / min-distance / min
+    // time-delta simplification. All produce a thinned tgeometry.
+    // -----------------------------------------------------------------
+    auto simplify_double_exec_factory = [](
+        Temporal *(*FN)(const Temporal *, double)) {
+        return [FN](DataChunk &args, ExpressionState &, Vector &result) {
+            BinaryExecutor::Execute<string_t, double, string_t>(
+                args.data[0], args.data[1], result, args.size(),
+                [&](string_t blob, double eps) {
+                    Temporal *t = DecodeTemporalCopy(blob);
+                    Temporal *r = FN(t, eps);
+                    free(t);
+                    if (!r) throw InvalidInputException("simplify failed");
+                    return TemporalToBlob(result, r);
+                });
+        };
+    };
+
+    auto simplify_double_bool_exec_factory = [](
+        Temporal *(*FN)(const Temporal *, double, bool)) {
+        return [FN](DataChunk &args, ExpressionState &, Vector &result) {
+            const idx_t cnt = args.size();
+            args.data[0].Flatten(cnt); args.data[1].Flatten(cnt);
+            const bool has_third = args.ColumnCount() >= 3;
+            if (has_third) args.data[2].Flatten(cnt);
+            auto blob_data = FlatVector::GetData<string_t>(args.data[0]);
+            auto eps_data  = FlatVector::GetData<double>(args.data[1]);
+            for (idx_t i = 0; i < cnt; ++i) {
+                if (FlatVector::IsNull(args.data[0], i) || FlatVector::IsNull(args.data[1], i)) {
+                    FlatVector::Validity(result).SetInvalid(i);
+                    continue;
+                }
+                bool sync = has_third ? FlatVector::GetData<bool>(args.data[2])[i] : true;
+                Temporal *t = DecodeTemporalCopy(blob_data[i]);
+                Temporal *r = FN(t, eps_data[i], sync);
+                free(t);
+                if (!r) {
+                    FlatVector::Validity(result).SetInvalid(i);
+                    continue;
+                }
+                FlatVector::GetData<string_t>(result)[i] = TemporalToBlob(result, r);
+            }
+        };
+    };
+
+    loader.RegisterFunction(ScalarFunction(
+        "minDistSimplify", {TGEOM, DBL}, TGEOM,
+        simplify_double_exec_factory(temporal_simplify_min_dist)));
+
+    loader.RegisterFunction(ScalarFunction(
+        "minTimeDeltaSimplify", {TGEOM, LogicalType::INTERVAL}, TGEOM,
+        [](DataChunk &args, ExpressionState &, Vector &result) {
+            BinaryExecutor::Execute<string_t, interval_t, string_t>(
+                args.data[0], args.data[1], result, args.size(),
+                [&](string_t blob, interval_t iv) {
+                    Temporal *t = DecodeTemporalCopy(blob);
+                    MeosInterval miv = IntervaltToInterval(iv);
+                    Temporal *r = temporal_simplify_min_tdelta(t, &miv);
+                    free(t);
+                    if (!r) throw InvalidInputException("minTimeDeltaSimplify failed");
+                    return TemporalToBlob(result, r);
+                });
+        }));
+
+    loader.RegisterFunction(ScalarFunction(
+        "maxDistSimplify", {TGEOM, DBL}, TGEOM,
+        simplify_double_bool_exec_factory(temporal_simplify_max_dist)));
+    loader.RegisterFunction(ScalarFunction(
+        "maxDistSimplify", {TGEOM, DBL, LogicalType::BOOLEAN}, TGEOM,
+        simplify_double_bool_exec_factory(temporal_simplify_max_dist)));
+
+    loader.RegisterFunction(ScalarFunction(
+        "douglasPeuckerSimplify", {TGEOM, DBL}, TGEOM,
+        simplify_double_bool_exec_factory(temporal_simplify_dp)));
+    loader.RegisterFunction(ScalarFunction(
+        "douglasPeuckerSimplify", {TGEOM, DBL, LogicalType::BOOLEAN}, TGEOM,
+        simplify_double_bool_exec_factory(temporal_simplify_dp)));
 }
 
 } // namespace duckdb

--- a/src/include/geo/tgeometry_ops.hpp
+++ b/src/include/geo/tgeometry_ops.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+// Cross-type predicate / operator registrations for tgeometry — boxops
+// (overlaps / contains / contained / same / adjacent), position predicates
+// (left / right / below / above / front / back / before / after and their
+// over-* variants), spatial relationships (e / a / t variants of contains
+// / disjoint / intersects / touches / dwithin), and the temporal distance
+// operator family. Mirrors the corresponding cross-type surface that
+// MobilityDB ships in 060/062/064/070/072_tgeo_*.in.sql.
+struct TGeometryOps {
+    static void RegisterScalarFunctions(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/include/single_tile_getters.hpp
+++ b/src/include/single_tile_getters.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+// Single-tile getter functions: given a (value, timestamp, point) and a tile
+// grid configuration (size + origin), return the single tile/box that
+// contains the input.
+//
+// These complement the LIST<TBOX>/LIST<STBOX> emitters (`valueTiles`,
+// `timeTiles`, `valueTimeTiles`, `spaceTiles`, ...) by exposing the
+// per-input lookup form that MobilityDB ships at the SQL surface.
+struct SingleTileGetters {
+    static void RegisterScalarFunctions(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/include/temporal/temporal.hpp
+++ b/src/include/temporal/temporal.hpp
@@ -41,6 +41,7 @@ struct TemporalTypes {
     static void RegisterCastFunctions(ExtensionLoader &loader);
     static void RegisterScalarFunctions(ExtensionLoader &loader);
     static void RegisterTemporalUnnestFunction(ExtensionLoader &loader);
+    static void RegisterTileGetters(ExtensionLoader &loader);
 };
 
 } // namespace duckdb

--- a/src/include/temporal/temporal_aggregates.hpp
+++ b/src/include/temporal/temporal_aggregates.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+// SkipList-state temporal aggregates (tcount / tand / tor / tmin / tmax /
+// tsum / tavg / tcentroid). Registered separately from the fixed-state
+// extent() aggregates (in span_aggregates.cpp) because they need a
+// destructor and reach into MEOS skiplist internals.
+struct TemporalAggregates {
+    static void RegisterAggregateFunctions(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -11,6 +11,7 @@
 #include "geo/tgeompoint.hpp"
 #include "duckdb.hpp"
 #include "geo/tgeometry.hpp"
+#include "geo/tgeometry_ops.hpp"
 #include "temporal/span.hpp"
 #include "temporal/span_aggregates.hpp"
 #include "duckdb/common/exception.hpp"
@@ -254,6 +255,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	TGeometryTypes::RegisterTypes(loader);
 	TGeometryTypes::RegisterCastFunctions(loader);
 	TGeometryTypes::RegisterScalarInOutFunctions(loader);
+	TGeometryOps::RegisterScalarFunctions(loader);
 
 	SetTypes::RegisterTypes(loader);
 	SetTypes::RegisterCastFunctions(loader);

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -244,6 +244,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	SpanTypes::RegisterTypes(loader);
 	SpanTypes::RegisterCastFunctions(loader);
 
+	// Tile getters return SpanTypes blobs and consume TBOX, so all those
+	// types must already be registered.
+	TemporalTypes::RegisterTileGetters(loader);
+
 	TgeompointType::RegisterType(loader);
 	TgeompointType::RegisterCastFunctions(loader);
 	TgeompointType::RegisterScalarFunctions(loader);

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -13,6 +13,7 @@
 #include "geo/tgeometry.hpp"
 #include "temporal/span.hpp"
 #include "temporal/span_aggregates.hpp"
+#include "temporal/temporal_aggregates.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar_function.hpp"
@@ -245,6 +246,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	SpanTypes::RegisterTypes(loader);
 	SpanTypes::RegisterCastFunctions(loader);
 	SpanAggregates::RegisterAggregateFunctions(loader);
+	TemporalAggregates::RegisterAggregateFunctions(loader);
 
 	TgeompointType::RegisterType(loader);
 	TgeompointType::RegisterCastFunctions(loader);

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
 #include "index/rtree_module.hpp"
+#include "single_tile_getters.hpp"
 
 #include <mutex>
 #include <fstream>
@@ -271,6 +272,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	TRTreeModule::RegisterRTreeIndex(loader);
 	TRTreeModule::RegisterIndexScan(loader);
 	TRTreeModule::RegisterScanOptimizer(loader);
+
+	// Single-tile getters depend on TBOX, STBOX, and the spatial GEOMETRY
+	// type being registered first.
+	SingleTileGetters::RegisterScalarFunctions(loader);
 }
 
 void MobilityduckExtension::Load(ExtensionLoader &loader) {

--- a/src/single_tile_getters.cpp
+++ b/src/single_tile_getters.cpp
@@ -1,0 +1,441 @@
+// Single-tile getter functions: given an input point in the (value, time,
+// space) domain and a tile grid configuration, return the single tile that
+// contains the input. Mirrors MobilityDB's `getValueTile` / `getTBoxTimeTile`
+// / `getValueTimeTile` (tbox-shaped) and `getSpaceTile` / `getStboxTimeTile`
+// / `getSpaceTimeTile` (stbox-shaped).
+
+#include "meos_wrapper_simple.hpp"
+
+#include "common.hpp"
+#include "single_tile_getters.hpp"
+#include "temporal/tbox.hpp"
+#include "geo/stbox.hpp"
+#include "geo_util.hpp"
+#include "time_util.hpp"
+#include "spatial/spatial_types.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+namespace {
+
+// MobilityDB default torigin for time tiles: '2000-01-03' (a Monday).
+// In MEOS PG-epoch microseconds: 2 days * 86_400 * 1_000_000.
+constexpr int64_t DEFAULT_TIME_ORIGIN_MEOS = 2LL * 86400LL * 1000000LL;
+
+inline string_t MallocBlobToResult(Vector &result, void *buf, size_t sz) {
+    string_t blob(reinterpret_cast<const char *>(buf), UnsafeNumericCast<uint32_t>(sz));
+    string_t stored = StringVector::AddStringOrBlob(result, blob);
+    free(buf);
+    return stored;
+}
+
+inline string_t TboxToBlob(Vector &result, TBox *tbox) {
+    string_t out = StringVector::AddStringOrBlob(
+        result, reinterpret_cast<const char *>(tbox), sizeof(TBox));
+    free(tbox);
+    return out;
+}
+
+inline string_t StboxToBlob(Vector &result, STBox *stbox) {
+    string_t out = StringVector::AddStringOrBlob(
+        result, reinterpret_cast<const char *>(stbox), sizeof(STBox));
+    free(stbox);
+    return out;
+}
+
+// =====================================================================
+// getValueTile(double, double [, double=0.0]) -> tbox
+// =====================================================================
+
+void GetValueTileExec(DataChunk &args, ExpressionState &, Vector &result) {
+    const idx_t count = args.size();
+    args.data[0].Flatten(count);
+    args.data[1].Flatten(count);
+    Vector *vorigin_vec = args.ColumnCount() >= 3 ? &args.data[2] : nullptr;
+    if (vorigin_vec) vorigin_vec->Flatten(count);
+
+    auto v_data = FlatVector::GetData<double>(args.data[0]);
+    auto vsize_data = FlatVector::GetData<double>(args.data[1]);
+    auto &result_validity = FlatVector::Validity(result);
+
+    for (idx_t i = 0; i < count; ++i) {
+        if (FlatVector::IsNull(args.data[0], i) || FlatVector::IsNull(args.data[1], i) ||
+            (vorigin_vec && FlatVector::IsNull(*vorigin_vec, i))) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        double v = v_data[i];
+        double vsize = vsize_data[i];
+        double vorigin = vorigin_vec ? FlatVector::GetData<double>(*vorigin_vec)[i] : 0.0;
+
+        TBox *tbox = tbox_get_value_time_tile(
+            Float8GetDatum(v), 0,
+            Float8GetDatum(vsize), nullptr,
+            Float8GetDatum(vorigin), 0,
+            T_FLOAT8, T_FLOATSPAN);
+        if (!tbox) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        FlatVector::GetData<string_t>(result)[i] = StringVector::AddStringOrBlob(
+            result, reinterpret_cast<const char *>(tbox), sizeof(TBox));
+        free(tbox);
+    }
+    if (count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+// =====================================================================
+// getTBoxTimeTile(timestamptz, interval [, timestamptz='2000-01-03']) -> tbox
+// =====================================================================
+
+void GetTBoxTimeTileExec(DataChunk &args, ExpressionState &, Vector &result) {
+    const idx_t count = args.size();
+    args.data[0].Flatten(count);
+    args.data[1].Flatten(count);
+    Vector *torigin_vec = args.ColumnCount() >= 3 ? &args.data[2] : nullptr;
+    if (torigin_vec) torigin_vec->Flatten(count);
+
+    auto t_data = FlatVector::GetData<timestamp_tz_t>(args.data[0]);
+    auto dur_data = FlatVector::GetData<interval_t>(args.data[1]);
+    auto &result_validity = FlatVector::Validity(result);
+
+    for (idx_t i = 0; i < count; ++i) {
+        if (FlatVector::IsNull(args.data[0], i) || FlatVector::IsNull(args.data[1], i) ||
+            (torigin_vec && FlatVector::IsNull(*torigin_vec, i))) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        timestamp_tz_t meos_t = DuckDBToMeosTimestamp(t_data[i]);
+        MeosInterval iv = IntervaltToInterval(dur_data[i]);
+        TimestampTz torigin = (TimestampTz) DEFAULT_TIME_ORIGIN_MEOS;
+        if (torigin_vec) {
+            timestamp_tz_t in = FlatVector::GetData<timestamp_tz_t>(*torigin_vec)[i];
+            torigin = (TimestampTz) DuckDBToMeosTimestamp(in).value;
+        }
+
+        TBox *tbox = tbox_get_value_time_tile(
+            (Datum) 0, (TimestampTz) meos_t.value,
+            (Datum) 0, &iv,
+            (Datum) 0, torigin,
+            T_TIMESTAMPTZ, T_TSTZSPAN);
+        if (!tbox) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        FlatVector::GetData<string_t>(result)[i] = StringVector::AddStringOrBlob(
+            result, reinterpret_cast<const char *>(tbox), sizeof(TBox));
+        free(tbox);
+    }
+    if (count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+// =====================================================================
+// getValueTimeTile(double, timestamptz, double, interval
+//                  [, double=0.0, timestamptz='2000-01-03']) -> tbox
+// =====================================================================
+
+void GetValueTimeTileExec(DataChunk &args, ExpressionState &, Vector &result) {
+    const idx_t count = args.size();
+    for (idx_t c = 0; c < args.ColumnCount(); ++c) {
+        args.data[c].Flatten(count);
+    }
+    Vector *vorigin_vec = args.ColumnCount() >= 5 ? &args.data[4] : nullptr;
+    Vector *torigin_vec = args.ColumnCount() >= 6 ? &args.data[5] : nullptr;
+
+    auto v_data = FlatVector::GetData<double>(args.data[0]);
+    auto t_data = FlatVector::GetData<timestamp_tz_t>(args.data[1]);
+    auto vsize_data = FlatVector::GetData<double>(args.data[2]);
+    auto dur_data = FlatVector::GetData<interval_t>(args.data[3]);
+    auto &result_validity = FlatVector::Validity(result);
+
+    for (idx_t i = 0; i < count; ++i) {
+        if (FlatVector::IsNull(args.data[0], i) || FlatVector::IsNull(args.data[1], i) ||
+            FlatVector::IsNull(args.data[2], i) || FlatVector::IsNull(args.data[3], i) ||
+            (vorigin_vec && FlatVector::IsNull(*vorigin_vec, i)) ||
+            (torigin_vec && FlatVector::IsNull(*torigin_vec, i))) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        double v = v_data[i];
+        timestamp_tz_t meos_t = DuckDBToMeosTimestamp(t_data[i]);
+        double vsize = vsize_data[i];
+        MeosInterval iv = IntervaltToInterval(dur_data[i]);
+        double vorigin = vorigin_vec ? FlatVector::GetData<double>(*vorigin_vec)[i] : 0.0;
+        TimestampTz torigin = (TimestampTz) DEFAULT_TIME_ORIGIN_MEOS;
+        if (torigin_vec) {
+            timestamp_tz_t in = FlatVector::GetData<timestamp_tz_t>(*torigin_vec)[i];
+            torigin = (TimestampTz) DuckDBToMeosTimestamp(in).value;
+        }
+
+        TBox *tbox = tbox_get_value_time_tile(
+            Float8GetDatum(v), (TimestampTz) meos_t.value,
+            Float8GetDatum(vsize), &iv,
+            Float8GetDatum(vorigin), torigin,
+            T_FLOAT8, T_FLOATSPAN);
+        if (!tbox) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        FlatVector::GetData<string_t>(result)[i] = StringVector::AddStringOrBlob(
+            result, reinterpret_cast<const char *>(tbox), sizeof(TBox));
+        free(tbox);
+    }
+    if (count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+// =====================================================================
+// getSpaceTile / getSpaceTimeTile / getStboxTimeTile
+// =====================================================================
+
+// Default sorigin = Point(0 0 0). Built once and reused — geometric origin
+// for all space-tile lookups when the user does not pass an explicit one.
+static GSERIALIZED *DefaultSpatialOrigin() {
+    static GSERIALIZED *cached = nullptr;
+    if (!cached) {
+        cached = geompoint_make3dz(0, 0.0, 0.0, 0.0);
+    }
+    return cached;
+}
+
+// Geometry blob to GSERIALIZED, requiring SRID info (defaults to 0).
+inline GSERIALIZED *DecodeGeometry(string_t geom_blob) {
+    return GeometryToGSerialized(geom_blob, 0);
+}
+
+// getSpaceTile(geom, xsize, ysize, zsize [, sorigin geom='Point(0 0 0)']) -> stbox
+void GetSpaceTileExec(DataChunk &args, ExpressionState &, Vector &result) {
+    const idx_t count = args.size();
+    for (idx_t c = 0; c < args.ColumnCount(); ++c) args.data[c].Flatten(count);
+    Vector *sorigin_vec = args.ColumnCount() >= 5 ? &args.data[4] : nullptr;
+
+    auto geom_data = FlatVector::GetData<string_t>(args.data[0]);
+    auto xsize_data = FlatVector::GetData<double>(args.data[1]);
+    auto ysize_data = FlatVector::GetData<double>(args.data[2]);
+    auto zsize_data = FlatVector::GetData<double>(args.data[3]);
+    auto &result_validity = FlatVector::Validity(result);
+
+    for (idx_t i = 0; i < count; ++i) {
+        if (FlatVector::IsNull(args.data[0], i) || FlatVector::IsNull(args.data[1], i) ||
+            FlatVector::IsNull(args.data[2], i) || FlatVector::IsNull(args.data[3], i) ||
+            (sorigin_vec && FlatVector::IsNull(*sorigin_vec, i))) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        GSERIALIZED *gs = DecodeGeometry(geom_data[i]);
+        GSERIALIZED *origin = DefaultSpatialOrigin();
+        bool free_origin = false;
+        if (sorigin_vec) {
+            origin = DecodeGeometry(FlatVector::GetData<string_t>(*sorigin_vec)[i]);
+            free_origin = true;
+        }
+        STBox *stbox = stbox_get_space_tile(
+            gs, xsize_data[i], ysize_data[i], zsize_data[i], origin);
+        free(gs);
+        if (free_origin) free(origin);
+        if (!stbox) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        FlatVector::GetData<string_t>(result)[i] = StringVector::AddStringOrBlob(
+            result, reinterpret_cast<const char *>(stbox), sizeof(STBox));
+        free(stbox);
+    }
+    if (count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+// getStboxTimeTile(timestamptz, interval [, timestamptz='2000-01-03']) -> stbox
+void GetStboxTimeTileExec(DataChunk &args, ExpressionState &, Vector &result) {
+    const idx_t count = args.size();
+    args.data[0].Flatten(count);
+    args.data[1].Flatten(count);
+    Vector *torigin_vec = args.ColumnCount() >= 3 ? &args.data[2] : nullptr;
+    if (torigin_vec) torigin_vec->Flatten(count);
+
+    auto t_data = FlatVector::GetData<timestamp_tz_t>(args.data[0]);
+    auto dur_data = FlatVector::GetData<interval_t>(args.data[1]);
+    auto &result_validity = FlatVector::Validity(result);
+
+    for (idx_t i = 0; i < count; ++i) {
+        if (FlatVector::IsNull(args.data[0], i) || FlatVector::IsNull(args.data[1], i) ||
+            (torigin_vec && FlatVector::IsNull(*torigin_vec, i))) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        timestamp_tz_t meos_t = DuckDBToMeosTimestamp(t_data[i]);
+        MeosInterval iv = IntervaltToInterval(dur_data[i]);
+        TimestampTz torigin = (TimestampTz) DEFAULT_TIME_ORIGIN_MEOS;
+        if (torigin_vec) {
+            timestamp_tz_t in = FlatVector::GetData<timestamp_tz_t>(*torigin_vec)[i];
+            torigin = (TimestampTz) DuckDBToMeosTimestamp(in).value;
+        }
+        STBox *stbox = stbox_get_time_tile((TimestampTz) meos_t.value, &iv, torigin);
+        if (!stbox) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        FlatVector::GetData<string_t>(result)[i] = StringVector::AddStringOrBlob(
+            result, reinterpret_cast<const char *>(stbox), sizeof(STBox));
+        free(stbox);
+    }
+    if (count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+// getSpaceTimeTile(geom, t, xsize, ysize, zsize, interval
+//                  [, sorigin='Point(0 0 0)', torigin='2000-01-03']) -> stbox
+void GetSpaceTimeTileExec(DataChunk &args, ExpressionState &, Vector &result) {
+    const idx_t count = args.size();
+    for (idx_t c = 0; c < args.ColumnCount(); ++c) args.data[c].Flatten(count);
+    Vector *sorigin_vec = args.ColumnCount() >= 7 ? &args.data[6] : nullptr;
+    Vector *torigin_vec = args.ColumnCount() >= 8 ? &args.data[7] : nullptr;
+
+    auto geom_data = FlatVector::GetData<string_t>(args.data[0]);
+    auto t_data = FlatVector::GetData<timestamp_tz_t>(args.data[1]);
+    auto xsize_data = FlatVector::GetData<double>(args.data[2]);
+    auto ysize_data = FlatVector::GetData<double>(args.data[3]);
+    auto zsize_data = FlatVector::GetData<double>(args.data[4]);
+    auto dur_data = FlatVector::GetData<interval_t>(args.data[5]);
+    auto &result_validity = FlatVector::Validity(result);
+
+    for (idx_t i = 0; i < count; ++i) {
+        if (FlatVector::IsNull(args.data[0], i) || FlatVector::IsNull(args.data[1], i) ||
+            FlatVector::IsNull(args.data[2], i) || FlatVector::IsNull(args.data[3], i) ||
+            FlatVector::IsNull(args.data[4], i) || FlatVector::IsNull(args.data[5], i) ||
+            (sorigin_vec && FlatVector::IsNull(*sorigin_vec, i)) ||
+            (torigin_vec && FlatVector::IsNull(*torigin_vec, i))) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        GSERIALIZED *gs = DecodeGeometry(geom_data[i]);
+        GSERIALIZED *origin = DefaultSpatialOrigin();
+        bool free_origin = false;
+        if (sorigin_vec) {
+            origin = DecodeGeometry(FlatVector::GetData<string_t>(*sorigin_vec)[i]);
+            free_origin = true;
+        }
+        timestamp_tz_t meos_t = DuckDBToMeosTimestamp(t_data[i]);
+        MeosInterval iv = IntervaltToInterval(dur_data[i]);
+        TimestampTz torigin = (TimestampTz) DEFAULT_TIME_ORIGIN_MEOS;
+        if (torigin_vec) {
+            timestamp_tz_t in = FlatVector::GetData<timestamp_tz_t>(*torigin_vec)[i];
+            torigin = (TimestampTz) DuckDBToMeosTimestamp(in).value;
+        }
+
+        STBox *stbox = stbox_get_space_time_tile(
+            gs, (TimestampTz) meos_t.value,
+            xsize_data[i], ysize_data[i], zsize_data[i],
+            &iv, origin, torigin);
+        free(gs);
+        if (free_origin) free(origin);
+        if (!stbox) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        FlatVector::GetData<string_t>(result)[i] = StringVector::AddStringOrBlob(
+            result, reinterpret_cast<const char *>(stbox), sizeof(STBox));
+        free(stbox);
+    }
+    if (count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+// Convenience overload: getSpaceTile(geom, xsize) — uniform xyz, default origin.
+void GetSpaceTileUniformExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    // Forward to the full-arity exec by synthesising a 4-column DataChunk.
+    DataChunk forwarded;
+    vector<LogicalType> types = {args.data[0].GetType(), LogicalType::DOUBLE,
+                                 LogicalType::DOUBLE, LogicalType::DOUBLE};
+    forwarded.Initialize(Allocator::DefaultAllocator(), types);
+    forwarded.SetCardinality(args.size());
+    forwarded.data[0].Reference(args.data[0]);
+    forwarded.data[1].Reference(args.data[1]);
+    forwarded.data[2].Reference(args.data[1]);
+    forwarded.data[3].Reference(args.data[1]);
+    GetSpaceTileExec(forwarded, state, result);
+}
+
+} // namespace
+
+void SingleTileGetters::RegisterScalarFunctions(ExtensionLoader &loader) {
+    LogicalType geometry = GeoTypes::GEOMETRY();
+
+    // ---- tbox getters ----
+    loader.RegisterFunction(ScalarFunction(
+        "getValueTile",
+        {LogicalType::DOUBLE, LogicalType::DOUBLE},
+        TboxType::TBOX(), GetValueTileExec));
+    loader.RegisterFunction(ScalarFunction(
+        "getValueTile",
+        {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE},
+        TboxType::TBOX(), GetValueTileExec));
+
+    loader.RegisterFunction(ScalarFunction(
+        "getTBoxTimeTile",
+        {LogicalType::TIMESTAMP_TZ, LogicalType::INTERVAL},
+        TboxType::TBOX(), GetTBoxTimeTileExec));
+    loader.RegisterFunction(ScalarFunction(
+        "getTBoxTimeTile",
+        {LogicalType::TIMESTAMP_TZ, LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ},
+        TboxType::TBOX(), GetTBoxTimeTileExec));
+
+    loader.RegisterFunction(ScalarFunction(
+        "getValueTimeTile",
+        {LogicalType::DOUBLE, LogicalType::TIMESTAMP_TZ,
+         LogicalType::DOUBLE, LogicalType::INTERVAL},
+        TboxType::TBOX(), GetValueTimeTileExec));
+    loader.RegisterFunction(ScalarFunction(
+        "getValueTimeTile",
+        {LogicalType::DOUBLE, LogicalType::TIMESTAMP_TZ,
+         LogicalType::DOUBLE, LogicalType::INTERVAL,
+         LogicalType::DOUBLE, LogicalType::TIMESTAMP_TZ},
+        TboxType::TBOX(), GetValueTimeTileExec));
+
+    // ---- stbox getters ----
+    // 4-arg: full xyz sizes, default sorigin
+    loader.RegisterFunction(ScalarFunction(
+        "getSpaceTile",
+        {geometry, LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE},
+        StboxType::STBOX(), GetSpaceTileExec));
+    // 5-arg: full xyz sizes + explicit sorigin
+    loader.RegisterFunction(ScalarFunction(
+        "getSpaceTile",
+        {geometry, LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE, geometry},
+        StboxType::STBOX(), GetSpaceTileExec));
+    // 2-arg: uniform xyz, default sorigin
+    loader.RegisterFunction(ScalarFunction(
+        "getSpaceTile",
+        {geometry, LogicalType::DOUBLE},
+        StboxType::STBOX(), GetSpaceTileUniformExec));
+
+    loader.RegisterFunction(ScalarFunction(
+        "getStboxTimeTile",
+        {LogicalType::TIMESTAMP_TZ, LogicalType::INTERVAL},
+        StboxType::STBOX(), GetStboxTimeTileExec));
+    loader.RegisterFunction(ScalarFunction(
+        "getStboxTimeTile",
+        {LogicalType::TIMESTAMP_TZ, LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ},
+        StboxType::STBOX(), GetStboxTimeTileExec));
+
+    loader.RegisterFunction(ScalarFunction(
+        "getSpaceTimeTile",
+        {geometry, LogicalType::TIMESTAMP_TZ,
+         LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE,
+         LogicalType::INTERVAL},
+        StboxType::STBOX(), GetSpaceTimeTileExec));
+    loader.RegisterFunction(ScalarFunction(
+        "getSpaceTimeTile",
+        {geometry, LogicalType::TIMESTAMP_TZ,
+         LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE,
+         LogicalType::INTERVAL, geometry},
+        StboxType::STBOX(), GetSpaceTimeTileExec));
+    loader.RegisterFunction(ScalarFunction(
+        "getSpaceTimeTile",
+        {geometry, LogicalType::TIMESTAMP_TZ,
+         LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE,
+         LogicalType::INTERVAL, geometry, LogicalType::TIMESTAMP_TZ},
+        StboxType::STBOX(), GetSpaceTimeTileExec));
+}
+
+} // namespace duckdb

--- a/src/temporal/span_aggregates.cpp
+++ b/src/temporal/span_aggregates.cpp
@@ -444,15 +444,22 @@ void SpanAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
     extent_set.AddFunction(MakeExtentTboxAggregate<TboxExtentFromTNumber>(TemporalTypes::TINT()));
     extent_set.AddFunction(MakeExtentTboxAggregate<TboxExtentFromTNumber>(TemporalTypes::TFLOAT()));
 
-    // ---- extent(stbox) -> stbox; extent(tgeompoint) -> stbox ----
+    // ---- extent(stbox | tgeompoint | tgeometry) -> stbox ----
     extent_set.AddFunction(MakeExtentStboxAggregate<StboxExtentFromSTBox>(StboxType::STBOX()));
     {
-        // tgeompoint is registered via TgeompointType::TGEOMPOINT().
-        // Avoid pulling in the header here by using a BLOB-aliased clone.
+        // tgeompoint / tgeometry are registered via their respective Type
+        // helpers; we avoid pulling those headers here by using a
+        // BLOB-aliased clone since the underlying MEOS extent transition
+        // function (`tspatial_extent_transfn`) is subtype-agnostic.
         LogicalType tgeompoint_type(LogicalTypeId::BLOB);
         tgeompoint_type.SetAlias("TGEOMPOINT");
         extent_set.AddFunction(
             MakeExtentStboxAggregate<StboxExtentFromTSpatial>(tgeompoint_type));
+
+        LogicalType tgeometry_type(LogicalTypeId::BLOB);
+        tgeometry_type.SetAlias("TGEOMETRY");
+        extent_set.AddFunction(
+            MakeExtentStboxAggregate<StboxExtentFromTSpatial>(tgeometry_type));
     }
 
     // ---- extent(tbool/ttext) -> tstzspan ----

--- a/src/temporal/span_aggregates.cpp
+++ b/src/temporal/span_aggregates.cpp
@@ -1,7 +1,14 @@
 #include "meos_wrapper_simple.hpp"
 
+#include "common.hpp"
 #include "temporal/span.hpp"
+#include "temporal/set.hpp"
+#include "temporal/spanset.hpp"
+#include "temporal/tbox.hpp"
+#include "geo/stbox.hpp"
+#include "temporal/temporal.hpp"
 #include "temporal/span_aggregates.hpp"
+#include "time_util.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
@@ -12,55 +19,47 @@ namespace duckdb {
 
 namespace {
 
-// State for the extent(span) aggregate. The MEOS Span is a fixed-size
-// struct, so we can hold it inline in the aggregate state.
+// =====================================================================
+// Span-typed extent: state = Span. Inputs span/set/spanset/scalars all
+// fold into the same shape, only the transition function differs.
+// =====================================================================
+
 struct SpanExtentState {
     Span span;
     bool isset;
 };
 
-struct SpanExtentFunction {
+template <auto TRANSFN>
+struct SpanExtentFromSpanLike {
     template <class STATE>
-    static void Initialize(STATE &state) {
-        state.isset = false;
-    }
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
 
-    static bool IgnoreNull() {
-        return true;
-    }
-
-    // Operation receives the input blob; we decode to Span and call MEOS
-    // span_extent_transfn, which expands state's bounds in place when
-    // state is non-null and otherwise returns a fresh palloc'd copy.
     template <class INPUT_TYPE, class STATE, class OP>
     static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
-        // INPUT_TYPE is string_t for blob-encoded spans.
-        const Span *input_span = reinterpret_cast<const Span *>(input.GetData());
+        // INPUT_TYPE is string_t — span / set / spanset blob.
+        const auto *in = reinterpret_cast<const std::remove_pointer_t<
+            decltype(TRANSFN(static_cast<Span *>(nullptr), nullptr))> *>(input.GetData());
         if (!state.isset) {
-            // First call: initialize state with a copy of the input.
-            memcpy(&state.span, input_span, sizeof(Span));
-            state.isset = true;
+            // Use a temporary state of NULL: TRANSFN palloc-copies into a fresh
+            // Span. Copy it back inline and free.
+            Span *fresh = TRANSFN(nullptr, in);
+            if (fresh) {
+                memcpy(&state.span, fresh, sizeof(Span));
+                free(fresh);
+                state.isset = true;
+            }
         } else {
-            // Subsequent calls: expand state in place.
-            // span_extent_transfn(state, s) calls span_expand(s, state).
-            (void) span_extent_transfn(&state.span, input_span);
+            (void) TRANSFN(&state.span, in);
         }
     }
-
     template <class INPUT_TYPE, class STATE, class OP>
-    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
-                                  idx_t /*count*/) {
-        // extent is idempotent in the value dimension, so a single
-        // application is equivalent to applying the same value `count`
-        // times.
-        Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
     }
-
     template <class STATE, class OP>
     static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
-        if (!source.isset) {
-            return;
-        }
+        if (!source.isset) return;
         if (!target.isset) {
             memcpy(&target.span, &source.span, sizeof(Span));
             target.isset = true;
@@ -68,31 +67,400 @@ struct SpanExtentFunction {
             (void) span_extent_transfn(&target.span, &source.span);
         }
     }
-
     template <class T, class STATE>
-    static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
-        if (!state.isset) {
-            finalize_data.ReturnNull();
-            return;
-        }
-        target = finalize_data.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
     }
 };
+
+// Original span extent retained — span_extent_transfn expands in place even
+// for the NULL-state case, so we keep the dedicated implementation for it
+// to avoid double-allocating.
+struct SpanExtentFunction {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Span *input_span = reinterpret_cast<const Span *>(input.GetData());
+        if (!state.isset) {
+            memcpy(&state.span, input_span, sizeof(Span));
+            state.isset = true;
+        } else {
+            (void) span_extent_transfn(&state.span, input_span);
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.span, &source.span, sizeof(Span));
+            target.isset = true;
+        } else {
+            (void) span_extent_transfn(&target.span, &source.span);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    }
+};
+
+// =====================================================================
+// Scalar inputs (int / bigint / float / date / timestamptz). For each
+// the MEOS transfn signature is (Span *, value) -> Span *.
+// =====================================================================
+
+template <class IN, Span *(*TRANSFN)(Span *, IN)>
+struct ScalarSpanExtentFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        Span *fresh = TRANSFN(state.isset ? &state.span : nullptr, input);
+        if (!state.isset && fresh) {
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.span, &source.span, sizeof(Span));
+            target.isset = true;
+        } else {
+            (void) span_extent_transfn(&target.span, &source.span);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    }
+};
+
+// Wrappers to convert DuckDB-side timestamp/date to MEOS-side before calling
+// the transition function, so the aggregate sees consistent inputs.
+inline Span *DateExtentDuckDB(Span *state, date_t d) {
+    return date_extent_transfn(state, ToMeosDate(d));
+}
+inline Span *TstzExtentDuckDB(Span *state, timestamp_tz_t t) {
+    return timestamptz_extent_transfn(state, (TimestampTz) DuckDBToMeosTimestamp(t).value);
+}
+inline Span *Int32Extent(Span *state, int32_t v) { return int_extent_transfn(state, v); }
+inline Span *Int64Extent(Span *state, int64_t v) { return bigint_extent_transfn(state, v); }
+inline Span *DoubleExtent(Span *state, double v) { return float_extent_transfn(state, v); }
+
+// =====================================================================
+// TBox extent: state = TBox. Both numeric tbox-shaped inputs (tbox itself,
+// tnumber via tnumber_extent_transfn) feed in here.
+// =====================================================================
+
+struct TBoxExtentState {
+    TBox box;
+    bool isset;
+};
+
+// Generic TBox-state aggregator, parametrised by the function that takes
+// (state, inputBlob) and returns a fresh-or-state TBox*. Both
+// `tnumber_extent_transfn(TBox*, const Temporal*)` and a "tbox extent"
+// (built on `tbox_expand`) match this signature once we wrap them.
+typedef TBox *(*TBoxTransFn)(TBox * /*state*/, const void * /*input ptr*/);
+
+template <TBoxTransFn TRANSFN>
+struct TBoxExtentFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        TBox *result = TRANSFN(state.isset ? &state.box : nullptr, input.GetData());
+        if (!state.isset && result) {
+            memcpy(&state.box, result, sizeof(TBox));
+            free(result);
+            state.isset = true;
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.box, &source.box, sizeof(TBox));
+            target.isset = true;
+        } else {
+            tbox_expand(&source.box, &target.box);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.box), sizeof(TBox)));
+    }
+};
+
+// Wrap MEOS extent-style functions to a uniform signature.
+TBox *TboxExtentFromTBox(TBox *state, const void *input) {
+    const TBox *box_in = reinterpret_cast<const TBox *>(input);
+    if (!state) {
+        TBox *fresh = (TBox *) malloc(sizeof(TBox));
+        memcpy(fresh, box_in, sizeof(TBox));
+        return fresh;
+    }
+    tbox_expand(box_in, state);
+    return state;
+}
+
+TBox *TboxExtentFromTNumber(TBox *state, const void *input) {
+    const Temporal *t = reinterpret_cast<const Temporal *>(input);
+    return tnumber_extent_transfn(state, t);
+}
+
+// =====================================================================
+// STBox extent: state = STBox.
+// =====================================================================
+
+struct STBoxExtentState {
+    STBox box;
+    bool isset;
+};
+
+typedef STBox *(*STBoxTransFn)(STBox * /*state*/, const void * /*input ptr*/);
+
+template <STBoxTransFn TRANSFN>
+struct STBoxExtentFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        STBox *result = TRANSFN(state.isset ? &state.box : nullptr, input.GetData());
+        if (!state.isset && result) {
+            memcpy(&state.box, result, sizeof(STBox));
+            free(result);
+            state.isset = true;
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.box, &source.box, sizeof(STBox));
+            target.isset = true;
+        } else {
+            stbox_expand(&source.box, &target.box);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.box), sizeof(STBox)));
+    }
+};
+
+STBox *StboxExtentFromSTBox(STBox *state, const void *input) {
+    const STBox *box_in = reinterpret_cast<const STBox *>(input);
+    if (!state) {
+        STBox *fresh = (STBox *) malloc(sizeof(STBox));
+        memcpy(fresh, box_in, sizeof(STBox));
+        return fresh;
+    }
+    stbox_expand(box_in, state);
+    return state;
+}
+
+STBox *StboxExtentFromTSpatial(STBox *state, const void *input) {
+    const Temporal *t = reinterpret_cast<const Temporal *>(input);
+    return tspatial_extent_transfn(state, t);
+}
+
+// =====================================================================
+// Span-typed extent over Temporal: temporal_extent_transfn yields the
+// time span (tstzspan) for tbool/ttext etc.
+// =====================================================================
+
+Span *TstzSpanExtentFromTemporal(Span *state, const void *input) {
+    const Temporal *t = reinterpret_cast<const Temporal *>(input);
+    return temporal_extent_transfn(state, t);
+}
+
+struct GenericSpanExtentState : SpanExtentState {};
+
+template <Span *(*TRANSFN)(Span *, const void *)>
+struct GenericSpanFromBlobFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.isset = false; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        Span *fresh = TRANSFN(state.isset ? &state.span : nullptr, input.GetData());
+        if (!state.isset && fresh) {
+            memcpy(&state.span, fresh, sizeof(Span));
+            free(fresh);
+            state.isset = true;
+        }
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+        if (!source.isset) return;
+        if (!target.isset) {
+            memcpy(&target.span, &source.span, sizeof(Span));
+            target.isset = true;
+        } else {
+            (void) span_extent_transfn(&target.span, &source.span);
+        }
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.isset) { fd.ReturnNull(); return; }
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(&state.span), sizeof(Span)));
+    }
+};
+
+Span *SpanExtentFromSet(Span *state, const void *input) {
+    const Set *s = reinterpret_cast<const Set *>(input);
+    return set_extent_transfn(state, s);
+}
+Span *SpanExtentFromSpanSet(Span *state, const void *input) {
+    const SpanSet *ss = reinterpret_cast<const SpanSet *>(input);
+    return spanset_extent_transfn(state, ss);
+}
+
+// =====================================================================
+// Aggregate-construction helpers
+// =====================================================================
 
 static AggregateFunction MakeExtentSpanAggregate(const LogicalType &span_type) {
     return AggregateFunction::UnaryAggregate<SpanExtentState, string_t, string_t, SpanExtentFunction>(
         span_type, span_type);
 }
 
+template <class T, Span *(*TRANSFN)(Span *, T)>
+static AggregateFunction MakeExtentScalarAggregate(const LogicalType &input_type, const LogicalType &out_span) {
+    return AggregateFunction::UnaryAggregate<SpanExtentState, T, string_t, ScalarSpanExtentFn<T, TRANSFN>>(
+        input_type, out_span);
+}
+
+template <Span *(*TRANSFN)(Span *, const void *)>
+static AggregateFunction MakeExtentBlobToSpanAggregate(const LogicalType &input_type,
+                                                       const LogicalType &out_span) {
+    return AggregateFunction::UnaryAggregate<SpanExtentState, string_t, string_t,
+                                             GenericSpanFromBlobFn<TRANSFN>>(input_type, out_span);
+}
+
+template <TBoxTransFn TRANSFN>
+static AggregateFunction MakeExtentTboxAggregate(const LogicalType &input_type) {
+    return AggregateFunction::UnaryAggregate<TBoxExtentState, string_t, string_t, TBoxExtentFn<TRANSFN>>(
+        input_type, TboxType::TBOX());
+}
+
+template <STBoxTransFn TRANSFN>
+static AggregateFunction MakeExtentStboxAggregate(const LogicalType &input_type) {
+    return AggregateFunction::UnaryAggregate<STBoxExtentState, string_t, string_t, STBoxExtentFn<TRANSFN>>(
+        input_type, StboxType::STBOX());
+}
+
 } // namespace
 
 void SpanAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
     AggregateFunctionSet extent_set("extent");
+
+    // ---- extent(span) for all 5 span types ----
     for (const auto &span_type : {SpanTypes::INTSPAN(), SpanTypes::BIGINTSPAN(),
                                   SpanTypes::FLOATSPAN(), SpanTypes::DATESPAN(),
                                   SpanTypes::TSTZSPAN()}) {
         extent_set.AddFunction(MakeExtentSpanAggregate(span_type));
     }
+
+    // ---- extent(scalar) -> typed span ----
+    extent_set.AddFunction(MakeExtentScalarAggregate<int32_t, Int32Extent>(
+        LogicalType::INTEGER, SpanTypes::INTSPAN()));
+    extent_set.AddFunction(MakeExtentScalarAggregate<int64_t, Int64Extent>(
+        LogicalType::BIGINT, SpanTypes::BIGINTSPAN()));
+    extent_set.AddFunction(MakeExtentScalarAggregate<double, DoubleExtent>(
+        LogicalType::DOUBLE, SpanTypes::FLOATSPAN()));
+    extent_set.AddFunction(MakeExtentScalarAggregate<date_t, DateExtentDuckDB>(
+        LogicalType::DATE, SpanTypes::DATESPAN()));
+    extent_set.AddFunction(MakeExtentScalarAggregate<timestamp_tz_t, TstzExtentDuckDB>(
+        LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN()));
+
+    // ---- extent(set) -> typed span ----
+    struct SetSpanPair {
+        LogicalType in;
+        LogicalType out;
+    };
+    const std::vector<SetSpanPair> set_pairs = {
+        {SetTypes::intset(),     SpanTypes::INTSPAN()},
+        {SetTypes::bigintset(),  SpanTypes::BIGINTSPAN()},
+        {SetTypes::floatset(),   SpanTypes::FLOATSPAN()},
+        {SetTypes::dateset(),    SpanTypes::DATESPAN()},
+        {SetTypes::tstzset(),    SpanTypes::TSTZSPAN()},
+    };
+    for (const auto &p : set_pairs) {
+        extent_set.AddFunction(MakeExtentBlobToSpanAggregate<SpanExtentFromSet>(p.in, p.out));
+    }
+
+    // ---- extent(spanset) -> typed span ----
+    const std::vector<SetSpanPair> spanset_pairs = {
+        {SpansetTypes::intspanset(),    SpanTypes::INTSPAN()},
+        {SpansetTypes::bigintspanset(), SpanTypes::BIGINTSPAN()},
+        {SpansetTypes::floatspanset(),  SpanTypes::FLOATSPAN()},
+        {SpansetTypes::datespanset(),   SpanTypes::DATESPAN()},
+        {SpansetTypes::tstzspanset(),   SpanTypes::TSTZSPAN()},
+    };
+    for (const auto &p : spanset_pairs) {
+        extent_set.AddFunction(MakeExtentBlobToSpanAggregate<SpanExtentFromSpanSet>(p.in, p.out));
+    }
+
+    // ---- extent(tbox) -> tbox; extent(tnumber) -> tbox ----
+    extent_set.AddFunction(MakeExtentTboxAggregate<TboxExtentFromTBox>(TboxType::TBOX()));
+    extent_set.AddFunction(MakeExtentTboxAggregate<TboxExtentFromTNumber>(TemporalTypes::TINT()));
+    extent_set.AddFunction(MakeExtentTboxAggregate<TboxExtentFromTNumber>(TemporalTypes::TFLOAT()));
+
+    // ---- extent(stbox) -> stbox; extent(tgeompoint) -> stbox ----
+    extent_set.AddFunction(MakeExtentStboxAggregate<StboxExtentFromSTBox>(StboxType::STBOX()));
+    {
+        // tgeompoint is registered via TgeompointType::TGEOMPOINT().
+        // Avoid pulling in the header here by using a BLOB-aliased clone.
+        LogicalType tgeompoint_type(LogicalTypeId::BLOB);
+        tgeompoint_type.SetAlias("TGEOMPOINT");
+        extent_set.AddFunction(
+            MakeExtentStboxAggregate<StboxExtentFromTSpatial>(tgeompoint_type));
+    }
+
+    // ---- extent(tbool/ttext) -> tstzspan ----
+    extent_set.AddFunction(MakeExtentBlobToSpanAggregate<TstzSpanExtentFromTemporal>(
+        TemporalTypes::TBOOL(), SpanTypes::TSTZSPAN()));
+    extent_set.AddFunction(MakeExtentBlobToSpanAggregate<TstzSpanExtentFromTemporal>(
+        TemporalTypes::TTEXT(), SpanTypes::TSTZSPAN()));
+
     loader.RegisterFunction(std::move(extent_set));
 }
 

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -20,6 +20,7 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 
+#include "time_util.hpp"
 #include "mobilityduck/bindings.hpp"
 
 namespace duckdb {
@@ -1720,6 +1721,345 @@ void TemporalTypes::RegisterTemporalUnnestFunction(ExtensionLoader &loader) {
             loader.RegisterFunction( fn);
         }
     }
+}
+
+namespace {
+
+inline string_t MallocBlobToResultLocal(Vector &result, void *buf, size_t sz) {
+    string_t blob(reinterpret_cast<const char *>(buf), UnsafeNumericCast<uint32_t>(sz));
+    string_t stored = StringVector::AddStringOrBlob(result, blob);
+    free(buf);
+    return stored;
+}
+
+// ----- getBin: single-bin getters returning spans -----
+//
+// MobilityDB SQL: getBin(value, size, origin) -> <type>span. We compute the
+// lower bound via MEOS *_get_bin and pair it with upper = lower + size to
+// emit a [lower, upper) span blob. Time/date variants stride the duration
+// interval rather than a numeric size.
+
+inline string_t SpanToBlob(Vector &result, Span *span) {
+    string_t out = StringVector::AddStringOrBlob(
+        result, reinterpret_cast<const char *>(span), sizeof(Span));
+    free(span);
+    return out;
+}
+
+void GetBinIntExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::Execute<int32_t, int32_t, int32_t, string_t>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](int32_t v, int32_t vsize, int32_t vorigin) {
+            int lower = int_get_bin(v, vsize, vorigin);
+            Span *span = intspan_make(lower, lower + vsize, true, false);
+            return SpanToBlob(result, span);
+        });
+}
+
+void GetBinBigintExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::Execute<int64_t, int64_t, int64_t, string_t>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](int64_t v, int64_t vsize, int64_t vorigin) {
+            int64_t lower = bigint_get_bin(v, vsize, vorigin);
+            Span *span = bigintspan_make(lower, lower + vsize, true, false);
+            return SpanToBlob(result, span);
+        });
+}
+
+void GetBinFloatExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::Execute<double, double, double, string_t>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](double v, double vsize, double vorigin) {
+            double lower = float_get_bin(v, vsize, vorigin);
+            Span *span = floatspan_make(lower, lower + vsize, true, false);
+            return SpanToBlob(result, span);
+        });
+}
+
+void GetBinTstzExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::Execute<timestamp_tz_t, interval_t, timestamp_tz_t, string_t>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](timestamp_tz_t t, interval_t duration, timestamp_tz_t torigin) {
+            timestamp_tz_t meos_t = DuckDBToMeosTimestamp(t);
+            timestamp_tz_t meos_torigin = DuckDBToMeosTimestamp(torigin);
+            MeosInterval iv = IntervaltToInterval(duration);
+            TimestampTz lower_meos = timestamptz_get_bin(
+                (TimestampTz) meos_t.value, &iv, (TimestampTz) meos_torigin.value);
+            TimestampTz upper_meos = add_timestamptz_interval(lower_meos, &iv);
+            Span *span = tstzspan_make(lower_meos, upper_meos, true, false);
+            return SpanToBlob(result, span);
+        });
+}
+
+void GetBinDateExec(DataChunk &args, ExpressionState &, Vector &result) {
+    TernaryExecutor::Execute<date_t, interval_t, date_t, string_t>(
+        args.data[0], args.data[1], args.data[2], result, args.size(),
+        [&](date_t d, interval_t duration, date_t origin) {
+            int32_t meos_d = ToMeosDate(d);
+            int32_t meos_origin = ToMeosDate(origin);
+            MeosInterval iv = IntervaltToInterval(duration);
+            DateADT lower = date_get_bin((DateADT) meos_d, &iv, (DateADT) meos_origin);
+            // Date bins use duration.day; months/micros are not meaningful
+            // for date-aligned bins (MobilityDB rejects them upstream).
+            DateADT upper = add_date_int(lower, (int32) iv.day);
+            Span *span = datespan_make(lower, upper, true, false);
+            return SpanToBlob(result, span);
+        });
+}
+
+// ----- tbox tile emitters: LIST(TBOX) outputs -----
+
+inline void EmitTboxList(Vector &result, idx_t row_idx, TBox *tiles, int count,
+                         idx_t &total_offset, list_entry_t *list_entries,
+                         Vector &child_vector, ValidityMask &result_validity) {
+    if (!tiles || count <= 0) {
+        if (tiles) free(tiles);
+        result_validity.SetInvalid(row_idx);
+        return;
+    }
+    ListVector::SetListSize(result, total_offset + count);
+    list_entries[row_idx] = list_entry_t{total_offset, static_cast<uint64_t>(count)};
+    auto *child_data = FlatVector::GetData<string_t>(child_vector);
+    const size_t tbox_bytes = sizeof(TBox);
+    for (int j = 0; j < count; ++j) {
+        child_data[total_offset + j] = StringVector::AddStringOrBlob(
+            child_vector, reinterpret_cast<const char *>(&tiles[j]), tbox_bytes);
+    }
+    free(tiles);
+    total_offset += count;
+}
+
+// valueTiles(tbox, vsize [, vorigin]) — int branch uses int xsize/xorigin, float uses double
+void TboxValueTilesExec(DataChunk &args, ExpressionState &, Vector &result) {
+    auto &tbox_vec = args.data[0];
+    auto &vsize_vec = args.data[1];
+    Vector *vorigin_vec = args.ColumnCount() >= 3 ? &args.data[2] : nullptr;
+    idx_t row_count = args.size();
+    tbox_vec.Flatten(row_count);
+    vsize_vec.Flatten(row_count);
+    if (vorigin_vec) vorigin_vec->Flatten(row_count);
+
+    auto &result_validity = FlatVector::Validity(result);
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &child_vector = ListVector::GetEntry(result);
+    child_vector.SetVectorType(VectorType::FLAT_VECTOR);
+    ListVector::Reserve(result, row_count);
+    idx_t total_offset = 0;
+
+    auto tbox_data = FlatVector::GetData<string_t>(tbox_vec);
+    for (idx_t i = 0; i < row_count; ++i) {
+        if (FlatVector::IsNull(tbox_vec, i) || FlatVector::IsNull(vsize_vec, i) ||
+            (vorigin_vec && FlatVector::IsNull(*vorigin_vec, i))) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        string_t blob = tbox_data[i];
+        TBox *box = (TBox *) malloc(blob.GetSize());
+        memcpy(box, blob.GetData(), blob.GetSize());
+
+        int count = 0;
+        TBox *tiles = nullptr;
+        if (box->span.spantype == T_INTSPAN) {
+            int32_t vsize = FlatVector::GetData<int32_t>(vsize_vec)[i];
+            int32_t vorigin = vorigin_vec ? FlatVector::GetData<int32_t>(*vorigin_vec)[i] : 0;
+            tiles = tintbox_value_tiles(box, vsize, vorigin, &count);
+        } else if (box->span.spantype == T_FLOATSPAN) {
+            double vsize = FlatVector::GetData<double>(vsize_vec)[i];
+            double vorigin = vorigin_vec ? FlatVector::GetData<double>(*vorigin_vec)[i] : 0.0;
+            tiles = tfloatbox_value_tiles(box, vsize, vorigin, &count);
+        } else {
+            free(box);
+            throw InvalidInputException("valueTiles: tbox has no value dimension");
+        }
+        free(box);
+        EmitTboxList(result, i, tiles, count, total_offset, list_entries, child_vector,
+                     result_validity);
+    }
+}
+
+// MobilityDB default torigin for time bins: '2000-01-03' (a Monday).
+// In MEOS PG-epoch microseconds that is 2 days * 86_400 * 1_000_000.
+constexpr int64_t DEFAULT_TIME_ORIGIN_MEOS = 2LL * 86400LL * 1000000LL;
+
+// timeTiles(tbox, duration [, torigin])
+void TboxTimeTilesExec(DataChunk &args, ExpressionState &, Vector &result) {
+    auto &tbox_vec = args.data[0];
+    auto &dur_vec = args.data[1];
+    Vector *torigin_vec = args.ColumnCount() >= 3 ? &args.data[2] : nullptr;
+    idx_t row_count = args.size();
+    tbox_vec.Flatten(row_count);
+    dur_vec.Flatten(row_count);
+    if (torigin_vec) torigin_vec->Flatten(row_count);
+
+    auto &result_validity = FlatVector::Validity(result);
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &child_vector = ListVector::GetEntry(result);
+    child_vector.SetVectorType(VectorType::FLAT_VECTOR);
+    ListVector::Reserve(result, row_count);
+    idx_t total_offset = 0;
+
+    auto tbox_data = FlatVector::GetData<string_t>(tbox_vec);
+    auto dur_data = FlatVector::GetData<interval_t>(dur_vec);
+    for (idx_t i = 0; i < row_count; ++i) {
+        if (FlatVector::IsNull(tbox_vec, i) || FlatVector::IsNull(dur_vec, i) ||
+            (torigin_vec && FlatVector::IsNull(*torigin_vec, i))) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        string_t blob = tbox_data[i];
+        TBox *box = (TBox *) malloc(blob.GetSize());
+        memcpy(box, blob.GetData(), blob.GetSize());
+
+        MeosInterval iv = IntervaltToInterval(dur_data[i]);
+        timestamp_tz_t torigin_meos;
+        torigin_meos.value = DEFAULT_TIME_ORIGIN_MEOS;
+        if (torigin_vec) {
+            timestamp_tz_t torigin_in = FlatVector::GetData<timestamp_tz_t>(*torigin_vec)[i];
+            torigin_meos = DuckDBToMeosTimestamp(torigin_in);
+        }
+
+        int count = 0;
+        TBox *tiles = nullptr;
+        if (box->span.spantype == T_INTSPAN) {
+            tiles = tintbox_time_tiles(box, &iv, (TimestampTz) torigin_meos.value, &count);
+        } else if (box->span.spantype == T_FLOATSPAN) {
+            tiles = tfloatbox_time_tiles(box, &iv, (TimestampTz) torigin_meos.value, &count);
+        } else {
+            free(box);
+            throw InvalidInputException("timeTiles: tbox has no value dimension to dispatch on");
+        }
+        free(box);
+        EmitTboxList(result, i, tiles, count, total_offset, list_entries, child_vector,
+                     result_validity);
+    }
+}
+
+// valueTimeTiles(tbox, vsize, duration [, vorigin, torigin])
+void TboxValueTimeTilesExec(DataChunk &args, ExpressionState &, Vector &result) {
+    auto &tbox_vec = args.data[0];
+    auto &vsize_vec = args.data[1];
+    auto &dur_vec = args.data[2];
+    Vector *vorigin_vec = args.ColumnCount() >= 4 ? &args.data[3] : nullptr;
+    Vector *torigin_vec = args.ColumnCount() >= 5 ? &args.data[4] : nullptr;
+    idx_t row_count = args.size();
+    tbox_vec.Flatten(row_count);
+    vsize_vec.Flatten(row_count);
+    dur_vec.Flatten(row_count);
+    if (vorigin_vec) vorigin_vec->Flatten(row_count);
+    if (torigin_vec) torigin_vec->Flatten(row_count);
+
+    auto &result_validity = FlatVector::Validity(result);
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &child_vector = ListVector::GetEntry(result);
+    child_vector.SetVectorType(VectorType::FLAT_VECTOR);
+    ListVector::Reserve(result, row_count);
+    idx_t total_offset = 0;
+
+    auto tbox_data = FlatVector::GetData<string_t>(tbox_vec);
+    auto dur_data = FlatVector::GetData<interval_t>(dur_vec);
+    for (idx_t i = 0; i < row_count; ++i) {
+        if (FlatVector::IsNull(tbox_vec, i) || FlatVector::IsNull(vsize_vec, i) ||
+            FlatVector::IsNull(dur_vec, i) ||
+            (vorigin_vec && FlatVector::IsNull(*vorigin_vec, i)) ||
+            (torigin_vec && FlatVector::IsNull(*torigin_vec, i))) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        string_t blob = tbox_data[i];
+        TBox *box = (TBox *) malloc(blob.GetSize());
+        memcpy(box, blob.GetData(), blob.GetSize());
+
+        MeosInterval iv = IntervaltToInterval(dur_data[i]);
+        timestamp_tz_t torigin_meos;
+        torigin_meos.value = DEFAULT_TIME_ORIGIN_MEOS;
+        if (torigin_vec) {
+            timestamp_tz_t torigin_in = FlatVector::GetData<timestamp_tz_t>(*torigin_vec)[i];
+            torigin_meos = DuckDBToMeosTimestamp(torigin_in);
+        }
+
+        int count = 0;
+        TBox *tiles = nullptr;
+        if (box->span.spantype == T_INTSPAN) {
+            int32_t vsize = FlatVector::GetData<int32_t>(vsize_vec)[i];
+            int32_t vorigin = vorigin_vec ? FlatVector::GetData<int32_t>(*vorigin_vec)[i] : 0;
+            tiles = tintbox_value_time_tiles(box, vsize, &iv, vorigin,
+                                             (TimestampTz) torigin_meos.value, &count);
+        } else if (box->span.spantype == T_FLOATSPAN) {
+            double vsize = FlatVector::GetData<double>(vsize_vec)[i];
+            double vorigin = vorigin_vec ? FlatVector::GetData<double>(*vorigin_vec)[i] : 0.0;
+            tiles = tfloatbox_value_time_tiles(box, vsize, &iv, vorigin,
+                                               (TimestampTz) torigin_meos.value, &count);
+        } else {
+            free(box);
+            throw InvalidInputException("valueTimeTiles: tbox has no value dimension");
+        }
+        free(box);
+        EmitTboxList(result, i, tiles, count, total_offset, list_entries, child_vector,
+                     result_validity);
+    }
+}
+
+} // namespace
+
+void TemporalTypes::RegisterTileGetters(ExtensionLoader &loader) {
+    // Single-bin getters — getBin(value, size, origin) -> <type>span
+    loader.RegisterFunction(ScalarFunction(
+        "getBin", {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER},
+        SpanTypes::INTSPAN(), GetBinIntExec));
+    loader.RegisterFunction(ScalarFunction(
+        "getBin", {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT},
+        SpanTypes::BIGINTSPAN(), GetBinBigintExec));
+    loader.RegisterFunction(ScalarFunction(
+        "getBin", {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE},
+        SpanTypes::FLOATSPAN(), GetBinFloatExec));
+    loader.RegisterFunction(ScalarFunction(
+        "getBin", {LogicalType::TIMESTAMP_TZ, LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ},
+        SpanTypes::TSTZSPAN(), GetBinTstzExec));
+    loader.RegisterFunction(ScalarFunction(
+        "getBin", {LogicalType::DATE, LogicalType::INTERVAL, LogicalType::DATE},
+        SpanTypes::DATESPAN(), GetBinDateExec));
+
+    LogicalType list_tbox = LogicalType::LIST(TboxType::TBOX());
+
+    // valueTiles(tbox, vsize [, vorigin]) — both INTEGER and DOUBLE size variants
+    loader.RegisterFunction(ScalarFunction(
+        "valueTiles", {TboxType::TBOX(), LogicalType::INTEGER},
+        list_tbox, TboxValueTilesExec));
+    loader.RegisterFunction(ScalarFunction(
+        "valueTiles", {TboxType::TBOX(), LogicalType::INTEGER, LogicalType::INTEGER},
+        list_tbox, TboxValueTilesExec));
+    loader.RegisterFunction(ScalarFunction(
+        "valueTiles", {TboxType::TBOX(), LogicalType::DOUBLE},
+        list_tbox, TboxValueTilesExec));
+    loader.RegisterFunction(ScalarFunction(
+        "valueTiles", {TboxType::TBOX(), LogicalType::DOUBLE, LogicalType::DOUBLE},
+        list_tbox, TboxValueTilesExec));
+
+    // timeTiles(tbox, duration [, torigin])
+    loader.RegisterFunction(ScalarFunction(
+        "timeTiles", {TboxType::TBOX(), LogicalType::INTERVAL},
+        list_tbox, TboxTimeTilesExec));
+    loader.RegisterFunction(ScalarFunction(
+        "timeTiles", {TboxType::TBOX(), LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ},
+        list_tbox, TboxTimeTilesExec));
+
+    // valueTimeTiles(tbox, vsize, duration [, vorigin, torigin])
+    loader.RegisterFunction(ScalarFunction(
+        "valueTimeTiles", {TboxType::TBOX(), LogicalType::INTEGER, LogicalType::INTERVAL},
+        list_tbox, TboxValueTimeTilesExec));
+    loader.RegisterFunction(ScalarFunction(
+        "valueTimeTiles",
+        {TboxType::TBOX(), LogicalType::INTEGER, LogicalType::INTERVAL,
+         LogicalType::INTEGER, LogicalType::TIMESTAMP_TZ},
+        list_tbox, TboxValueTimeTilesExec));
+    loader.RegisterFunction(ScalarFunction(
+        "valueTimeTiles", {TboxType::TBOX(), LogicalType::DOUBLE, LogicalType::INTERVAL},
+        list_tbox, TboxValueTimeTilesExec));
+    loader.RegisterFunction(ScalarFunction(
+        "valueTimeTiles",
+        {TboxType::TBOX(), LogicalType::DOUBLE, LogicalType::INTERVAL,
+         LogicalType::DOUBLE, LogicalType::TIMESTAMP_TZ},
+        list_tbox, TboxValueTimeTilesExec));
 }
 
 } // namespace duckdb

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -31,6 +31,7 @@
 #include "temporal/set.hpp"
 #include "time_util.hpp"
 #include "geo/tgeompoint.hpp"
+#include "geo/tgeometry.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
@@ -922,6 +923,7 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
             set.AddFunction(MakeTaggAggregate<TcountTempFn>(t, TemporalTypes::TINT()));
         }
         set.AddFunction(MakeTaggAggregate<TcountTempFn>(TgeompointType::TGEOMPOINT(), TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TcountTempFn>(TGeometryTypes::TGEOMETRY(), TemporalTypes::TINT()));
 
         // Time-only inputs.
         set.AddFunction(AggregateFunction::UnaryAggregateDestructor<
@@ -984,6 +986,8 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
         }
         set.AddFunction(MakeTaggAggregate<MergeAggFn>(
             TgeompointType::TGEOMPOINT(), TgeompointType::TGEOMPOINT()));
+        set.AddFunction(MakeTaggAggregate<MergeAggFn>(
+            TGeometryTypes::TGEOMETRY(), TGeometryTypes::TGEOMETRY()));
         loader.RegisterFunction(std::move(set));
     }
 
@@ -995,6 +999,7 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
             set.AddFunction(MakeTemporalStateAggregate<AppendInstantAggFn>(t));
         }
         set.AddFunction(MakeTemporalStateAggregate<AppendInstantAggFn>(TgeompointType::TGEOMPOINT()));
+        set.AddFunction(MakeTemporalStateAggregate<AppendInstantAggFn>(TGeometryTypes::TGEOMETRY()));
         loader.RegisterFunction(std::move(set));
     }
 
@@ -1006,6 +1011,7 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
             set.AddFunction(MakeTemporalStateAggregate<AppendSequenceAggFn>(t));
         }
         set.AddFunction(MakeTemporalStateAggregate<AppendSequenceAggFn>(TgeompointType::TGEOMPOINT()));
+        set.AddFunction(MakeTemporalStateAggregate<AppendSequenceAggFn>(TGeometryTypes::TGEOMETRY()));
         loader.RegisterFunction(std::move(set));
     }
 

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -26,6 +26,10 @@
 #include "common.hpp"
 #include "temporal/temporal.hpp"
 #include "temporal/temporal_aggregates.hpp"
+#include "temporal/span.hpp"
+#include "temporal/spanset.hpp"
+#include "temporal/set.hpp"
+#include "time_util.hpp"
 #include "geo/tgeompoint.hpp"
 
 #include "duckdb/common/exception.hpp"
@@ -55,9 +59,28 @@ Datum datum_sum_double4(Datum, Datum);
 // Forward-decl: same signature as in meos/include/temporal/temporal_aggfuncs.h.
 SkipList *temporal_tagg_combinefn(SkipList *state1, SkipList *state2,
                                   datum_func2 func, bool crossings);
+SkipList *temporal_tagg_transfn(SkipList *state, const Temporal *temp,
+                                datum_func2 func, bool crossings);
+
+// Window-aggregate helpers — same signatures as in
+// meos/include/temporal/temporal_waggfuncs.h. (TSequence is already declared
+// by the MEOS public headers; we just refer to it.)
+TSequence **temporal_transform_wcount(const Temporal *temp,
+                                      const ::Interval *interval, int *count);
+SkipList *temporal_wagg_transform_transfn(SkipList *state, const Temporal *temp,
+                                          const ::Interval *interval, datum_func2 func,
+                                          TSequence ** (*transform)(const Temporal *, const ::Interval *, int *));
 }
 
 namespace {
+
+// Mirror of `struct GeoAggregateState` from MEOS's tgeo_aggfuncs.h. Used
+// only to peek at the `hasz` flag carried in `SkipList::extra` so we can
+// pick the correct datum_sum functor at combine time.
+struct GeoAggregateStateLayout {
+    int32_t srid;
+    bool hasz;
+};
 
 // Mirrors the elem-walk in MEOS skiplist_free, nulling out keys/values so
 // the subsequent skiplist_free only releases the structural memory.
@@ -167,9 +190,81 @@ struct TemporalSkipListAggFn {
 #define DECLARE_TAGG(NAME, TRANSFN, FINALFN, MERGE_FN, CROSSINGS) \
     using NAME = TemporalSkipListAggFn<TRANSFN, FINALFN, MERGE_FN, CROSSINGS>;
 
-DECLARE_TAGG(TandFn,         tbool_tand_transfn,        temporal_tagg_finalfn,  datum_and,           false)
-DECLARE_TAGG(TorFn,          tbool_tor_transfn,         temporal_tagg_finalfn,  datum_or,            false)
-DECLARE_TAGG(TcountTempFn,   temporal_tcount_transfn,   temporal_tagg_finalfn,  datum_sum_int32,     false)
+// TcountAgg variants over time-only inputs use distinct transfn signatures.
+// The blob-shaped ones (set / span / spanset) all funnel through a common
+// blob-casting wrapper; the scalar timestamptz one needs its own functor
+// since the input isn't a string_t blob.
+
+inline SkipList *TcountTstzsetTransfn(SkipList *state, const Temporal *blob) {
+    return tstzset_tcount_transfn(state, reinterpret_cast<const Set *>(blob));
+}
+inline SkipList *TcountTstzspanTransfn(SkipList *state, const Temporal *blob) {
+    return tstzspan_tcount_transfn(state, reinterpret_cast<const Span *>(blob));
+}
+inline SkipList *TcountTstzspansetTransfn(SkipList *state, const Temporal *blob) {
+    return tstzspanset_tcount_transfn(state, reinterpret_cast<const SpanSet *>(blob));
+}
+
+DECLARE_TAGG(TandFn,             tbool_tand_transfn,         temporal_tagg_finalfn,  datum_and,        false)
+DECLARE_TAGG(TorFn,              tbool_tor_transfn,          temporal_tagg_finalfn,  datum_or,         false)
+DECLARE_TAGG(TcountTempFn,       temporal_tcount_transfn,    temporal_tagg_finalfn,  datum_sum_int32,  false)
+DECLARE_TAGG(TcountTstzsetFn,    TcountTstzsetTransfn,       temporal_tagg_finalfn,  datum_sum_int32,  false)
+DECLARE_TAGG(TcountTstzspanFn,   TcountTstzspanTransfn,      temporal_tagg_finalfn,  datum_sum_int32,  false)
+DECLARE_TAGG(TcountTstzspansetFn, TcountTstzspansetTransfn,  temporal_tagg_finalfn,  datum_sum_int32,  false)
+
+// TcountAgg(timestamptz) — input is a scalar TimestampTz, not a blob.
+struct TcountTstzFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.skiplist = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        timestamp_tz_t meos_t = DuckDBToMeosTimestamp(input);
+        state.skiplist = timestamptz_tcount_transfn(state.skiplist, (TimestampTz) meos_t.value);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.skiplist) return;
+        if (!target.skiplist) {
+            target.skiplist = source.skiplist;
+            source.skiplist = nullptr;
+            return;
+        }
+        SkipList *result = temporal_tagg_combinefn(target.skiplist, source.skiplist,
+                                                   &datum_sum_int32, /*crossings=*/false);
+        SafeFreeLoserSkiplist(result, target.skiplist, source.skiplist);
+        target.skiplist = result;
+        source.skiplist = nullptr;
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.skiplist) { fd.ReturnNull(); return; }
+        Temporal *result = temporal_tagg_finalfn(state.skiplist);
+        SkipList *raw = state.skiplist;
+        state.skiplist = nullptr;
+        if (!result) {
+            skiplist_free(raw);
+            fd.ReturnNull();
+            return;
+        }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
 DECLARE_TAGG(TminTintFn,     tint_tmin_transfn,         temporal_tagg_finalfn,  datum_min_int32,     false)
 DECLARE_TAGG(TmaxTintFn,     tint_tmax_transfn,         temporal_tagg_finalfn,  datum_max_int32,     false)
 DECLARE_TAGG(TsumTintFn,     tint_tsum_transfn,         temporal_tagg_finalfn,  datum_sum_int32,     false)
@@ -209,16 +304,16 @@ struct TcentroidFn {
             return;
         }
         // Choose merge functor based on dimensionality stored in the
-        // skiplist's `extra` (a GeoAggregateState). Bit 0 of the first
-        // byte after the SkipList header is `hasz` per MEOS layout.
-        // Falling back to double3 (2D) if extra is null.
+        // skiplist's `extra` (a GeoAggregateState laid out as
+        // {int32 srid; bool hasz;}). Falling back to double3 (2D) if
+        // extra is null.
         datum_func2 func = &datum_sum_double3;
         const auto *extra = (target.skiplist && target.skiplist->extra)
                               ? target.skiplist->extra
                               : (source.skiplist ? source.skiplist->extra : nullptr);
         if (extra) {
-            // GeoAggregateState begins with `bool hasz;` — first byte.
-            if (*static_cast<const bool *>(extra)) {
+            const auto *gs = static_cast<const GeoAggregateStateLayout *>(extra);
+            if (gs->hasz) {
                 func = &datum_sum_double4;
             }
         }
@@ -257,6 +352,544 @@ static AggregateFunction MakeTaggAggregate(const LogicalType &input_type, const 
         SkipListState, string_t, string_t, OP, AggregateDestructorType::LEGACY>(input_type, return_type);
 }
 
+// =====================================================================
+// Window aggregates (W*Agg): binary aggregate over (Temporal, Interval).
+// State = SkipList *, transfn takes the extra Interval, combinefn is the
+// same as for the non-windowed variant.
+// =====================================================================
+
+template <
+    SkipList *(*TRANSFN)(SkipList *, const Temporal *, const ::Interval *),
+    Temporal *(*FINALFN)(SkipList *),
+    Datum (*MERGE_FN)(Datum, Datum),
+    bool CROSSINGS = false>
+struct WindowAggFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.skiplist = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class A_TYPE, class B_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const A_TYPE &input, const B_TYPE &interv,
+                          AggregateBinaryInput &) {
+        const Temporal *t = reinterpret_cast<const Temporal *>(input.GetData());
+        MeosInterval iv = IntervaltToInterval(interv);
+        state.skiplist = TRANSFN(state.skiplist, t, &iv);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.skiplist) return;
+        if (!target.skiplist) {
+            target.skiplist = source.skiplist;
+            source.skiplist = nullptr;
+            return;
+        }
+        SkipList *result = temporal_tagg_combinefn(target.skiplist, source.skiplist,
+                                                   MERGE_FN, CROSSINGS);
+        SafeFreeLoserSkiplist(result, target.skiplist, source.skiplist);
+        target.skiplist = result;
+        source.skiplist = nullptr;
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.skiplist) { fd.ReturnNull(); return; }
+        Temporal *result = FINALFN(state.skiplist);
+        SkipList *raw = state.skiplist;
+        state.skiplist = nullptr;
+        if (!result) {
+            skiplist_free(raw);
+            fd.ReturnNull();
+            return;
+        }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+// WcountAgg: input is transformed through `temporal_transform_wcount`
+// before being aggregated with `datum_sum_int32`. The result is always
+// a tint regardless of input subtype.
+struct WcountAggFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.skiplist = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class A_TYPE, class B_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const A_TYPE &input, const B_TYPE &interv,
+                          AggregateBinaryInput &) {
+        const Temporal *t = reinterpret_cast<const Temporal *>(input.GetData());
+        MeosInterval iv = IntervaltToInterval(interv);
+        state.skiplist = temporal_wagg_transform_transfn(
+            state.skiplist, t, &iv, &datum_sum_int32, &temporal_transform_wcount);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.skiplist) return;
+        if (!target.skiplist) {
+            target.skiplist = source.skiplist;
+            source.skiplist = nullptr;
+            return;
+        }
+        SkipList *result = temporal_tagg_combinefn(target.skiplist, source.skiplist,
+                                                   &datum_sum_int32, /*crossings=*/false);
+        SafeFreeLoserSkiplist(result, target.skiplist, source.skiplist);
+        target.skiplist = result;
+        source.skiplist = nullptr;
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.skiplist) { fd.ReturnNull(); return; }
+        Temporal *result = temporal_tagg_finalfn(state.skiplist);
+        SkipList *raw = state.skiplist;
+        state.skiplist = nullptr;
+        if (!result) {
+            skiplist_free(raw);
+            fd.ReturnNull();
+            return;
+        }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+// Concrete window aggregates.
+using WminTintFn   = WindowAggFn<tint_wmin_transfn,   temporal_tagg_finalfn, datum_min_int32,  false>;
+using WmaxTintFn   = WindowAggFn<tint_wmax_transfn,   temporal_tagg_finalfn, datum_max_int32,  false>;
+using WsumTintFn   = WindowAggFn<tint_wsum_transfn,   temporal_tagg_finalfn, datum_sum_int32,  false>;
+using WminTfloatFn = WindowAggFn<tfloat_wmin_transfn, temporal_tagg_finalfn, datum_min_float8, true>;
+using WmaxTfloatFn = WindowAggFn<tfloat_wmax_transfn, temporal_tagg_finalfn, datum_max_float8, true>;
+using WsumTfloatFn = WindowAggFn<tfloat_wsum_transfn, temporal_tagg_finalfn, datum_sum_float8, false>;
+using WavgFn       = WindowAggFn<tnumber_wavg_transfn, tnumber_tavg_finalfn,  datum_sum_double2, false>;
+
+template <class OP>
+static AggregateFunction MakeWindowAggregate(const LogicalType &input_type, const LogicalType &return_type) {
+    auto fn = AggregateFunction::BinaryAggregate<
+        SkipListState, string_t, interval_t, string_t, OP, AggregateDestructorType::LEGACY>(
+        input_type, LogicalType::INTERVAL, return_type);
+    fn.destructor = AggregateFunction::StateDestroy<SkipListState, OP>;
+    return fn;
+}
+
+// =====================================================================
+// MergeAgg: same SkipList state, but with no per-instant merge functor.
+// MEOS treats `func == NULL` as "concatenate values without conflict
+// resolution"; the resulting Temporal is the merged sequence/sequenceset.
+// =====================================================================
+
+inline SkipList *MergeTransfn(SkipList *state, const Temporal *temp) {
+    return temporal_tagg_transfn(state, temp, /*func=*/nullptr, /*crossings=*/false);
+}
+
+struct MergeAggFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.skiplist = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Temporal *t = reinterpret_cast<const Temporal *>(input.GetData());
+        state.skiplist = MergeTransfn(state.skiplist, t);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.skiplist) return;
+        if (!target.skiplist) {
+            target.skiplist = source.skiplist;
+            source.skiplist = nullptr;
+            return;
+        }
+        SkipList *result = temporal_tagg_combinefn(target.skiplist, source.skiplist,
+                                                   /*func=*/nullptr, /*crossings=*/false);
+        SafeFreeLoserSkiplist(result, target.skiplist, source.skiplist);
+        target.skiplist = result;
+        source.skiplist = nullptr;
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.skiplist) { fd.ReturnNull(); return; }
+        Temporal *result = temporal_tagg_finalfn(state.skiplist);
+        SkipList *raw = state.skiplist;
+        state.skiplist = nullptr;
+        if (!result) {
+            skiplist_free(raw);
+            fd.ReturnNull();
+            return;
+        }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+// =====================================================================
+// AppendInstantAgg / AppendSequenceAgg: state shape is `Temporal *`
+// (not a SkipList). The MEOS transfn mutates the state Temporal in
+// place and returns either the same pointer or a freshly-allocated
+// successor. Combine merges two states via the public `temporal_merge`.
+// =====================================================================
+
+struct TemporalState {
+    Temporal *value;
+};
+
+template <Temporal *(*COMBINE_MERGE)(const Temporal *, const Temporal *) = temporal_merge>
+struct TemporalStateCombineBase {
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.value) return;
+        if (!target.value) {
+            target.value = source.value;
+            source.value = nullptr;
+            return;
+        }
+        Temporal *merged = COMBINE_MERGE(target.value, source.value);
+        free(target.value);
+        free(source.value);
+        target.value = merged;
+        source.value = nullptr;
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.value) { fd.ReturnNull(); return; }
+        Temporal *result = temporal_compact(state.value);
+        free(state.value);
+        state.value = nullptr;
+        if (!result) { fd.ReturnNull(); return; }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.value) {
+            free(state.value);
+            state.value = nullptr;
+        }
+    }
+};
+
+// AppendInstantAgg(temporal) — uses default LINEAR-or-discrete interpretation
+// inferred from the temporal subtype, no maxdist / maxt thresholds.
+struct AppendInstantAggFn : TemporalStateCombineBase<> {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.value = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Temporal *t = reinterpret_cast<const Temporal *>(input.GetData());
+        // The MEOS transfn expects a TInstant *; an aggregate input that
+        // is already a sequence falls through to AppendSequenceAgg.
+        const TInstant *inst = reinterpret_cast<const TInstant *>(t);
+        // INTERP_NONE lets MEOS pick the natural interpretation for the
+        // base type (DISCRETE for tbool/ttext, LINEAR for tnumber/tgeo).
+        state.value = temporal_app_tinst_transfn(
+            state.value, inst, INTERP_NONE, /*maxdist=*/0.0, /*maxt=*/nullptr);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+};
+
+// AppendSequenceAgg(temporal) — input is already a TSequence.
+struct AppendSequenceAggFn : TemporalStateCombineBase<> {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.value = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Temporal *t = reinterpret_cast<const Temporal *>(input.GetData());
+        const TSequence *seq = reinterpret_cast<const TSequence *>(t);
+        state.value = temporal_app_tseq_transfn(state.value, seq);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+};
+
+template <class OP>
+static AggregateFunction MakeTemporalStateAggregate(const LogicalType &type) {
+    return AggregateFunction::UnaryAggregateDestructor<
+        TemporalState, string_t, string_t, OP, AggregateDestructorType::LEGACY>(type, type);
+}
+
+// =====================================================================
+// SpanUnionAgg: state shape is `SpanSet *`. Each input span/spanset is
+// folded into the state via MEOS's union transfns. Final state is the
+// state itself (no separate finalfn — `spanset_union_finalfn` is a
+// passthrough at this point).
+// =====================================================================
+
+struct SpanSetState {
+    SpanSet *value;
+};
+
+template <class STATE>
+inline void SpanSetCombine(STATE &source, STATE &target) {
+    if (!source.value) return;
+    if (!target.value) {
+        target.value = source.value;
+        source.value = nullptr;
+        return;
+    }
+    // spanset_union_transfn either mutates target.value in place (returns
+    // the same pointer) or frees it and returns a fresh allocation; in
+    // both cases the old target should not be freed by us. The source is
+    // a const input — we own it independently and must free it.
+    target.value = spanset_union_transfn(target.value, source.value);
+    free(source.value);
+    source.value = nullptr;
+}
+
+template <class T, class STATE>
+inline void SpanSetFinalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+    if (!state.value) { fd.ReturnNull(); return; }
+    // spanset_union_finalfn frees the state internally on the success
+    // path, so clear the pointer first to prevent Destroy from
+    // double-freeing if anything below throws.
+    SpanSet *result = spanset_union_finalfn(state.value);
+    state.value = nullptr;
+    if (!result) { fd.ReturnNull(); return; }
+    size_t size = (size_t) spanset_mem_size(result);
+    target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+    free(result);
+}
+
+template <class STATE>
+inline void SpanSetDestroy(STATE &state) {
+    if (state.value) {
+        free(state.value);
+        state.value = nullptr;
+    }
+}
+
+// SpanUnionAgg(<typed-span>) — input is a Span blob.
+struct SpanUnionFromSpanFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.value = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const Span *s = reinterpret_cast<const Span *>(input.GetData());
+        state.value = span_union_transfn(state.value, s);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        SpanSetCombine(const_cast<STATE &>(source_const), target);
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        SpanSetFinalize(state, target, fd);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) { SpanSetDestroy(state); }
+};
+
+// SpanUnionAgg(<typed-spanset>) — input is a SpanSet blob.
+struct SpanUnionFromSpanSetFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.value = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        const SpanSet *ss = reinterpret_cast<const SpanSet *>(input.GetData());
+        state.value = spanset_union_transfn(state.value, ss);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        SpanSetCombine(const_cast<STATE &>(source_const), target);
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        SpanSetFinalize(state, target, fd);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) { SpanSetDestroy(state); }
+};
+
+template <class OP>
+static AggregateFunction MakeSpanSetAggregate(const LogicalType &input_type, const LogicalType &return_type) {
+    return AggregateFunction::UnaryAggregateDestructor<
+        SpanSetState, string_t, string_t, OP, AggregateDestructorType::LEGACY>(input_type, return_type);
+}
+
+// =====================================================================
+// SetUnionAgg: state shape is `Set *`. Inputs come in two flavours —
+// scalars (folded via `value_union_transfn`) and sets (folded via
+// `set_union_transfn`).
+// =====================================================================
+
+struct SetAggState {
+    Set *value;
+};
+
+template <class STATE>
+inline void SetCombine(STATE &source, STATE &target) {
+    if (!source.value) return;
+    if (!target.value) {
+        target.value = source.value;
+        source.value = nullptr;
+        return;
+    }
+    // Same ownership story as SpanSetCombine: transfn handles target;
+    // source is a separate allocation we own.
+    target.value = set_union_transfn(target.value, source.value);
+    free(source.value);
+    source.value = nullptr;
+}
+
+template <class T, class STATE>
+inline void SetFinalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+    if (!state.value) { fd.ReturnNull(); return; }
+    // set_union_finalfn frees the state internally on the success path.
+    Set *result = set_union_finalfn(state.value);
+    state.value = nullptr;
+    if (!result) { fd.ReturnNull(); return; }
+    size_t size = (size_t) set_mem_size(result);
+    target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+    free(result);
+}
+
+template <class STATE>
+inline void SetDestroy(STATE &state) {
+    if (state.value) {
+        free(state.value);
+        state.value = nullptr;
+    }
+}
+
+// SetUnionAgg(<typed-set>) — input is a Set blob.
+struct SetUnionFromSetFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.value = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        Set *s = const_cast<Set *>(reinterpret_cast<const Set *>(input.GetData()));
+        state.value = set_union_transfn(state.value, s);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        SetCombine(const_cast<STATE &>(source_const), target);
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        SetFinalize(state, target, fd);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) { SetDestroy(state); }
+};
+
+// SetUnionAgg(<scalar>) — input is a primitive value lifted to a Datum.
+template <class IN, Datum (*TO_DATUM)(IN), meosType BASETYPE>
+struct SetUnionFromScalarFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.value = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        state.value = value_union_transfn(state.value, TO_DATUM(input), BASETYPE);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        SetCombine(const_cast<STATE &>(source_const), target);
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        SetFinalize(state, target, fd);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) { SetDestroy(state); }
+};
+
+// Datum casting helpers — MobilityDuck doesn't pull in PG's `postgres.h`,
+// so we cast explicitly. For floats this is a bit-pattern reinterpret; for
+// integer / date / tstz a sign-extending widening to int64 covers both 64-
+// and 32-bit Datum builds.
+inline Datum Int32ToDatum(int32_t v) { return (Datum) (int64_t) v; }
+inline Datum Int64ToDatum(int64_t v) { return (Datum) v; }
+inline Datum Float8ToDatum(double v) {
+    Datum d;
+    static_assert(sizeof(d) == sizeof(v), "Datum must be 64-bit");
+    memcpy(&d, &v, sizeof(d));
+    return d;
+}
+inline Datum DateToDatum(date_t v) { return (Datum) (int64_t) ToMeosDate(v); }
+inline Datum TstzToDatum(timestamp_tz_t v) {
+    return (Datum) (int64_t) DuckDBToMeosTimestamp(v).value;
+}
+
+template <class OP>
+static AggregateFunction MakeSetAggregate(const LogicalType &input_type, const LogicalType &return_type) {
+    return AggregateFunction::UnaryAggregateDestructor<
+        SetAggState, string_t, string_t, OP, AggregateDestructorType::LEGACY>(input_type, return_type);
+}
+
+template <class IN, Datum (*TO_DATUM)(IN), meosType BASETYPE>
+static AggregateFunction MakeSetUnionScalarAggregate(const LogicalType &input_type,
+                                                     const LogicalType &return_type) {
+    return AggregateFunction::UnaryAggregateDestructor<
+        SetAggState, IN, string_t,
+        SetUnionFromScalarFn<IN, TO_DATUM, BASETYPE>,
+        AggregateDestructorType::LEGACY>(input_type, return_type);
+}
+
 } // namespace
 
 void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
@@ -281,7 +914,7 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(set));
     }
 
-    // ---- TcountAgg over each temporal type → tint ----
+    // ---- TcountAgg over each temporal type and over time-only inputs → tint ----
     {
         AggregateFunctionSet set("TcountAgg");
         for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
@@ -289,6 +922,16 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
             set.AddFunction(MakeTaggAggregate<TcountTempFn>(t, TemporalTypes::TINT()));
         }
         set.AddFunction(MakeTaggAggregate<TcountTempFn>(TgeompointType::TGEOMPOINT(), TemporalTypes::TINT()));
+
+        // Time-only inputs.
+        set.AddFunction(AggregateFunction::UnaryAggregateDestructor<
+            SkipListState, timestamp_tz_t, string_t, TcountTstzFn,
+            AggregateDestructorType::LEGACY>(
+            LogicalType::TIMESTAMP_TZ, TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TcountTstzsetFn>(    SetTypes::tstzset(),         TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TcountTstzspanFn>(   SpanTypes::TSTZSPAN(),       TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TcountTstzspansetFn>(SpansetTypes::tstzspanset(), TemporalTypes::TINT()));
+
         loader.RegisterFunction(std::move(set));
     }
 
@@ -329,6 +972,132 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
         AggregateFunctionSet set("TcentroidAgg");
         set.AddFunction(MakeTaggAggregate<TcentroidFn>(
             TgeompointType::TGEOMPOINT(), TgeompointType::TGEOMPOINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- MergeAgg over each temporal type → same type ----
+    {
+        AggregateFunctionSet set("MergeAgg");
+        for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
+                              TemporalTypes::TFLOAT(), TemporalTypes::TTEXT()}) {
+            set.AddFunction(MakeTaggAggregate<MergeAggFn>(t, t));
+        }
+        set.AddFunction(MakeTaggAggregate<MergeAggFn>(
+            TgeompointType::TGEOMPOINT(), TgeompointType::TGEOMPOINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- AppendInstantAgg over each temporal type → same type ----
+    {
+        AggregateFunctionSet set("AppendInstantAgg");
+        for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
+                              TemporalTypes::TFLOAT(), TemporalTypes::TTEXT()}) {
+            set.AddFunction(MakeTemporalStateAggregate<AppendInstantAggFn>(t));
+        }
+        set.AddFunction(MakeTemporalStateAggregate<AppendInstantAggFn>(TgeompointType::TGEOMPOINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- AppendSequenceAgg over each temporal type → same type ----
+    {
+        AggregateFunctionSet set("AppendSequenceAgg");
+        for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
+                              TemporalTypes::TFLOAT(), TemporalTypes::TTEXT()}) {
+            set.AddFunction(MakeTemporalStateAggregate<AppendSequenceAggFn>(t));
+        }
+        set.AddFunction(MakeTemporalStateAggregate<AppendSequenceAggFn>(TgeompointType::TGEOMPOINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- SpanUnionAgg(span | spanset) -> typed spanset ----
+    struct SpanInputPair {
+        LogicalType in;
+        LogicalType out;
+    };
+    {
+        AggregateFunctionSet set("SpanUnionAgg");
+        const std::vector<SpanInputPair> span_pairs = {
+            {SpanTypes::INTSPAN(),     SpansetTypes::intspanset()},
+            {SpanTypes::BIGINTSPAN(),  SpansetTypes::bigintspanset()},
+            {SpanTypes::FLOATSPAN(),   SpansetTypes::floatspanset()},
+            {SpanTypes::DATESPAN(),    SpansetTypes::datespanset()},
+            {SpanTypes::TSTZSPAN(),    SpansetTypes::tstzspanset()},
+        };
+        for (const auto &p : span_pairs) {
+            set.AddFunction(MakeSpanSetAggregate<SpanUnionFromSpanFn>(p.in, p.out));
+        }
+        const std::vector<SpanInputPair> spanset_pairs = {
+            {SpansetTypes::intspanset(),    SpansetTypes::intspanset()},
+            {SpansetTypes::bigintspanset(), SpansetTypes::bigintspanset()},
+            {SpansetTypes::floatspanset(),  SpansetTypes::floatspanset()},
+            {SpansetTypes::datespanset(),   SpansetTypes::datespanset()},
+            {SpansetTypes::tstzspanset(),   SpansetTypes::tstzspanset()},
+        };
+        for (const auto &p : spanset_pairs) {
+            set.AddFunction(MakeSpanSetAggregate<SpanUnionFromSpanSetFn>(p.in, p.out));
+        }
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- Window aggregates: WminAgg / WmaxAgg / WsumAgg / WcountAgg / WavgAgg ----
+    {
+        AggregateFunctionSet set("WminAgg");
+        set.AddFunction(MakeWindowAggregate<WminTintFn>(TemporalTypes::TINT(),     TemporalTypes::TINT()));
+        set.AddFunction(MakeWindowAggregate<WminTfloatFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(set));
+    }
+    {
+        AggregateFunctionSet set("WmaxAgg");
+        set.AddFunction(MakeWindowAggregate<WmaxTintFn>(TemporalTypes::TINT(),     TemporalTypes::TINT()));
+        set.AddFunction(MakeWindowAggregate<WmaxTfloatFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(set));
+    }
+    {
+        AggregateFunctionSet set("WsumAgg");
+        set.AddFunction(MakeWindowAggregate<WsumTintFn>(TemporalTypes::TINT(),     TemporalTypes::TINT()));
+        set.AddFunction(MakeWindowAggregate<WsumTfloatFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(set));
+    }
+    {
+        AggregateFunctionSet set("WcountAgg");
+        set.AddFunction(MakeWindowAggregate<WcountAggFn>(TemporalTypes::TINT(),    TemporalTypes::TINT()));
+        set.AddFunction(MakeWindowAggregate<WcountAggFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+    {
+        AggregateFunctionSet set("WavgAgg");
+        set.AddFunction(MakeWindowAggregate<WavgFn>(TemporalTypes::TINT(),    TemporalTypes::TFLOAT()));
+        set.AddFunction(MakeWindowAggregate<WavgFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- SetUnionAgg(<scalar | typed-set>) -> typed set ----
+    {
+        AggregateFunctionSet set("SetUnionAgg");
+        // Scalar inputs.
+        set.AddFunction(MakeSetUnionScalarAggregate<int32_t, Int32ToDatum, T_INT4>(
+            LogicalType::INTEGER, SetTypes::intset()));
+        set.AddFunction(MakeSetUnionScalarAggregate<int64_t, Int64ToDatum, T_INT8>(
+            LogicalType::BIGINT, SetTypes::bigintset()));
+        set.AddFunction(MakeSetUnionScalarAggregate<double, Float8ToDatum, T_FLOAT8>(
+            LogicalType::DOUBLE, SetTypes::floatset()));
+        set.AddFunction(MakeSetUnionScalarAggregate<date_t, DateToDatum, T_DATE>(
+            LogicalType::DATE, SetTypes::dateset()));
+        set.AddFunction(MakeSetUnionScalarAggregate<timestamp_tz_t, TstzToDatum, T_TIMESTAMPTZ>(
+            LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()));
+
+        // Set inputs.
+        const std::vector<SpanInputPair> set_pairs = {
+            {SetTypes::intset(),     SetTypes::intset()},
+            {SetTypes::bigintset(),  SetTypes::bigintset()},
+            {SetTypes::floatset(),   SetTypes::floatset()},
+            {SetTypes::textset(),    SetTypes::textset()},
+            {SetTypes::dateset(),    SetTypes::dateset()},
+            {SetTypes::tstzset(),    SetTypes::tstzset()},
+        };
+        for (const auto &p : set_pairs) {
+            set.AddFunction(MakeSetAggregate<SetUnionFromSetFn>(p.in, p.out));
+        }
         loader.RegisterFunction(std::move(set));
     }
 }

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -1,6 +1,9 @@
-// SkipList-state temporal aggregates: tcount, tand, tor, tmin, tmax, tsum,
-// tavg, tcentroid. These differ from the fixed-state `extent()` aggregates
-// in two ways:
+// SkipList-state temporal aggregates: TcountAgg, TandAgg, TorAgg, TminAgg,
+// TmaxAgg, TsumAgg, TavgAgg, TcentroidAgg. Names follow MobilityDB RFC #827:
+// every SkipList aggregate is exposed under a Pascal-cased *Agg identifier,
+// disambiguating it from the same-stem scalar accessors (Tmin(tbox), etc.)
+// in case-folding catalogs like DuckDB. These differ from the fixed-state
+// `extent()` aggregates in two ways:
 //
 //   1. State holds a `SkipList *` pointer; the skiplist owns variable-size
 //      heap-allocated Temporal* values, so the aggregate needs a destructor.
@@ -257,21 +260,30 @@ static AggregateFunction MakeTaggAggregate(const LogicalType &input_type, const 
 } // namespace
 
 void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
-    // ---- tand / tor on tbool ----
+    // SkipList aggregates are registered under the Pascal-cased *Agg names
+    // proposed in MobilityDB RFC #827. These avoid the case-folding
+    // collision DuckDB's catalog hits when an aggregate and a scalar share
+    // a canonical lowercase name (e.g. previously `tmin` aggregate vs the
+    // existing `Tmin(tbox)` scalar). The MobilityDB upstream PR #828 adds
+    // the matching aliases on the PG side; the original aggregate names
+    // (`tand`, `tcount`, etc.) remain valid in PG for backward compat but
+    // collide in DuckDB and are intentionally not registered here.
+
+    // ---- TandAgg / TorAgg on tbool ----
     {
-        AggregateFunctionSet set("tand");
+        AggregateFunctionSet set("TandAgg");
         set.AddFunction(MakeTaggAggregate<TandFn>(TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
         loader.RegisterFunction(std::move(set));
     }
     {
-        AggregateFunctionSet set("tor");
+        AggregateFunctionSet set("TorAgg");
         set.AddFunction(MakeTaggAggregate<TorFn>(TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
         loader.RegisterFunction(std::move(set));
     }
 
-    // ---- tcount over each temporal type → tint ----
+    // ---- TcountAgg over each temporal type → tint ----
     {
-        AggregateFunctionSet set("tcount");
+        AggregateFunctionSet set("TcountAgg");
         for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
                               TemporalTypes::TFLOAT(), TemporalTypes::TTEXT()}) {
             set.AddFunction(MakeTaggAggregate<TcountTempFn>(t, TemporalTypes::TINT()));
@@ -280,38 +292,41 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(set));
     }
 
-    // ---- tmin / tmax — DEFERRED ----
-    //
-    // The MobilityDB SQL surface has two semantically-different functions
-    // sharing a case-insensitive name: scalar `Tmin(tbox|stbox) -> timestamptz`
-    // (already registered in tbox.cpp / stbox.cpp) and aggregate
-    // `tMin(tint|tfloat|ttext) -> Temporal`. PostgreSQL dispatches by the
-    // argument-types tuple, but DuckDB's catalog folds both onto a single
-    // canonical lowercase name `tmin` and rejects mixing scalar + aggregate
-    // overloads on the same name (catalog raises "GetAlterInfo not
-    // implemented for this type"). Resolving this requires either renaming
-    // the existing box scalars or registering the aggregate under a
-    // disambiguated name. Out of scope for this PR.
-
-    // ---- tsum on tint, tfloat ----
+    // ---- TminAgg / TmaxAgg on tint, tfloat, ttext ----
     {
-        AggregateFunctionSet set("tsum");
+        AggregateFunctionSet set("TminAgg");
+        set.AddFunction(MakeTaggAggregate<TminTintFn>(TemporalTypes::TINT(),    TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TminTfloatFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        set.AddFunction(MakeTaggAggregate<TminTtextFn>(TemporalTypes::TTEXT(),   TemporalTypes::TTEXT()));
+        loader.RegisterFunction(std::move(set));
+    }
+    {
+        AggregateFunctionSet set("TmaxAgg");
+        set.AddFunction(MakeTaggAggregate<TmaxTintFn>(TemporalTypes::TINT(),    TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TmaxTfloatFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        set.AddFunction(MakeTaggAggregate<TmaxTtextFn>(TemporalTypes::TTEXT(),   TemporalTypes::TTEXT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- TsumAgg on tint, tfloat ----
+    {
+        AggregateFunctionSet set("TsumAgg");
         set.AddFunction(MakeTaggAggregate<TsumTintFn>(TemporalTypes::TINT(),    TemporalTypes::TINT()));
         set.AddFunction(MakeTaggAggregate<TsumTfloatFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
         loader.RegisterFunction(std::move(set));
     }
 
-    // ---- tavg on tint, tfloat → tfloat ----
+    // ---- TavgAgg on tint, tfloat → tfloat ----
     {
-        AggregateFunctionSet set("tavg");
+        AggregateFunctionSet set("TavgAgg");
         set.AddFunction(MakeTaggAggregate<TavgFn>(TemporalTypes::TINT(),  TemporalTypes::TFLOAT()));
         set.AddFunction(MakeTaggAggregate<TavgFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
         loader.RegisterFunction(std::move(set));
     }
 
-    // ---- tcentroid on tgeompoint → tgeompoint ----
+    // ---- TcentroidAgg on tgeompoint → tgeompoint ----
     {
-        AggregateFunctionSet set("tcentroid");
+        AggregateFunctionSet set("TcentroidAgg");
         set.AddFunction(MakeTaggAggregate<TcentroidFn>(
             TgeompointType::TGEOMPOINT(), TgeompointType::TGEOMPOINT()));
         loader.RegisterFunction(std::move(set));

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -1,0 +1,321 @@
+// SkipList-state temporal aggregates: tcount, tand, tor, tmin, tmax, tsum,
+// tavg, tcentroid. These differ from the fixed-state `extent()` aggregates
+// in two ways:
+//
+//   1. State holds a `SkipList *` pointer; the skiplist owns variable-size
+//      heap-allocated Temporal* values, so the aggregate needs a destructor.
+//
+//   2. Combine merges two skiplists via MEOS's `temporal_tagg_combinefn`.
+//      That function is exported from libmeos but not declared in the
+//      installed public headers, so we forward-declare it here. Same goes
+//      for the `datum_*` per-aggregate merge functors.
+//
+// The MEOS combine semantics share Temporal* pointers between the two input
+// skiplists once both are non-empty: the returned skiplist holds the merged
+// elements while the "loser" skiplist still references the same pointers.
+// We can't call the standard `skiplist_free` on the loser without double-
+// freeing, so after combine we walk the loser's elements and NULL out their
+// keys/values before calling `skiplist_free` (which then only releases the
+// SkipList struct + freed[] array + elem array).
+
+#include "meos_wrapper_simple.hpp"
+
+#include "common.hpp"
+#include "temporal/temporal.hpp"
+#include "temporal/temporal_aggregates.hpp"
+#include "geo/tgeompoint.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+extern "C" {
+// Per-aggregate merge functions (exported from libmeos.a but not in the
+// public headers).
+Datum datum_and(Datum, Datum);
+Datum datum_or(Datum, Datum);
+Datum datum_min_int32(Datum, Datum);
+Datum datum_max_int32(Datum, Datum);
+Datum datum_sum_int32(Datum, Datum);
+Datum datum_min_float8(Datum, Datum);
+Datum datum_max_float8(Datum, Datum);
+Datum datum_sum_float8(Datum, Datum);
+Datum datum_min_text(Datum, Datum);
+Datum datum_max_text(Datum, Datum);
+Datum datum_sum_double2(Datum, Datum);
+Datum datum_sum_double3(Datum, Datum);
+Datum datum_sum_double4(Datum, Datum);
+
+// Forward-decl: same signature as in meos/include/temporal/temporal_aggfuncs.h.
+SkipList *temporal_tagg_combinefn(SkipList *state1, SkipList *state2,
+                                  datum_func2 func, bool crossings);
+}
+
+namespace {
+
+// Mirrors the elem-walk in MEOS skiplist_free, nulling out keys/values so
+// the subsequent skiplist_free only releases the structural memory.
+void NullSkiplistElements(SkipList *list) {
+    if (!list || !list->elems) return;
+    int cur = 0;
+    while (cur != -1) {
+        SkipListElem *elem = &list->elems[cur];
+        elem->key = nullptr;
+        elem->value = nullptr;
+        cur = elem->next[0];
+    }
+}
+
+void SafeFreeLoserSkiplist(SkipList *result, SkipList *a, SkipList *b) {
+    SkipList *loser = (result == a) ? b : a;
+    if (loser) {
+        NullSkiplistElements(loser);
+        skiplist_free(loser);
+    }
+}
+
+// Aggregate state — one pointer.
+struct SkipListState {
+    SkipList *skiplist;
+};
+
+// Generic SkipList aggregate over Temporal inputs.
+//
+//   TRANSFN     — MEOS transition function (state, blob_decoded_temporal).
+//   FINALFN     — MEOS finalize function (state -> Temporal *).
+//   MERGE_FN    — datum_func2 used by combinefn.
+//   CROSSINGS   — pass to combinefn (true for tfloat min/max).
+template <SkipList *(*TRANSFN)(SkipList *, const Temporal *),
+          Temporal *(*FINALFN)(SkipList *),
+          Datum (*MERGE_FN)(Datum, Datum),
+          bool CROSSINGS = false>
+struct TemporalSkipListAggFn {
+    template <class STATE>
+    static void Initialize(STATE &state) {
+        state.skiplist = nullptr;
+    }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        // Decode input blob to Temporal *. The MEOS transfn copies the
+        // value into the skiplist, so the transient blob memory is fine.
+        const Temporal *t = reinterpret_cast<const Temporal *>(input.GetData());
+        state.skiplist = TRANSFN(state.skiplist, t);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.skiplist) return;
+        if (!target.skiplist) {
+            target.skiplist = source.skiplist;
+            source.skiplist = nullptr;
+            return;
+        }
+        SkipList *result = temporal_tagg_combinefn(target.skiplist, source.skiplist,
+                                                   MERGE_FN, CROSSINGS);
+        SafeFreeLoserSkiplist(result, target.skiplist, source.skiplist);
+        target.skiplist = result;
+        source.skiplist = nullptr;
+    }
+
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.skiplist) {
+            fd.ReturnNull();
+            return;
+        }
+        Temporal *result = FINALFN(state.skiplist);
+        // MEOS finalfns release the skiplist themselves on the success
+        // path; on the empty-skiplist path they leave it intact and
+        // return NULL. Either way, we can no longer safely call
+        // skiplist_free on this pointer.
+        SkipList *raw = state.skiplist;
+        state.skiplist = nullptr;
+        if (!result) {
+            // Empty input → skiplist still allocated; release it now.
+            skiplist_free(raw);
+            fd.ReturnNull();
+            return;
+        }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+// Macro to declare a concrete aggregate type with a fixed return-type alias.
+#define DECLARE_TAGG(NAME, TRANSFN, FINALFN, MERGE_FN, CROSSINGS) \
+    using NAME = TemporalSkipListAggFn<TRANSFN, FINALFN, MERGE_FN, CROSSINGS>;
+
+DECLARE_TAGG(TandFn,         tbool_tand_transfn,        temporal_tagg_finalfn,  datum_and,           false)
+DECLARE_TAGG(TorFn,          tbool_tor_transfn,         temporal_tagg_finalfn,  datum_or,            false)
+DECLARE_TAGG(TcountTempFn,   temporal_tcount_transfn,   temporal_tagg_finalfn,  datum_sum_int32,     false)
+DECLARE_TAGG(TminTintFn,     tint_tmin_transfn,         temporal_tagg_finalfn,  datum_min_int32,     false)
+DECLARE_TAGG(TmaxTintFn,     tint_tmax_transfn,         temporal_tagg_finalfn,  datum_max_int32,     false)
+DECLARE_TAGG(TsumTintFn,     tint_tsum_transfn,         temporal_tagg_finalfn,  datum_sum_int32,     false)
+DECLARE_TAGG(TminTfloatFn,   tfloat_tmin_transfn,       temporal_tagg_finalfn,  datum_min_float8,    true)
+DECLARE_TAGG(TmaxTfloatFn,   tfloat_tmax_transfn,       temporal_tagg_finalfn,  datum_max_float8,    true)
+DECLARE_TAGG(TsumTfloatFn,   tfloat_tsum_transfn,       temporal_tagg_finalfn,  datum_sum_float8,    false)
+DECLARE_TAGG(TminTtextFn,    ttext_tmin_transfn,        temporal_tagg_finalfn,  datum_min_text,      false)
+DECLARE_TAGG(TmaxTtextFn,    ttext_tmax_transfn,        temporal_tagg_finalfn,  datum_max_text,      false)
+DECLARE_TAGG(TavgFn,         tnumber_tavg_transfn,      tnumber_tavg_finalfn,   datum_sum_double2,   false)
+
+// tcentroid: chooses sum_double3 (2D) vs sum_double4 (3D) based on input
+// dimension. We forward to the same templated functor via a runtime-chosen
+// merge func by branching at Combine time. To keep the templates simple we
+// use a small wrapper that overrides Combine.
+struct TcentroidFn {
+    template <class STATE>
+    static void Initialize(STATE &state) { state.skiplist = nullptr; }
+    static bool IgnoreNull() { return true; }
+
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &) {
+        // tpoint_tcentroid_transfn takes Temporal * (non-const), and copies.
+        Temporal *t = const_cast<Temporal *>(reinterpret_cast<const Temporal *>(input.GetData()));
+        state.skiplist = tpoint_tcentroid_transfn(state.skiplist, t);
+    }
+    template <class INPUT_TYPE, class STATE, class OP>
+    static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &u, idx_t) {
+        Operation<INPUT_TYPE, STATE, OP>(state, input, u);
+    }
+    template <class STATE, class OP>
+    static void Combine(const STATE &source_const, STATE &target, AggregateInputData &) {
+        STATE &source = const_cast<STATE &>(source_const);
+        if (!source.skiplist) return;
+        if (!target.skiplist) {
+            target.skiplist = source.skiplist;
+            source.skiplist = nullptr;
+            return;
+        }
+        // Choose merge functor based on dimensionality stored in the
+        // skiplist's `extra` (a GeoAggregateState). Bit 0 of the first
+        // byte after the SkipList header is `hasz` per MEOS layout.
+        // Falling back to double3 (2D) if extra is null.
+        datum_func2 func = &datum_sum_double3;
+        const auto *extra = (target.skiplist && target.skiplist->extra)
+                              ? target.skiplist->extra
+                              : (source.skiplist ? source.skiplist->extra : nullptr);
+        if (extra) {
+            // GeoAggregateState begins with `bool hasz;` — first byte.
+            if (*static_cast<const bool *>(extra)) {
+                func = &datum_sum_double4;
+            }
+        }
+        SkipList *result = temporal_tagg_combinefn(target.skiplist, source.skiplist, func, false);
+        SafeFreeLoserSkiplist(result, target.skiplist, source.skiplist);
+        target.skiplist = result;
+        source.skiplist = nullptr;
+    }
+    template <class T, class STATE>
+    static void Finalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+        if (!state.skiplist) { fd.ReturnNull(); return; }
+        Temporal *result = tpoint_tcentroid_finalfn(state.skiplist);
+        SkipList *raw = state.skiplist;
+        state.skiplist = nullptr;
+        if (!result) {
+            skiplist_free(raw);
+            fd.ReturnNull();
+            return;
+        }
+        size_t size = temporal_mem_size(result);
+        target = fd.ReturnString(string_t(reinterpret_cast<const char *>(result), size));
+        free(result);
+    }
+    template <class STATE>
+    static void Destroy(STATE &state, AggregateInputData &) {
+        if (state.skiplist) {
+            skiplist_free(state.skiplist);
+            state.skiplist = nullptr;
+        }
+    }
+};
+
+template <class OP>
+static AggregateFunction MakeTaggAggregate(const LogicalType &input_type, const LogicalType &return_type) {
+    return AggregateFunction::UnaryAggregateDestructor<
+        SkipListState, string_t, string_t, OP, AggregateDestructorType::LEGACY>(input_type, return_type);
+}
+
+} // namespace
+
+void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
+    // ---- tand / tor on tbool ----
+    {
+        AggregateFunctionSet set("tand");
+        set.AddFunction(MakeTaggAggregate<TandFn>(TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
+        loader.RegisterFunction(std::move(set));
+    }
+    {
+        AggregateFunctionSet set("tor");
+        set.AddFunction(MakeTaggAggregate<TorFn>(TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- tcount over each temporal type → tint ----
+    {
+        AggregateFunctionSet set("tcount");
+        for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
+                              TemporalTypes::TFLOAT(), TemporalTypes::TTEXT()}) {
+            set.AddFunction(MakeTaggAggregate<TcountTempFn>(t, TemporalTypes::TINT()));
+        }
+        set.AddFunction(MakeTaggAggregate<TcountTempFn>(TgeompointType::TGEOMPOINT(), TemporalTypes::TINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- tmin / tmax — DEFERRED ----
+    //
+    // The MobilityDB SQL surface has two semantically-different functions
+    // sharing a case-insensitive name: scalar `Tmin(tbox|stbox) -> timestamptz`
+    // (already registered in tbox.cpp / stbox.cpp) and aggregate
+    // `tMin(tint|tfloat|ttext) -> Temporal`. PostgreSQL dispatches by the
+    // argument-types tuple, but DuckDB's catalog folds both onto a single
+    // canonical lowercase name `tmin` and rejects mixing scalar + aggregate
+    // overloads on the same name (catalog raises "GetAlterInfo not
+    // implemented for this type"). Resolving this requires either renaming
+    // the existing box scalars or registering the aggregate under a
+    // disambiguated name. Out of scope for this PR.
+
+    // ---- tsum on tint, tfloat ----
+    {
+        AggregateFunctionSet set("tsum");
+        set.AddFunction(MakeTaggAggregate<TsumTintFn>(TemporalTypes::TINT(),    TemporalTypes::TINT()));
+        set.AddFunction(MakeTaggAggregate<TsumTfloatFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- tavg on tint, tfloat → tfloat ----
+    {
+        AggregateFunctionSet set("tavg");
+        set.AddFunction(MakeTaggAggregate<TavgFn>(TemporalTypes::TINT(),  TemporalTypes::TFLOAT()));
+        set.AddFunction(MakeTaggAggregate<TavgFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
+        loader.RegisterFunction(std::move(set));
+    }
+
+    // ---- tcentroid on tgeompoint → tgeompoint ----
+    {
+        AggregateFunctionSet set("tcentroid");
+        set.AddFunction(MakeTaggAggregate<TcentroidFn>(
+            TgeompointType::TGEOMPOINT(), TgeompointType::TGEOMPOINT()));
+        loader.RegisterFunction(std::move(set));
+    }
+}
+
+} // namespace duckdb

--- a/test/sql/parity/025_temporal_tile_getters.test
+++ b/test/sql/parity/025_temporal_tile_getters.test
@@ -1,0 +1,119 @@
+# name: test/sql/parity/025_temporal_tile_getters.test
+# description: getBin (single-bin getters) and tbox tile emitters
+# group: [sql]
+#
+# Mirrors MobilityDB SQL surface for sql/temporal/025_temporal_tile.in.sql:
+#   - getBin(integer|bigint|float|date|timestamptz, size|duration, origin)
+#     returning the typed span containing the value.
+#   - valueTiles / timeTiles / valueTimeTiles emitters returning LIST(TBOX).
+#
+# Outputs differ from the MobilityDB manual example for the date variant:
+# the manual shows [2001-01-03, 2001-01-10) but the actual MEOS algorithm
+# (date_get_bin -> int_get_bin) produces [2001-01-01, 2001-01-08), which
+# is what we assert here.
+
+require mobilityduck
+
+# =============================================================================
+# getBin — numeric variants
+# =============================================================================
+
+query I
+SELECT getBin(2, 2, 0)::VARCHAR;
+----
+[2, 4)
+
+query I
+SELECT getBin(5::bigint, 2::bigint, 0::bigint)::VARCHAR;
+----
+[4, 6)
+
+query I
+SELECT getBin(2.0, 2.5, 1.5)::VARCHAR;
+----
+[1.5, 4)
+
+# =============================================================================
+# getBin — date / timestamptz
+# =============================================================================
+
+query I
+SELECT getBin(DATE '2001-01-04', INTERVAL '1 week', DATE '2000-01-03')::VARCHAR;
+----
+[2001-01-01, 2001-01-08)
+
+query I
+SELECT getBin(DATE '2001-01-04', INTERVAL '1 week', DATE '2001-01-07')::VARCHAR;
+----
+[2000-12-31, 2001-01-07)
+
+query I
+SELECT getBin(TIMESTAMPTZ '2001-01-04', INTERVAL '1 day', TIMESTAMPTZ '2000-01-03')::VARCHAR;
+----
+[2001-01-04 00:00:00+00, 2001-01-05 00:00:00+00)
+
+# =============================================================================
+# valueTiles — int / float dispatch via tbox->span.spantype
+# =============================================================================
+
+query I
+SELECT len(valueTiles(tbox 'TBOXINT XT([1,10],[2000-01-01,2000-01-10])', 3));
+----
+4
+
+query I
+SELECT (valueTiles(tbox 'TBOXINT XT([1,10],[2000-01-01,2000-01-10])', 3))[1]::VARCHAR;
+----
+TBOXINT X([0, 3))
+
+query I
+SELECT len(valueTiles(tbox 'TBOXFLOAT XT([0.0,5.5],[2000-01-01,2000-01-10])', 1.5));
+----
+4
+
+# =============================================================================
+# timeTiles — default torigin = 2000-01-03 (Monday)
+# =============================================================================
+
+query I
+SELECT len(timeTiles(tbox 'TBOXINT XT([1,10],[2000-01-01,2000-01-10])', INTERVAL '3 days'));
+----
+4
+
+query I
+SELECT (timeTiles(tbox 'TBOXINT XT([1,10],[2000-01-01,2000-01-10])', INTERVAL '3 days'))[1]::VARCHAR;
+----
+TBOXINT XT([1, 11),[1999-12-31 00:00:00+00, 2000-01-03 00:00:00+00))
+
+# Explicit torigin overrides the default
+query I
+SELECT (timeTiles(
+  tbox 'TBOXINT XT([1,10],[2000-01-01,2000-01-10])',
+  INTERVAL '3 days',
+  TIMESTAMPTZ '2000-01-01'
+))[1]::VARCHAR;
+----
+TBOXINT XT([1, 11),[2000-01-01 00:00:00+00, 2000-01-04 00:00:00+00))
+
+# =============================================================================
+# valueTimeTiles — cartesian of value tiles × time tiles
+# =============================================================================
+
+query I
+SELECT len(valueTimeTiles(tbox 'TBOXINT XT([1,10],[2000-01-01,2000-01-10])', 5, INTERVAL '5 days'));
+----
+9
+
+query I
+SELECT (valueTimeTiles(tbox 'TBOXINT XT([1,10],[2000-01-01,2000-01-10])', 5, INTERVAL '5 days'))[1]::VARCHAR;
+----
+TBOXINT XT([0, 5),[1999-12-29 00:00:00+00, 2000-01-03 00:00:00+00))
+
+query I
+SELECT len(valueTimeTiles(
+  tbox 'TBOXFLOAT XT([0.0,10.0],[2000-01-01,2000-01-10])',
+  2.5, INTERVAL '5 days', 0.0, TIMESTAMPTZ '2000-01-01'
+));
+----
+10
+

--- a/test/sql/parity/026_single_tile_getters.test
+++ b/test/sql/parity/026_single_tile_getters.test
@@ -1,0 +1,92 @@
+# name: test/sql/parity/026_single_tile_getters.test
+# description: Single-tile getters — getValueTile / getTBoxTimeTile /
+#              getValueTimeTile (tbox) and getSpaceTile / getStboxTimeTile /
+#              getSpaceTimeTile (stbox). Each returns the single tile/box
+#              that contains the input point in the (value, time, space)
+#              domain, given a tile grid configuration (size + origin).
+#              MobilityDB SQL surface lives in 025_temporal_tile.in.sql and
+#              058_tpoint_tile.in.sql.
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# getValueTile(double, double [, double=0.0]) -> tbox
+# =============================================================================
+
+query I
+SELECT getValueTile(2.0, 2.5, 1.5)::VARCHAR;
+----
+TBOXFLOAT X([1.5, 4))
+
+# Default vorigin = 0.0
+query I
+SELECT getValueTile(2.0, 2.5)::VARCHAR;
+----
+TBOXFLOAT X([0, 2.5))
+
+# =============================================================================
+# getTBoxTimeTile(timestamptz, interval [, timestamptz='2000-01-03']) -> tbox
+# =============================================================================
+
+query I
+SELECT getTBoxTimeTile(TIMESTAMPTZ '2001-01-04', INTERVAL '1 day')::VARCHAR;
+----
+TBOX T([2001-01-04 00:00:00+00, 2001-01-05 00:00:00+00))
+
+# Explicit torigin overrides the default
+query I
+SELECT getTBoxTimeTile(TIMESTAMPTZ '2001-01-04', INTERVAL '1 week', TIMESTAMPTZ '2001-01-07')::VARCHAR;
+----
+TBOX T([2000-12-31 00:00:00+00, 2001-01-07 00:00:00+00))
+
+# =============================================================================
+# getValueTimeTile(double, timestamptz, double, interval
+#                  [, double=0.0, timestamptz='2000-01-03']) -> tbox
+# =============================================================================
+
+query I
+SELECT getValueTimeTile(2.0, TIMESTAMPTZ '2001-01-04', 2.5, INTERVAL '1 day')::VARCHAR;
+----
+TBOXFLOAT XT([0, 2.5),[2001-01-04 00:00:00+00, 2001-01-05 00:00:00+00))
+
+query I
+SELECT getValueTimeTile(2.0, TIMESTAMPTZ '2001-01-04', 2.5, INTERVAL '1 day', 1.5, TIMESTAMPTZ '2000-01-01')::VARCHAR;
+----
+TBOXFLOAT XT([1.5, 4),[2001-01-04 00:00:00+00, 2001-01-05 00:00:00+00))
+
+# =============================================================================
+# getSpaceTile(geom, xsize, ysize, zsize [, sorigin geom='Point(0 0 0)'])
+#  -> stbox
+# =============================================================================
+
+query I
+SELECT getSpaceTile(ST_Point(1.5, 2.5), 1.0, 1.0, 1.0)::VARCHAR;
+----
+STBOX X((1,2),(2,3))
+
+# Convenience uniform-xyz overload: getSpaceTile(geom, xsize)
+query I
+SELECT getSpaceTile(ST_Point(1.5, 2.5), 1.0)::VARCHAR;
+----
+STBOX X((1,2),(2,3))
+
+# =============================================================================
+# getStboxTimeTile(timestamptz, interval [, timestamptz='2000-01-03']) -> stbox
+# =============================================================================
+
+query I
+SELECT getStboxTimeTile(TIMESTAMPTZ '2001-01-04', INTERVAL '1 day')::VARCHAR;
+----
+STBOX T([2001-01-04 00:00:00+00, 2001-01-05 00:00:00+00))
+
+# =============================================================================
+# getSpaceTimeTile(geom, t, xsize, ysize, zsize, interval
+#                  [, sorigin='Point(0 0 0)', torigin='2000-01-03']) -> stbox
+# =============================================================================
+
+query I
+SELECT getSpaceTimeTile(ST_Point(1.5, 2.5), TIMESTAMPTZ '2001-01-04',
+  1.0, 1.0, 1.0, INTERVAL '1 day')::VARCHAR;
+----
+STBOX XT(((1,2),(2,3)),[2001-01-04 00:00:00+00, 2001-01-05 00:00:00+00))

--- a/test/sql/parity/030_aggregates_extent.test
+++ b/test/sql/parity/030_aggregates_extent.test
@@ -1,0 +1,145 @@
+# name: test/sql/parity/030_aggregates_extent.test
+# description: extent() aggregate parity across span / set / spanset / scalar /
+#              tbox / stbox / temporal inputs.
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# extent(scalar)
+# =============================================================================
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (1::INTEGER),(5::INTEGER),(3::INTEGER)) t(v);
+----
+[1, 6)
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (1::BIGINT),(5::BIGINT),(3::BIGINT)) t(v);
+----
+[1, 6)
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (1.5::DOUBLE),(5.5::DOUBLE),(3.5::DOUBLE)) t(v);
+----
+[1.5, 5.5]
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (DATE '2001-01-01'),(DATE '2001-02-15'),(DATE '2001-01-15')) t(v);
+----
+[2001-01-01, 2001-02-16)
+
+query I
+SELECT extent(v)::VARCHAR FROM (VALUES (TIMESTAMPTZ '2001-01-01 00:00:00+00'),(TIMESTAMPTZ '2001-02-15 00:00:00+00')) t(v);
+----
+[2001-01-01 00:00:00+00, 2001-02-15 00:00:00+00]
+
+# =============================================================================
+# extent(span) — already covered by previous PR, verify still fine
+# =============================================================================
+
+query I
+SELECT extent(v::intspan)::VARCHAR FROM (VALUES ('[1,5)'), ('[3,8)')) t(v);
+----
+[1, 8)
+
+query I
+SELECT extent(v::floatspan)::VARCHAR FROM (VALUES ('[1.0,5.0]'), ('[3.0,8.0]')) t(v);
+----
+[1, 8]
+
+# =============================================================================
+# extent(set)
+# =============================================================================
+
+query I
+SELECT extent(v::intset)::VARCHAR FROM (VALUES ('{1,3,5}'), ('{2,4,7}')) t(v);
+----
+[1, 8)
+
+query I
+SELECT extent(v::tstzset)::VARCHAR FROM (VALUES
+  ('{2001-01-01, 2001-01-05}'), ('{2001-01-03, 2001-01-10}')) t(v);
+----
+[2001-01-01 00:00:00+00, 2001-01-10 00:00:00+00]
+
+# =============================================================================
+# extent(spanset)
+# =============================================================================
+
+query I
+SELECT extent(v::intspanset)::VARCHAR FROM (VALUES ('{[1,3),[5,7)}'), ('{[10,15)}')) t(v);
+----
+[1, 15)
+
+query I
+SELECT extent(v::tstzspanset)::VARCHAR FROM (VALUES
+  ('{[2001-01-01, 2001-01-03), [2001-01-05, 2001-01-07)}'),
+  ('{[2001-01-10, 2001-01-15)}')) t(v);
+----
+[2001-01-01 00:00:00+00, 2001-01-15 00:00:00+00)
+
+# =============================================================================
+# extent(tbox)
+# =============================================================================
+
+query I
+SELECT extent(v::tbox)::VARCHAR FROM (VALUES
+  ('TBOXINT XT([1, 5),[2000-01-01, 2000-01-05])'),
+  ('TBOXINT XT([3, 8),[2000-01-03, 2000-01-08])')) t(v);
+----
+TBOXINT XT([1, 8),[2000-01-01 00:00:00+00, 2000-01-08 00:00:00+00])
+
+# =============================================================================
+# extent(stbox)
+# =============================================================================
+
+query I
+SELECT extent(v::stbox)::VARCHAR FROM (VALUES
+  ('STBOX X((1,2),(3,4))'),
+  ('STBOX X((0,1),(5,6))')) t(v);
+----
+STBOX X((0,1),(5,6))
+
+# =============================================================================
+# extent(temporal)
+# =============================================================================
+
+query I
+SELECT extent(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+TBOXINT XT([1, 6),[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00])
+
+query I
+SELECT extent(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-05')) t(v);
+----
+TBOXFLOAT XT([1.5, 5.5],[2000-01-01 00:00:00+00, 2000-01-05 00:00:00+00])
+
+query I
+SELECT extent(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-05')) t(v);
+----
+[2000-01-01 00:00:00+00, 2000-01-05 00:00:00+00]
+
+query I
+SELECT extent(v::ttext)::VARCHAR FROM (VALUES ('"hi"@2000-01-01'),('"bye"@2000-01-05')) t(v);
+----
+[2000-01-01 00:00:00+00, 2000-01-05 00:00:00+00]
+
+query I
+SELECT extent(v::tgeompoint)::VARCHAR FROM (VALUES ('Point(1 2)@2000-01-01'),('Point(3 4)@2000-01-02')) t(v);
+----
+STBOX XT(((1,2),(3,4)),[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00])
+
+# =============================================================================
+# extent ignores NULLs
+# =============================================================================
+
+query I
+SELECT extent(v::INTEGER)::VARCHAR FROM (VALUES (1),(NULL),(5),(NULL),(3)) t(v);
+----
+[1, 6)
+
+query I
+SELECT extent(v::INTEGER)::VARCHAR FROM (VALUES (NULL::INTEGER)) t(v);
+----
+NULL

--- a/test/sql/parity/031_aggregates_skiplist.test
+++ b/test/sql/parity/031_aggregates_skiplist.test
@@ -1,0 +1,108 @@
+# name: test/sql/parity/031_aggregates_skiplist.test
+# description: SkipList-state temporal aggregates — tand, tor, tcount, tsum,
+#              tavg, tcentroid. tmin/tmax aggregate variants are deferred
+#              this PR (they collide with the existing scalar Tmin(tbox) /
+#              Tmax(tbox) functions under DuckDB's case-insensitive name
+#              resolution).
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# tand / tor on tbool
+# =============================================================================
+
+query I
+SELECT tand(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('true@2000-01-02')) t(v);
+----
+{t@2000-01-01 00:00:00+00, t@2000-01-02 00:00:00+00}
+
+query I
+SELECT tor(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
+----
+{t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00}
+
+# Single-row aggregate degenerates to identity over the input.
+query I
+SELECT tand(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01')) t(v);
+----
+{t@2000-01-01 00:00:00+00}
+
+# =============================================================================
+# tcount over each temporal type → tint
+# =============================================================================
+
+query I
+SELECT tcount(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
+
+query I
+SELECT tcount(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
+
+query I
+SELECT tcount(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
+
+query I
+SELECT tcount(v::ttext)::VARCHAR FROM (VALUES ('"hi"@2000-01-01'),('"bye"@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
+
+# =============================================================================
+# tsum on tint, tfloat
+# =============================================================================
+
+query I
+SELECT tsum(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 5@2000-01-02 00:00:00+00}
+
+query I
+SELECT tsum(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('2.5@2000-01-02')) t(v);
+----
+{1.5@2000-01-01 00:00:00+00, 2.5@2000-01-02 00:00:00+00}
+
+# =============================================================================
+# tavg on tint, tfloat → tfloat
+# =============================================================================
+
+query I
+SELECT tavg(v::tint)::VARCHAR FROM (VALUES ('2@2000-01-01'),('4@2000-01-02')) t(v);
+----
+{2@2000-01-01 00:00:00+00, 4@2000-01-02 00:00:00+00}
+
+query I
+SELECT tavg(v::tfloat)::VARCHAR FROM (VALUES ('2.0@2000-01-01'),('4.0@2000-01-02')) t(v);
+----
+{2@2000-01-01 00:00:00+00, 4@2000-01-02 00:00:00+00}
+
+# =============================================================================
+# tcentroid on tgeompoint
+#
+# Output is the EWKB-hex display format MobilityDuck uses for geometry, not
+# WKT — both points encode the input coordinates verbatim.
+# =============================================================================
+
+query I
+SELECT tcentroid(v::tgeompoint)::VARCHAR FROM (VALUES
+  ('Point(0 0)@2000-01-01'),('Point(2 4)@2000-01-02')) t(v);
+----
+{010100000000000000000000000000000000000000@2000-01-01 00:00:00+00, 010100000000000000000000400000000000001040@2000-01-02 00:00:00+00}
+
+# =============================================================================
+# Empty / NULL handling
+# =============================================================================
+
+query I
+SELECT tand(v::tbool)::VARCHAR FROM (VALUES (NULL::VARCHAR)) t(v) WHERE v IS NOT NULL;
+----
+NULL
+
+query I
+SELECT tcount(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),(NULL),('5@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}

--- a/test/sql/parity/031_aggregates_skiplist.test
+++ b/test/sql/parity/031_aggregates_skiplist.test
@@ -1,94 +1,118 @@
 # name: test/sql/parity/031_aggregates_skiplist.test
-# description: SkipList-state temporal aggregates — tand, tor, tcount, tsum,
-#              tavg, tcentroid. tmin/tmax aggregate variants are deferred
-#              this PR (they collide with the existing scalar Tmin(tbox) /
-#              Tmax(tbox) functions under DuckDB's case-insensitive name
-#              resolution).
+# description: SkipList-state temporal aggregates — TandAgg, TorAgg, TcountAgg,
+#              TminAgg, TmaxAgg, TsumAgg, TavgAgg, TcentroidAgg. Names follow
+#              MobilityDB RFC #827 — every SkipList aggregate is exposed
+#              under a Pascal-cased *Agg identifier. The MobilityDB upstream
+#              PR #828 adds the matching aliases on the PG side.
 # group: [sql]
 
 require mobilityduck
 
 # =============================================================================
-# tand / tor on tbool
+# TandAgg / TorAgg on tbool
 # =============================================================================
 
 query I
-SELECT tand(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('true@2000-01-02')) t(v);
+SELECT TandAgg(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('true@2000-01-02')) t(v);
 ----
 {t@2000-01-01 00:00:00+00, t@2000-01-02 00:00:00+00}
 
 query I
-SELECT tor(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
+SELECT TorAgg(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
 ----
 {t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00}
 
 # Single-row aggregate degenerates to identity over the input.
 query I
-SELECT tand(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01')) t(v);
+SELECT TandAgg(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01')) t(v);
 ----
 {t@2000-01-01 00:00:00+00}
 
 # =============================================================================
-# tcount over each temporal type → tint
+# TcountAgg over each temporal type → tint
 # =============================================================================
 
 query I
-SELECT tcount(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+SELECT TcountAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
 
 query I
-SELECT tcount(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
+SELECT TcountAgg(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
 
 query I
-SELECT tcount(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
+SELECT TcountAgg(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
 
 query I
-SELECT tcount(v::ttext)::VARCHAR FROM (VALUES ('"hi"@2000-01-01'),('"bye"@2000-01-02')) t(v);
+SELECT TcountAgg(v::ttext)::VARCHAR FROM (VALUES ('"hi"@2000-01-01'),('"bye"@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
 
 # =============================================================================
-# tsum on tint, tfloat
+# TminAgg / TmaxAgg on tint, tfloat, ttext
 # =============================================================================
 
 query I
-SELECT tsum(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+SELECT TminAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02'),('3@2000-01-03')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 5@2000-01-02 00:00:00+00, 3@2000-01-03 00:00:00+00}
+
+query I
+SELECT TmaxAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02'),('3@2000-01-03')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 5@2000-01-02 00:00:00+00, 3@2000-01-03 00:00:00+00}
+
+query I
+SELECT TminAgg(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
+----
+{1.5@2000-01-01 00:00:00+00, 5.5@2000-01-02 00:00:00+00}
+
+query I
+SELECT TmaxAgg(v::ttext)::VARCHAR FROM (VALUES ('"a"@2000-01-01'),('"z"@2000-01-02')) t(v);
+----
+{"a"@2000-01-01 00:00:00+00, "z"@2000-01-02 00:00:00+00}
+
+# =============================================================================
+# TsumAgg on tint, tfloat
+# =============================================================================
+
+query I
+SELECT TsumAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+00, 5@2000-01-02 00:00:00+00}
 
 query I
-SELECT tsum(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('2.5@2000-01-02')) t(v);
+SELECT TsumAgg(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('2.5@2000-01-02')) t(v);
 ----
 {1.5@2000-01-01 00:00:00+00, 2.5@2000-01-02 00:00:00+00}
 
 # =============================================================================
-# tavg on tint, tfloat → tfloat
+# TavgAgg on tint, tfloat → tfloat
 # =============================================================================
 
 query I
-SELECT tavg(v::tint)::VARCHAR FROM (VALUES ('2@2000-01-01'),('4@2000-01-02')) t(v);
+SELECT TavgAgg(v::tint)::VARCHAR FROM (VALUES ('2@2000-01-01'),('4@2000-01-02')) t(v);
 ----
 {2@2000-01-01 00:00:00+00, 4@2000-01-02 00:00:00+00}
 
 query I
-SELECT tavg(v::tfloat)::VARCHAR FROM (VALUES ('2.0@2000-01-01'),('4.0@2000-01-02')) t(v);
+SELECT TavgAgg(v::tfloat)::VARCHAR FROM (VALUES ('2.0@2000-01-01'),('4.0@2000-01-02')) t(v);
 ----
 {2@2000-01-01 00:00:00+00, 4@2000-01-02 00:00:00+00}
 
 # =============================================================================
-# tcentroid on tgeompoint
+# TcentroidAgg on tgeompoint
 #
 # Output is the EWKB-hex display format MobilityDuck uses for geometry, not
 # WKT — both points encode the input coordinates verbatim.
 # =============================================================================
 
 query I
-SELECT tcentroid(v::tgeompoint)::VARCHAR FROM (VALUES
+SELECT TcentroidAgg(v::tgeompoint)::VARCHAR FROM (VALUES
   ('Point(0 0)@2000-01-01'),('Point(2 4)@2000-01-02')) t(v);
 ----
 {010100000000000000000000000000000000000000@2000-01-01 00:00:00+00, 010100000000000000000000400000000000001040@2000-01-02 00:00:00+00}
@@ -98,11 +122,11 @@ SELECT tcentroid(v::tgeompoint)::VARCHAR FROM (VALUES
 # =============================================================================
 
 query I
-SELECT tand(v::tbool)::VARCHAR FROM (VALUES (NULL::VARCHAR)) t(v) WHERE v IS NOT NULL;
+SELECT TandAgg(v::tbool)::VARCHAR FROM (VALUES (NULL::VARCHAR)) t(v) WHERE v IS NOT NULL;
 ----
 NULL
 
 query I
-SELECT tcount(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),(NULL),('5@2000-01-02')) t(v);
+SELECT TcountAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),(NULL),('5@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}

--- a/test/sql/parity/031_aggregates_skiplist.test
+++ b/test/sql/parity/031_aggregates_skiplist.test
@@ -1,9 +1,11 @@
 # name: test/sql/parity/031_aggregates_skiplist.test
-# description: SkipList-state temporal aggregates — TandAgg, TorAgg, TcountAgg,
-#              TminAgg, TmaxAgg, TsumAgg, TavgAgg, TcentroidAgg. Names follow
-#              MobilityDB RFC #827 — every SkipList aggregate is exposed
-#              under a Pascal-cased *Agg identifier. The MobilityDB upstream
-#              PR #828 adds the matching aliases on the PG side.
+# description: SkipList-state aggregates — TandAgg, TorAgg, TcountAgg, TminAgg,
+#              TmaxAgg, TsumAgg, TavgAgg, TcentroidAgg, MergeAgg,
+#              AppendInstantAgg, AppendSequenceAgg, SpanUnionAgg, SetUnionAgg,
+#              and the window aggregates W{min,max,sum,count,avg}Agg. Names
+#              follow MobilityDB RFC #827 — every SkipList aggregate is
+#              exposed under a Pascal-cased *Agg identifier. The MobilityDB
+#              upstream PR #828 adds the matching aliases on the PG side.
 # group: [sql]
 
 require mobilityduck
@@ -116,6 +118,114 @@ SELECT TcentroidAgg(v::tgeompoint)::VARCHAR FROM (VALUES
   ('Point(0 0)@2000-01-01'),('Point(2 4)@2000-01-02')) t(v);
 ----
 {010100000000000000000000000000000000000000@2000-01-01 00:00:00+00, 010100000000000000000000400000000000001040@2000-01-02 00:00:00+00}
+
+# =============================================================================
+# TcountAgg over time-only inputs (timestamptz / tstzset / tstzspan / tstzspanset)
+# =============================================================================
+
+query I
+SELECT TcountAgg(t::timestamptz)::VARCHAR FROM (VALUES
+  ('2000-01-01 00:00:00+00'::timestamptz), ('2000-01-02 00:00:00+00')) t(t);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
+
+query I
+SELECT TcountAgg(s::tstzset)::VARCHAR FROM (VALUES
+  ('{2000-01-01, 2000-01-02}'::tstzset), ('{2000-01-02, 2000-01-03}')) t(s);
+----
+{1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00, 1@2000-01-03 00:00:00+00}
+
+query I
+SELECT TcountAgg(s::tstzspan)::VARCHAR FROM (VALUES
+  ('[2000-01-01, 2000-01-03)'::tstzspan), ('[2000-01-02, 2000-01-04)')) t(s);
+----
+{[1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00, 1@2000-01-03 00:00:00+00, 1@2000-01-04 00:00:00+00)}
+
+query I
+SELECT TcountAgg(s::tstzspanset)::VARCHAR FROM (VALUES
+  ('{[2000-01-01, 2000-01-03)}'::tstzspanset), ('{[2000-01-02, 2000-01-04)}')) t(s);
+----
+{[1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00, 1@2000-01-03 00:00:00+00, 1@2000-01-04 00:00:00+00)}
+
+# =============================================================================
+# MergeAgg / AppendInstantAgg / AppendSequenceAgg
+# =============================================================================
+
+query I
+SELECT MergeAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+{1@2000-01-01 00:00:00+00, 5@2000-01-02 00:00:00+00}
+
+query I
+SELECT AppendInstantAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+[1@2000-01-01 00:00:00+00, 5@2000-01-02 00:00:00+00]
+
+query I
+SELECT AppendSequenceAgg(v::tint)::VARCHAR FROM (VALUES
+  ('[1@2000-01-01, 2@2000-01-02]'::tint),
+  ('[5@2000-01-04, 6@2000-01-05]')) t(v);
+----
+{[1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00], [5@2000-01-04 00:00:00+00, 6@2000-01-05 00:00:00+00]}
+
+# =============================================================================
+# SpanUnionAgg / SetUnionAgg
+# =============================================================================
+
+query I
+SELECT SpanUnionAgg(s::intspan)::VARCHAR FROM (VALUES ('[1, 5)'), ('[3, 8)')) t(s);
+----
+{[1, 8)}
+
+query I
+SELECT SpanUnionAgg(s::intspanset)::VARCHAR FROM (VALUES
+  ('{[1, 3), [5, 7)}'), ('{[10, 15)}')) t(s);
+----
+{[1, 3), [5, 7), [10, 15)}
+
+query I
+SELECT SetUnionAgg(v::int)::VARCHAR FROM (VALUES (1), (3), (5), (3)) t(v);
+----
+{1, 3, 5}
+
+query I
+SELECT SetUnionAgg(v::intset)::VARCHAR FROM (VALUES ('{1, 3}'::intset), ('{2, 4}')) t(v);
+----
+{1, 2, 3, 4}
+
+query I
+SELECT SetUnionAgg(d::date)::VARCHAR FROM (VALUES ('2001-01-01'::date), ('2001-01-03')) t(d);
+----
+{2001-01-01, 2001-01-03}
+
+# =============================================================================
+# Window aggregates: WminAgg / WmaxAgg / WsumAgg / WcountAgg / WavgAgg
+# =============================================================================
+
+query I
+SELECT WminAgg(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02'),('3@2000-01-04')) t(v);
+----
+{[1@2000-01-01 00:00:00+00, 1@2000-01-03 00:00:00+00], (5@2000-01-03 00:00:00+00, 3@2000-01-04 00:00:00+00, 3@2000-01-06 00:00:00+00]}
+
+query I
+SELECT WmaxAgg(v::tfloat, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
+----
+{[1.5@2000-01-01 00:00:00+00, 1.5@2000-01-02 00:00:00+00), [5.5@2000-01-02 00:00:00+00, 5.5@2000-01-04 00:00:00+00]}
+
+query I
+SELECT WsumAgg(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+{[1@2000-01-01 00:00:00+00, 6@2000-01-02 00:00:00+00, 6@2000-01-03 00:00:00+00], (5@2000-01-03 00:00:00+00, 5@2000-01-04 00:00:00+00]}
+
+query I
+SELECT WcountAgg(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+----
+{[1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00, 2@2000-01-03 00:00:00+00], (1@2000-01-03 00:00:00+00, 1@2000-01-04 00:00:00+00]}
+
+query I
+SELECT WavgAgg(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('2@2000-01-01'),('4@2000-01-02')) t(v);
+----
+Interp=Step;{[2@2000-01-01 00:00:00+00, 3@2000-01-02 00:00:00+00, 3@2000-01-03 00:00:00+00], (4@2000-01-03 00:00:00+00, 4@2000-01-04 00:00:00+00]}
 
 # =============================================================================
 # Empty / NULL handling

--- a/test/sql/parity/040_tgeometry_foundations.test
+++ b/test/sql/parity/040_tgeometry_foundations.test
@@ -1,0 +1,154 @@
+# name: test/sql/parity/040_tgeometry_foundations.test
+# description: Foundational tgeometry surface — accessors, time/value
+#              restrict, modifiers, and comparison. Mirrors the analogous
+#              tgeompoint surface registered in src/geo/tgeompoint.cpp,
+#              reusing the same generic Temporal handlers from
+#              src/temporal/temporal_functions.cpp where the C MEOS
+#              functions are subtype-agnostic.
+#
+#              Geometry values are emitted in EWKB-hex display rather than
+#              WKT, so the expected outputs encode the input coordinates
+#              verbatim.
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# Accessors
+# =============================================================================
+
+query I
+SELECT numInstants(t::tgeometry) FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+1
+
+query I
+SELECT numInstants(t::tgeometry) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+2
+
+query I
+SELECT startTimestamp(t::tgeometry)::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+2000-01-01 00:00:00+00
+
+query I
+SELECT endTimestamp(t::tgeometry)::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+2000-01-03 00:00:00+00
+
+query I
+SELECT duration(t::tgeometry)::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+2 days
+
+query I
+SELECT lowerInc(t::tgeometry) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true
+
+# tgeometry defaults to STEP interpolation, which requires both inclusive
+# bounds — so the sequence form `[..., ...)` would be rejected at parse
+# time. Use a closed sequence and assert upperInc = true instead.
+query I
+SELECT upperInc(t::tgeometry) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true
+
+query I
+SELECT len(timestamps(t::tgeometry)) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+2
+
+# =============================================================================
+# Time-domain restrict
+# =============================================================================
+
+query I
+SELECT atTime(t::tgeometry, TIMESTAMPTZ '2000-01-01')::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+010100000000000000000000000000000000000000@2000-01-01 00:00:00+00
+
+query I
+SELECT beforeTimestamp(t::tgeometry, TIMESTAMPTZ '2000-01-02')::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+[010100000000000000000000000000000000000000@2000-01-01 00:00:00+00, 010100000000000000000000000000000000000000@2000-01-02 00:00:00+00)
+
+# =============================================================================
+# Modifiers (shift / scale / shiftScale)
+# =============================================================================
+
+query I
+SELECT shiftTime(t::tgeometry, INTERVAL '1 day')::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+[010100000000000000000000000000000000000000@2000-01-02 00:00:00+00, 010100000000000000000000400000000000000040@2000-01-04 00:00:00+00]
+
+query I
+SELECT scaleTime(t::tgeometry, INTERVAL '1 day')::VARCHAR FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+[010100000000000000000000000000000000000000@2000-01-01 00:00:00+00, 010100000000000000000000400000000000000040@2000-01-02 00:00:00+00]
+
+# =============================================================================
+# Spatial restrict
+# =============================================================================
+
+query I
+SELECT atGeometry(
+  t::tgeometry,
+  ST_GeomFromText('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'))::VARCHAR
+FROM (VALUES ('Point(0.5 0.5)@2000-01-01')) t(t);
+----
+0101000000000000000000E03F000000000000E03F@2000-01-01 00:00:00+00
+
+# =============================================================================
+# Comparison (named functions and operators)
+# =============================================================================
+
+query I
+SELECT temporal_eq(t::tgeometry, t::tgeometry) FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+true
+
+query I
+SELECT t1::tgeometry = t2::tgeometry FROM (VALUES
+  ('Point(0 0)@2000-01-01', 'Point(0 0)@2000-01-01')) t(t1, t2);
+----
+true
+
+query I
+SELECT t1::tgeometry <> t2::tgeometry FROM (VALUES
+  ('Point(0 0)@2000-01-01', 'Point(1 1)@2000-01-01')) t(t1, t2);
+----
+true
+
+query I
+SELECT temporal_cmp(t::tgeometry, t::tgeometry) FROM (VALUES
+  ('Point(0 0)@2000-01-01')) t(t);
+----
+0
+
+# =============================================================================
+# tempSubtype + interp + memSize
+# =============================================================================
+
+query I
+SELECT tempSubtype(t::tgeometry) FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+Instant
+
+query I
+SELECT tempSubtype(t::tgeometry) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+Sequence

--- a/test/sql/parity/040_tgeometry_parity.test
+++ b/test/sql/parity/040_tgeometry_parity.test
@@ -310,3 +310,48 @@ SELECT (traversedArea(t::tgeometry) IS NOT NULL) FROM (VALUES
   ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
 ----
 true
+
+# =============================================================================
+# Aggregate wiring — extent / TcountAgg / MergeAgg / AppendInstantAgg over
+# tgeometry inputs.
+# =============================================================================
+
+query I
+SELECT extent(t::tgeometry)::VARCHAR FROM (VALUES
+  ('Point(0 0)@2000-01-01'), ('Point(2 2)@2000-01-02')) t(t);
+----
+STBOX XT(((0,0),(2,2)),[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00])
+
+query I
+SELECT TcountAgg(t::tgeometry)::VARCHAR FROM (VALUES
+  ('Point(0 0)@2000-01-01'), ('Point(2 2)@2000-01-02')) t(t);
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00}
+
+query I
+SELECT (MergeAgg(t::tgeometry) IS NOT NULL) FROM (VALUES
+  ('Point(0 0)@2000-01-01'), ('Point(2 2)@2000-01-02')) t(t);
+----
+true
+
+query I
+SELECT (AppendInstantAgg(t::tgeometry) IS NOT NULL) FROM (VALUES
+  ('Point(0 0)@2000-01-01'), ('Point(2 2)@2000-01-02')) t(t);
+----
+true
+
+# =============================================================================
+# Tile / box emitters — spaceBoxes, spaceTimeBoxes.
+# =============================================================================
+
+query I
+SELECT (len(spaceBoxes(t::tgeometry, 1.0, 1.0, 1.0)) >= 1) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true
+
+query I
+SELECT (len(spaceTimeBoxes(t::tgeometry, 1.0, 1.0, 1.0, INTERVAL '1 day')) >= 1) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true

--- a/test/sql/parity/040_tgeometry_parity.test
+++ b/test/sql/parity/040_tgeometry_parity.test
@@ -1,13 +1,19 @@
-# name: test/sql/parity/040_tgeometry_foundations.test
-# description: Foundational tgeometry surface — accessors, time/value
-#              restrict, modifiers, and comparison. Mirrors the analogous
-#              tgeompoint surface registered in src/geo/tgeompoint.cpp,
-#              reusing the same generic Temporal handlers from
-#              src/temporal/temporal_functions.cpp where the C MEOS
-#              functions are subtype-agnostic.
+# name: test/sql/parity/040_tgeometry_parity.test
+# description: tgeometry parity — foundational accessors / time/value
+#              restrict / modifiers / comparison, plus the cross-type
+#              predicate surface (boxops, posops, spatial-relationships,
+#              temporal-spatial-relationships, and the tdistance / <->
+#              distance family).
 #
-#              Geometry values are emitted in EWKB-hex display rather than
-#              WKT, so the expected outputs encode the input coordinates
+#              Most MEOS C functions reached here are subtype-agnostic —
+#              the registrations reuse the generic TemporalFunctions::*
+#              handlers from src/temporal/temporal_functions.cpp where
+#              they exist, and src/geo/tgeometry_ops.cpp adds templated
+#              wrappers around the tspatial_* / tgeo_* MEOS exports for
+#              the cross-type surface.
+#
+#              Geometry values are emitted in EWKB-hex display rather
+#              than WKT, so expected outputs encode input coordinates
 #              verbatim.
 # group: [sql]
 
@@ -152,3 +158,116 @@ SELECT tempSubtype(t::tgeometry) FROM (VALUES
   ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
 ----
 Sequence
+
+# =============================================================================
+# Box predicates: temporal_overlaps / contains / contained / same / adjacent
+# (named functions + the matching &&, @>, <@, ~=, -|- operators)
+# =============================================================================
+
+query I
+SELECT t1::tgeometry && t2::tgeometry FROM (VALUES
+  ('Point(0 0)@2000-01-01', 'Point(0 0)@2000-01-01')) t(t1, t2);
+----
+true
+
+query I
+SELECT temporal_contains(t::tgeometry, '[2000-01-01, 2000-01-02]'::tstzspan) FROM
+  (VALUES ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true
+
+query I
+SELECT temporal_same(t::tgeometry, t::tgeometry) FROM (VALUES
+  ('Point(0 0)@2000-01-01')) t(t);
+----
+true
+
+# =============================================================================
+# Position predicates
+# =============================================================================
+
+query I
+SELECT temporal_left(t1::tgeometry, t2::tgeometry) FROM (VALUES
+  ('Point(0 0)@2000-01-01', 'Point(5 5)@2000-01-01')) t(t1, t2);
+----
+true
+
+query I
+SELECT temporal_below(t1::tgeometry, t2::tgeometry) FROM (VALUES
+  ('Point(0 0)@2000-01-01', 'Point(0 5)@2000-01-01')) t(t1, t2);
+----
+true
+
+query I
+SELECT temporal_before(t::tgeometry, '[2000-01-05, 2000-01-06]'::tstzspan) FROM
+  (VALUES ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true
+
+# =============================================================================
+# Spatial relationships (ever / always)
+# =============================================================================
+
+query I
+SELECT eContains(
+  ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))'),
+  t::tgeometry)
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+query I
+SELECT eIntersects(
+  t::tgeometry,
+  ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))'))
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+query I
+SELECT eDwithin(t::tgeometry, ST_Point(0, 0), 5.0)
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+# eDwithin is symmetric in its first two arguments — geo, tgeo and
+# tgeo, geo both reach the same MEOS tgeo_geo function.
+query I
+SELECT eDwithin(ST_Point(0, 0), t::tgeometry, 5.0)
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+# =============================================================================
+# Temporal spatial relationships (return tbool)
+# =============================================================================
+
+query I
+SELECT tIntersects(
+  t::tgeometry,
+  ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))'))::VARCHAR
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+t@2000-01-01 00:00:00+00
+
+query I
+SELECT tDwithin(t::tgeometry, ST_Point(10, 0), 5.0)::VARCHAR
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+f@2000-01-01 00:00:00+00
+
+# =============================================================================
+# Distance — tdistance + <->
+# =============================================================================
+
+query I
+SELECT tdistance(t1::tgeometry, t2::tgeometry)::VARCHAR
+FROM (VALUES ('Point(0 0)@2000-01-01', 'Point(3 4)@2000-01-01')) t(t1, t2);
+----
+5@2000-01-01 00:00:00+00
+
+query I
+SELECT (t1::tgeometry <-> t2::tgeometry)::VARCHAR
+FROM (VALUES ('Point(0 0)@2000-01-01', 'Point(3 4)@2000-01-01')) t(t1, t2);
+----
+5@2000-01-01 00:00:00+00

--- a/test/sql/parity/040_tgeometry_parity.test
+++ b/test/sql/parity/040_tgeometry_parity.test
@@ -271,3 +271,42 @@ SELECT (t1::tgeometry <-> t2::tgeometry)::VARCHAR
 FROM (VALUES ('Point(0 0)@2000-01-01', 'Point(3 4)@2000-01-01')) t(t1, t2);
 ----
 5@2000-01-01 00:00:00+00
+
+# =============================================================================
+# Spatial functions: SRID accessor / setter, transform, stbox, coercions,
+# centroid, convexHull, traversedArea.
+# =============================================================================
+
+query I
+SELECT SRID(t::tgeometry) FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+0
+
+query I
+SELECT SRID(setSRID(t::tgeometry, 4326)) FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+4326
+
+query I
+SELECT stbox(t::tgeometry)::VARCHAR FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+STBOX XT(((0,0),(0,0)),[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00])
+
+# tgeometry → tgeompoint round-trip via the explicit coercion pair.
+query I
+SELECT tempSubtype(tgeompoint(t::tgeometry)) FROM (VALUES
+  ('Point(0 0)@2000-01-01')) t(t);
+----
+Instant
+
+query I
+SELECT (convexHull(t::tgeometry) IS NOT NULL) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true
+
+query I
+SELECT (traversedArea(t::tgeometry) IS NOT NULL) FROM (VALUES
+  ('[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')) t(t);
+----
+true


### PR DESCRIPTION
## Summary

The **comprehensive `tgeometry` parity PR**, packaging everything the tgeometry surface depends on into a single review unit. Stacks PR #85 / #86 / #87 / #88 underneath, then layers the tgeometry-specific work on top.

This **supersedes** PR #89 — same content, but as one cohesive PR rather than a stack.

## What's included

| Layer | Source | What it adds |
|---|---|---|
| **Prerequisite: tile getters / aggregate framework / SkipList aggregates / single-tile getters** | merges of #85, #86, #87, #88 | `getBin`, tbox tile emitters, `extent()` expansion, all `*Agg` aggregates per RFC #827, single-tile getters |
| **tgeometry foundational accessors** | `src/geo/tgeometry.cpp` | `valueSet`, `valueN`, `valueAtTimestamp`, `getTime`, `duration`, `lowerInc`, `upperInc`, `numInstants`, `instants`, `numSequences`, `sequences`, `startSequence`, `endSequence`, `sequenceN`, `numTimestamps`, `timestamps`, `startTimestamp`, `endTimestamp`, `timestampN`, `segments` |
| **tgeometry time-domain restrict** | `src/geo/tgeometry.cpp` | `atTime` / `minusTime` over `(timestamptz, tstzset, tstzspan, tstzspanset)`; `beforeTimestamp`, `afterTimestamp` |
| **tgeometry value restrict** | `src/geo/tgeometry.cpp` | `atValues` / `minusValues` over `(geometry, geomset)` |
| **tgeometry spatial restrict** | `src/geo/tgeometry.cpp` | `atGeometry`, `minusGeometry`, `minusStbox` |
| **tgeometry modifiers** | `src/geo/tgeometry.cpp` | `shiftTime`, `scaleTime`, `shiftScaleTime`, `appendInstant`, `appendSequence`, `insert`, `update`, `deleteTime` |
| **tgeometry comparison** | `src/geo/tgeometry.cpp` | `temporal_eq` / `ne` / `lt` / `le` / `gt` / `ge` / `cmp` + `=`, `<>`, `<`, `<=`, `>`, `>=` |
| **tgeometry box predicates** | `src/geo/tgeometry_ops.cpp` (new) | `temporal_overlaps` / `contains` / `contained` / `same` / `adjacent` + `&&`, `@>`, `<@`, `~=`, `-|-` operators over `(tgeometry × stbox / tstzspan / tgeometry)` |
| **tgeometry position predicates** | `src/geo/tgeometry_ops.cpp` | 16 names (`temporal_left` / `right` / `below` / `above` / `front` / `back` / `before` / `after` and their `over-*` variants) over `(tgeometry × stbox / tgeometry)`; the four time-axis ones also accept `tstzspan` |
| **tgeometry spatial relationships** | `src/geo/tgeometry_ops.cpp` | `eContains` / `aContains` / `eDisjoint` / `aDisjoint` / `eIntersects` / `aIntersects` / `eTouches` / `aTouches` / `eDwithin` / `aDwithin` |
| **tgeometry temporal-spatial relationships** | `src/geo/tgeometry_ops.cpp` | `tContains`, `tDisjoint`, `tIntersects`, `tTouches`, `tDwithin` (return `tbool`) |
| **tgeometry distance** | `src/geo/tgeometry_ops.cpp` | `tdistance` and `<->` over `(tgeometry × geometry / tgeometry)` |
| **tgeometry spatial functions** | `src/geo/tgeometry_ops.cpp` | `SRID`, `setSRID`, `transform`, `stbox`, `tgeompoint(tgeometry)` / `tgeometry(tgeompoint)` coercions, `centroid`, `convexHull`, `traversedArea` |
| **tgeometry aggregates** | `src/temporal/span_aggregates.cpp`, `src/temporal/temporal_aggregates.cpp` | `extent(tgeometry)` → stbox; `TcountAgg(tgeometry)` → tint; `MergeAgg(tgeometry)`; `AppendInstantAgg(tgeometry)`; `AppendSequenceAgg(tgeometry)` |
| **tgeometry tile / box emitters** | `src/geo/tgeometry_ops.cpp` | `spaceBoxes(tgeometry, x, y, z)` and `spaceTimeBoxes(tgeometry, x, y, z, interval)` returning `LIST<stbox>` |
| **tgeometry analytics (registration only)** | `src/geo/tgeometry_ops.cpp` | `minDistSimplify`, `minTimeDeltaSimplify`, `maxDistSimplify`, `douglasPeuckerSimplify` — registered for parity; MEOS internally rejects non-numeric / non-point inputs at runtime, same as MobilityDB |

## Out of scope (planned follow-ups)

- **`tgeography`** — separate type registration; will follow this PR using the patterns established here.
- **GiST / SP-GiST index machinery** — separate phase.
- **I/O round-trip** (`asEWKB` / `asHexEWKB` / `asMFJSON` / matching parsers) for tgeometry — depends on PR #83 landing first.
- **`spaceSplit` / `spaceTimeSplit` TableFunctions** for tgeometry — depends on PR #79 landing first.

## Test plan

- [x] `test/sql/parity/040_tgeometry_parity.test` — 45 assertions covering every category
- [x] All 137 cumulative-base assertions still pass (001_set, 025_temporal_tile_getters, 026_single_tile_getters, 030_aggregates_extent, 031_aggregates_skiplist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)