### PR TITLE
Reframe parity inventory from gap-tracker to per-function reference

### DIFF
--- a/doc/PARITY-INVENTORY.md
+++ b/doc/PARITY-INVENTORY.md
@@ -1,4 +1,4 @@
-# MobilityDuck — what's not yet shipped
+# MobilityDuck — per-function parity reference
 
 This is the per-function detail behind [`PARITY.md`](PARITY.md). If
 you're coming from MobilityDB and want to know whether a specific
@@ -6,7 +6,7 @@ function is callable today, this is the file to grep.
 
 Status flags:
 - ✓ — shipped, callable today.
-- ◯ — not yet shipped; can be added on demand.
+- ◯ — not yet covered; can be added on demand.
 - ✗ — won't be added (architectural mismatch with DuckDB, or a
   PostgreSQL-only utility).
 
@@ -25,7 +25,6 @@ PostgreSQL).
 | Reachable only via the named-function form because DuckDB's parser rejects the operator (the `#` time-axis operators `<<#`/`&<#`/`#>>`/`#&>` and the `\|`-bearing Y/Z-axis operators) — call `before`, `overBefore`, `after`, `overAfter`, `above`, `below`, `front`, `back`, etc. | 12 | ✓ via named form |
 | Renamed in MobilityDuck with the `*Agg` suffix on aggregate functions | 12 | ✓ |
 | Architectural blocks (no separate `geography` SQL type, no MVT) | 2 | ✗ |
-| Not yet shipped | 0 — all parity items shipped | — |
 | **Effective coverage** | ~100% of the in-scope surface | |
 
 ## What's intentionally not here

--- a/doc/PARITY.md
+++ b/doc/PARITY.md
@@ -4,8 +4,8 @@ If you've used MobilityDB on PostgreSQL and are trying out MobilityDuck
 on DuckDB, this document is for you. It tells you what works the same,
 what works under a different name, and what's intentionally missing.
 
-For the per-function checklist of what's not yet shipped, see
-[`PARITY-INVENTORY.md`](PARITY-INVENTORY.md).
+For the per-function reference of MobilityDuck's parity surface,
+see [`PARITY-INVENTORY.md`](PARITY-INVENTORY.md).
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary

The "what's not yet shipped" framing was load-bearing while parity was in progress, but the inventory's own table now reads:

\`\`\`
| Not yet shipped | 0 — all parity items shipped | — |
\`\`\`

A zero-row that announces its own staleness. The framing is stale: \`PARITY-INVENTORY.md\` is no longer an inventory of misses, it is a **per-function reference of the parity surface** (what's shipped, what's intentionally not, with status flags).

This PR aligns the framing with the file's actual purpose.

## What changed (four surgical edits)

\`PARITY-INVENTORY.md\` H1:

\`\`\`diff
-# MobilityDuck — what's not yet shipped
+# MobilityDuck — per-function parity reference
\`\`\`

\`PARITY-INVENTORY.md\` status-flag legend (the ◯ flag):

\`\`\`diff
-- ◯ — not yet shipped; can be added on demand.
+- ◯ — not yet covered; can be added on demand.
\`\`\`

\`PARITY-INVENTORY.md\` "How much" table (the zero-row):

\`\`\`diff
 | Architectural blocks (no separate \`geography\` SQL type, no MVT) | 2 | ✗ |
-| Not yet shipped | 0 — all parity items shipped | — |
 | **Effective coverage** | ~100% of the in-scope surface | |
\`\`\`

\`PARITY.md\` cross-link to the inventory:

\`\`\`diff
-For the per-function checklist of what's not yet shipped, see
-[\`PARITY-INVENTORY.md\`](PARITY-INVENTORY.md).
+For the per-function reference of MobilityDuck's parity surface,
+see [\`PARITY-INVENTORY.md\`](PARITY-INVENTORY.md).
\`\`\`

## What's preserved

- The "What's intentionally not here" and "What's shipped" sections of \`PARITY-INVENTORY.md\` are unchanged — they're the file's actual content.
- The \`## Reporting a gap\` heading anchor (kept by PR #94) still resolves.

## Stack

This is the third in a series of small parity-doc edits, all targeting \`doc/parity\`:

- **#93** — link kNN fallback to tracking issue MobilityDB#840.
- **#94** — add \`CONTRIBUTING.md\`; redirect parity-doc gap reports there.
- **This PR (#95)** — reframe the inventory from gap-tracker to per-function reference.

The three PRs are independent (no conflicting hunks); any merge order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)