### PR TITLE
PARITY.md: link kNN fallback to tracking issue MobilityDB#840

### DIFF
--- a/doc/PARITY.md
+++ b/doc/PARITY.md
@@ -235,9 +235,12 @@ the five spans, and all eight temporal types); the `WHERE col && q`
 predicate is rewritten into an index scan automatically.
 
 The kNN operator `|=|` works syntactically (`ORDER BY col |=| q LIMIT k`
-gives correct results), but currently falls back to seq-scan + sort +
-limit because MEOS' R-tree doesn't yet expose a priority-queue scan.
-Output is correct; throughput on large tables isn't.
+gives correct results), but falls back to seq-scan + sort + limit
+because MEOS' R-tree does not yet expose a priority-queue scan.
+Output is correct; throughput on large tables is not. Tracked in
+[MobilityDB#840](https://github.com/MobilityDB/MobilityDB/issues/840),
+which lays out the four-stage plan to add a `RTreeNNCursor` API to
+MEOS and replace the fallback in MobilityDuck once the API lands.
 
 The MobilityDB SP-GiST / GiST opclass support functions (`*_spgist_*`,
 `*_kdtree_*`, `*_quadtree_*`, `*_gist_*`) and the GIN extract


### PR DESCRIPTION
## Summary

Updates the kNN paragraph in \`doc/PARITY.md\` to point at the new tracking issue [\`MobilityDB#840\`](https://github.com/MobilityDB/MobilityDB/issues/840), which lays out the four-stage plan to add an \`RTreeNNCursor\` API to MEOS and replace the seq-scan fallback in MobilityDuck once the API lands.

## What changed

\`\`\`diff
 The kNN operator \`|=|\` works syntactically (\`ORDER BY col |=| q LIMIT k\`
-gives correct results), but currently falls back to seq-scan + sort +
-limit because MEOS' R-tree doesn't yet expose a priority-queue scan.
-Output is correct; throughput on large tables isn't.
+gives correct results), but falls back to seq-scan + sort + limit
+because MEOS' R-tree does not yet expose a priority-queue scan.
+Output is correct; throughput on large tables is not. Tracked in
+[MobilityDB#840](https://github.com/MobilityDB/MobilityDB/issues/840),
+which lays out the four-stage plan to add a \`RTreeNNCursor\` API to
+MEOS and replace the fallback in MobilityDuck once the API lands.
\`\`\`

## Why

Future visitors of \`PARITY.md\` can follow progress and decision points on the gap rather than just reading a description of it. The tracking issue carries the API design, sequencing relative to PR #740 (SP-GiST), and the five decision points for @mschoema and @nhungoc1508 to settle.

## Editorial tweaks made in passing

- Removed "currently" (the gap is the present state, not a recent regression).
- Expanded "doesn't" → "does not" and "isn't" → "is not" to match the surrounding formal documentation style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)