### PR TITLE
Add CONTRIBUTING.md; redirect parity-doc gap reports there

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to MobilityDuck
+
+MobilityDuck is the DuckDB extension for MEOS-stored mobility data. Contributions, gap reports, and questions are all welcome.
+
+## Reporting a gap or bug
+
+Please open an issue at https://github.com/MobilityDB/MobilityDuck/issues with:
+
+- The MobilityDuck / MEOS / DuckDB versions you are running. Run `SELECT mobilityduck_full_version();` from the DuckDB shell — it returns the extension version, the linked MEOS commit, the DuckDB version, and the full toolchain.
+- The function signature or SQL query you tried.
+- The expected behaviour (typically what MobilityDB on PostgreSQL does for the same input — [`doc/PARITY.md`](doc/PARITY.md) is the reference for *"should work the same"*).
+- The actual behaviour, including any error messages.
+
+## Filing a feature request
+
+For new functions, OGC-conformance improvements, or planner / index integrations, an issue with the proposed signature and use case is enough to start a conversation. Cross-reference any related tracking issue on the [MobilityDB main repo](https://github.com/MobilityDB/MobilityDB/issues) — MEOS-side API gaps that affect MobilityDuck are tracked there.
+
+## Pull requests
+
+- Branch from `master`. Use `feat/`, `fix/`, `docs/`, `refactor/` prefixes.
+- Keep PRs focused — one logical change per PR.
+- Reference related issues with `Fixes #N` or `Refs #N`.
+- For feature parity work, add or update tests under `test/` mirroring the MobilityDB regression that proves the parity claim.
+
+## Governance
+
+MobilityDuck is part of the [MobilityDB ecosystem](https://libmeos.org/). Significant design decisions are typically discussed first on the MobilityDB main repo so the broader community can weigh in.
+
+## License
+
+By contributing you agree that your contributions are licensed under the project's [MIT License](LICENSE).

--- a/doc/PARITY-INVENTORY.md
+++ b/doc/PARITY-INVENTORY.md
@@ -148,8 +148,4 @@ shape MobilityDuck uses for `frechetDistancePath` /
 
 ## Reporting a gap
 
-Run `mobilityduck_full_version()` from the SQL shell to get the
-extension version, the linked MEOS commit, the DuckDB version, and
-the full toolchain. If you spot a missing function or unexpected
-behaviour, please open an issue with that version line and the
-function signature you tried to call.
+See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for how to file an issue, including the version-line capture step.

--- a/doc/PARITY.md
+++ b/doc/PARITY.md
@@ -257,6 +257,5 @@ These MobilityDB type families aren't part of MobilityDuck today:
 
 ---
 
-*Spotted something that should work but doesn't? Please open an
-issue with the function signature you tried to call and the version
-line from `mobilityduck_full_version()`.*
+*Spotted something that should work but doesn't? See
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) for how to report a gap.*


### PR DESCRIPTION
## Summary

The parity docs each carried near-duplicate "report a gap" prose:

- \`doc/PARITY.md\` ended with an italic footer asking readers to open an issue with the version line and signature.
- \`doc/PARITY-INVENTORY.md\` had a \`## Reporting a gap\` section saying effectively the same thing.

This PR centralizes the contributor-facing guidance in a single \`CONTRIBUTING.md\` at the repository root and has both parity docs point at it.

## What's in the new \`CONTRIBUTING.md\`

- How to report a gap or bug, including the \`mobilityduck_full_version()\` capture step.
- How to file a feature request, with cross-reference to MobilityDB main for MEOS-side API gaps.
- PR conventions (branching, prefixes, focus, parity-test mirror rule).
- Governance — MobilityDuck is part of the broader MEOS ecosystem; significant design decisions go through MobilityDB main.
- License clause referencing the project's MIT License.

## Doc edits

\`doc/PARITY.md\` footer:
\`\`\`diff
-*Spotted something that should work but doesn't? Please open an
-issue with the function signature you tried to call and the version
-line from \`mobilityduck_full_version()\`.*
+*Spotted something that should work but doesn't? See
+[\`CONTRIBUTING.md\`](../CONTRIBUTING.md) for how to report a gap.*
\`\`\`

\`doc/PARITY-INVENTORY.md\` "Reporting a gap" section (heading kept so any inbound \`#reporting-a-gap\` anchor link keeps resolving):

\`\`\`diff
 ## Reporting a gap

-Run \`mobilityduck_full_version()\` from the SQL shell to get the
-extension version, the linked MEOS commit, the DuckDB version, and
-the full toolchain. If you spot a missing function or unexpected
-behaviour, please open an issue with that version line and the
-function signature you tried to call.
+See [\`CONTRIBUTING.md\`](../CONTRIBUTING.md) for how to file an issue, including the version-line capture step.
\`\`\`

## Out of scope (deliberately)

- The "what's not yet shipped" framing in \`doc/PARITY.md\` line 7 and the H1 of \`PARITY-INVENTORY.md\` — that's a bigger doc-restructure question (the inventory's table now reads "0 — all parity items shipped", so the framing is becoming stale, but reframing it is a separate conversation).
- This PR is **complementary to #93** (the kNN tracking-link update) — they don't conflict; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)