### PR TITLE
feat(bindings): temporal ops parity — boxops / comparison / position / precision / same

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -13,3 +13,5 @@ duckdb_extension_load(spatial
     SOURCE_DIR  ${CMAKE_CURRENT_LIST_DIR}/duckdb-spatial
     INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/duckdb-spatial/src/spatial
 )
+
+duckdb_extension_load(icu)

--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -109,8 +109,8 @@ struct TemporalFunctions {
     static void Temporal_shift_time(DataChunk &args, ExpressionState &state, Vector &result);
     static void Temporal_scale_time(DataChunk &args, ExpressionState &state, Vector &result);
     static void Temporal_shift_scale_time(DataChunk &args, ExpressionState &state, Vector &result);
-    // TODO: static void Temporal_tprecision
-    // TODO: static void Temporal_tsample
+    static void Temporal_tprecision(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_tsample(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
      * Transformation functions
@@ -224,9 +224,46 @@ struct TemporalFunctions {
      * Unary tnumber functions
      ****************************************************/
     static void Tnumber_abs(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tnumber_tboxes(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tnumber_split_n_tboxes(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tnumber_split_each_n_tboxes(DataChunk &args, ExpressionState &state, Vector &result);
     // Temporal_derivative declared in the math-functions block below.
     static void Tfloat_degrees(DataChunk &args, ExpressionState &state, Vector &result);
     static void Tfloat_radians(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
+     * Temporal comparison predicates returning Temporal
+     * (temporal_teq / tne / tlt / tle / tgt / tge)
+     ****************************************************/
+#define DECL_TCMP(OP)                                                                              \
+    static void OP##_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result);          \
+    static void OP##_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result);          \
+    static void OP##_int_tint(DataChunk &args, ExpressionState &state, Vector &result);            \
+    static void OP##_tint_int(DataChunk &args, ExpressionState &state, Vector &result);            \
+    static void OP##_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);        \
+    static void OP##_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);        \
+    static void OP##_text_ttext(DataChunk &args, ExpressionState &state, Vector &result);          \
+    static void OP##_ttext_text(DataChunk &args, ExpressionState &state, Vector &result);          \
+    static void OP##_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+
+    DECL_TCMP(Teq)
+    DECL_TCMP(Tne)
+#undef DECL_TCMP
+
+#define DECL_TCMP_ORD(OP)                                                                          \
+    static void OP##_int_tint(DataChunk &args, ExpressionState &state, Vector &result);            \
+    static void OP##_tint_int(DataChunk &args, ExpressionState &state, Vector &result);            \
+    static void OP##_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result);        \
+    static void OP##_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result);        \
+    static void OP##_text_ttext(DataChunk &args, ExpressionState &state, Vector &result);          \
+    static void OP##_ttext_text(DataChunk &args, ExpressionState &state, Vector &result);          \
+    static void OP##_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+
+    DECL_TCMP_ORD(Tlt)
+    DECL_TCMP_ORD(Tle)
+    DECL_TCMP_ORD(Tgt)
+    DECL_TCMP_ORD(Tge)
+#undef DECL_TCMP_ORD
 
     /* ***************************************************
      * Distance operator on tnumber
@@ -248,14 +285,17 @@ struct TemporalFunctions {
     static void Contained_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contains_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contained_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contains_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contained_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
      * Temporal time-position predicates (<<#, #>>, &<#, #&>)
@@ -377,18 +417,22 @@ struct TemporalFunctions {
     static void Contained_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contains_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contained_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contains_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contained_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contains_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Contained_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Overlaps_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adjacent_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Same_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
      * tnumber × {numspan, tbox} position predicates

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -206,6 +206,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	static std::once_flag meos_init_flag;
     std::call_once(meos_init_flag, []() {
         meos_initialize();
+        meos_initialize_timezone("UTC");
         meos_initialize_error_handler(&MobilityduckMeosErrorHandler);
     });
 

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1376,12 +1376,15 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_float));
     loader.RegisterFunction(ScalarFunction("nearestApproachDistance", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, LogicalType::DOUBLE, TemporalFunctions::Nad_tfloat_tfloat));
 
-    // Temporal topological predicates: temporal × temporal (4 ops × 4 type pairs)
+    // Temporal topological predicates: temporal × temporal (5 ops × 4 type pairs).
+    // Each operator also registers the matching `temporal_*` named alias.
     for (auto &t1 : TemporalTypes::AllTypes()) {
         for (auto &t2 : TemporalTypes::AllTypes()) {
             loader.RegisterFunction(ScalarFunction("@>", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_temporal));
             loader.RegisterFunction(ScalarFunction("<@", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_temporal));
             loader.RegisterFunction(ScalarFunction("&&", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("~=", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Same_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_same", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Same_temporal_temporal));
             loader.RegisterFunction(ScalarFunction("-|-", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_temporal));
         }
     }
@@ -1390,10 +1393,15 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(ScalarFunction("@>", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_tstzspan));
         loader.RegisterFunction(ScalarFunction("<@", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_tstzspan));
         loader.RegisterFunction(ScalarFunction("&&", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("~=", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Same_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_same", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Same_temporal_tstzspan));
         loader.RegisterFunction(ScalarFunction("-|-", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_tstzspan));
+
         loader.RegisterFunction(ScalarFunction("@>", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tstzspan_temporal));
         loader.RegisterFunction(ScalarFunction("<@", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tstzspan_temporal));
         loader.RegisterFunction(ScalarFunction("&&", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("~=", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Same_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_same", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Same_tstzspan_temporal));
         loader.RegisterFunction(ScalarFunction("-|-", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tstzspan_temporal));
     }
 
@@ -1475,35 +1483,23 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         auto fspan = SpanTypes::FLOATSPAN();
         auto tbox  = TboxType::TBOX();
 
-        // tnumber × numspan
-        loader.RegisterFunction(ScalarFunction("@>",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("<@",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&&",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("-|-", {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("@>",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("<@",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("&&",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_numspan));
-        loader.RegisterFunction(ScalarFunction("-|-", {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_numspan));
-        // numspan × tnumber
-        loader.RegisterFunction(ScalarFunction("@>",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("<@",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&&",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("-|-", {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("@>",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contains_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("<@",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Contained_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("&&",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_numspan_tnumber));
-        loader.RegisterFunction(ScalarFunction("-|-", {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_numspan_tnumber));
-        // tnumber × tbox
+#define REG_TOP5(L, R, FN_SUFFIX) \
+    loader.RegisterFunction(ScalarFunction("@>",            {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Contains_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("<@",            {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Contained_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("&&",            {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("~=",            {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Same_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_same", {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Same_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("-|-",           {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_##FN_SUFFIX));
+
+        REG_TOP5(tint,  ispan, tnumber_numspan)
+        REG_TOP5(tflt,  fspan, tnumber_numspan)
+        REG_TOP5(ispan, tint,  numspan_tnumber)
+        REG_TOP5(fspan, tflt,  numspan_tnumber)
         for (auto &t : {tint, tflt}) {
-            loader.RegisterFunction(ScalarFunction("@>",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("<@",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("&&",  {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("-|-", {t, tbox}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tnumber_tbox));
-            loader.RegisterFunction(ScalarFunction("@>",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("<@",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("&&",  {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tbox_tnumber));
-            loader.RegisterFunction(ScalarFunction("-|-", {tbox, t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tbox_tnumber));
+            REG_TOP5(t,    tbox, tnumber_tbox)
+            REG_TOP5(tbox, t,    tbox_tnumber)
         }
+#undef REG_TOP5
 
         // Position ops (<<, >>, &<, &>) — same surface
         loader.RegisterFunction(ScalarFunction("<<",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
@@ -1596,6 +1592,164 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("||", {LogicalType::VARCHAR, TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_text_ttext));
     loader.RegisterFunction(ScalarFunction("||", {TemporalTypes::TTEXT(), LogicalType::VARCHAR}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_ttext_text));
     loader.RegisterFunction(ScalarFunction("||", {TemporalTypes::TTEXT(), TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_ttext_ttext));
+
+    // Named aliases for the time-position predicates (DuckDB parser rejects the `#` character
+    // in operator tokens, so temporal_before etc. are the only reachable forms).
+    for (auto &t1 : TemporalTypes::AllTypes()) {
+        for (auto &t2 : TemporalTypes::AllTypes()) {
+            loader.RegisterFunction(ScalarFunction("temporal_before",     {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_after",      {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_overbefore", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_overafter",  {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_temporal));
+        }
+    }
+    for (auto &t : TemporalTypes::AllTypes()) {
+        loader.RegisterFunction(ScalarFunction("temporal_before",     {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Before_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_after",      {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::After_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_overbefore", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_overafter",  {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_before",     {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Before_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_after",      {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::After_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_overbefore", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overbefore_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_overafter",  {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overafter_tstzspan_temporal));
+    }
+
+    // Named aliases for the topological predicates (temporal_contains/contained/overlaps/adjacent).
+    // `temporal_same` is already wired inside the operator loops above; the others are added here.
+    for (auto &t1 : TemporalTypes::AllTypes()) {
+        for (auto &t2 : TemporalTypes::AllTypes()) {
+            loader.RegisterFunction(ScalarFunction("temporal_contains",  {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_contained", {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_overlaps",  {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_temporal));
+            loader.RegisterFunction(ScalarFunction("temporal_adjacent",  {t1, t2}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_temporal));
+        }
+    }
+    for (auto &t : TemporalTypes::AllTypes()) {
+        loader.RegisterFunction(ScalarFunction("temporal_contains",  {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contains_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_contained", {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Contained_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_overlaps",  {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_adjacent",  {t, SpanTypes::TSTZSPAN()}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_temporal_tstzspan));
+        loader.RegisterFunction(ScalarFunction("temporal_contains",  {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contains_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_contained", {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Contained_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_overlaps",  {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_tstzspan_temporal));
+        loader.RegisterFunction(ScalarFunction("temporal_adjacent",  {SpanTypes::TSTZSPAN(), t}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_tstzspan_temporal));
+    }
+    {
+        auto tint  = TemporalTypes::TINT();
+        auto tflt  = TemporalTypes::TFLOAT();
+        auto ispan = SpanTypes::INTSPAN();
+        auto fspan = SpanTypes::FLOATSPAN();
+        auto tbox  = TboxType::TBOX();
+#define REG_NAMED_TOP4(L, R, FN_SUFFIX) \
+    loader.RegisterFunction(ScalarFunction("temporal_contains",  {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Contains_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_contained", {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Contained_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_overlaps",  {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Overlaps_##FN_SUFFIX)); \
+    loader.RegisterFunction(ScalarFunction("temporal_adjacent",  {L, R}, LogicalType::BOOLEAN, TemporalFunctions::Adjacent_##FN_SUFFIX));
+        REG_NAMED_TOP4(tint,  ispan, tnumber_numspan)
+        REG_NAMED_TOP4(tflt,  fspan, tnumber_numspan)
+        REG_NAMED_TOP4(ispan, tint,  numspan_tnumber)
+        REG_NAMED_TOP4(fspan, tflt,  numspan_tnumber)
+        for (auto &t : {tint, tflt}) {
+            REG_NAMED_TOP4(t,    tbox, tnumber_tbox)
+            REG_NAMED_TOP4(tbox, t,    tbox_tnumber)
+        }
+#undef REG_NAMED_TOP4
+    }
+
+    // Named aliases for numeric-axis position predicates (temporal_left/right/overleft/overright).
+    {
+        auto tint  = TemporalTypes::TINT();
+        auto tflt  = TemporalTypes::TFLOAT();
+        auto ispan = SpanTypes::INTSPAN();
+        auto fspan = SpanTypes::FLOATSPAN();
+        auto tbox  = TboxType::TBOX();
+        loader.RegisterFunction(ScalarFunction("temporal_left",      {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("temporal_right",     {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("temporal_overleft",  {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("temporal_overright", {tint, ispan}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("temporal_left",      {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("temporal_right",     {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("temporal_overleft",  {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("temporal_overright", {tflt, fspan}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_numspan));
+        loader.RegisterFunction(ScalarFunction("temporal_left",      {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Left_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_right",     {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Right_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_overleft",  {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_overright", {ispan, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overright_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_left",      {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Left_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_right",     {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Right_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_overleft",  {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_numspan_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_overright", {fspan, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_numspan_tnumber));
+        for (auto &t : {tint, tflt}) {
+            loader.RegisterFunction(ScalarFunction("temporal_left",      {t,    tbox}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("temporal_right",     {t,    tbox}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("temporal_overleft",  {t,    tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("temporal_overright", {t,    tbox}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tbox));
+            loader.RegisterFunction(ScalarFunction("temporal_left",      {tbox, t},    LogicalType::BOOLEAN, TemporalFunctions::Left_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("temporal_right",     {tbox, t},    LogicalType::BOOLEAN, TemporalFunctions::Right_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("temporal_overleft",  {tbox, t},    LogicalType::BOOLEAN, TemporalFunctions::Overleft_tbox_tnumber));
+            loader.RegisterFunction(ScalarFunction("temporal_overright", {tbox, t},    LogicalType::BOOLEAN, TemporalFunctions::Overright_tbox_tnumber));
+        }
+        loader.RegisterFunction(ScalarFunction("temporal_left",      {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_right",     {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_overleft",  {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_overright", {tint, tint}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_left",      {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Left_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_right",     {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Right_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_overleft",  {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overleft_tnumber_tnumber));
+        loader.RegisterFunction(ScalarFunction("temporal_overright", {tflt, tflt}, LogicalType::BOOLEAN, TemporalFunctions::Overright_tnumber_tnumber));
+    }
+
+    // Temporal comparison predicates returning tbool (temporal_teq/tne/tlt/tle/tgt/tge).
+    // The upstream ?=/?>/<? operator tokens are rejected by DuckDB's parser; only named forms work.
+#define REG_TCMP(NAME, FN) \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::BOOLEAN,    TemporalTypes::TBOOL()},  TemporalTypes::TBOOL(), TemporalFunctions::FN##_bool_tbool));         \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TBOOL(),  LogicalType::BOOLEAN},    TemporalTypes::TBOOL(), TemporalFunctions::FN##_tbool_bool));         \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::INTEGER,    TemporalTypes::TINT()},   TemporalTypes::TBOOL(), TemporalFunctions::FN##_int_tint));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),   LogicalType::INTEGER},    TemporalTypes::TBOOL(), TemporalFunctions::FN##_tint_int));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, TemporalTypes::TBOOL(), TemporalFunctions::FN##_float_tfloat));      \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     TemporalTypes::TBOOL(), TemporalFunctions::FN##_tfloat_float));      \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::VARCHAR,    TemporalTypes::TTEXT()},  TemporalTypes::TBOOL(), TemporalFunctions::FN##_text_ttext));        \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TTEXT(),  LogicalType::VARCHAR},    TemporalTypes::TBOOL(), TemporalFunctions::FN##_ttext_text));        \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),   TemporalTypes::TINT()},   TemporalTypes::TBOOL(), TemporalFunctions::FN##_temporal_temporal)); \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TBOOL(), TemporalFunctions::FN##_temporal_temporal)); \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TBOOL(),  TemporalTypes::TBOOL()},  TemporalTypes::TBOOL(), TemporalFunctions::FN##_temporal_temporal));
+    REG_TCMP("temporal_teq", Teq)
+    REG_TCMP("temporal_tne", Tne)
+#undef REG_TCMP
+
+#define REG_TCMP_ORD(NAME, FN) \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::INTEGER,    TemporalTypes::TINT()},   TemporalTypes::TBOOL(), TemporalFunctions::FN##_int_tint));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),   LogicalType::INTEGER},    TemporalTypes::TBOOL(), TemporalFunctions::FN##_tint_int));           \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, TemporalTypes::TBOOL(), TemporalFunctions::FN##_float_tfloat));      \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     TemporalTypes::TBOOL(), TemporalFunctions::FN##_tfloat_float));      \
+    loader.RegisterFunction(ScalarFunction(NAME, {LogicalType::VARCHAR,    TemporalTypes::TTEXT()},  TemporalTypes::TBOOL(), TemporalFunctions::FN##_text_ttext));        \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TTEXT(),  LogicalType::VARCHAR},    TemporalTypes::TBOOL(), TemporalFunctions::FN##_ttext_text));        \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TINT(),   TemporalTypes::TINT()},   TemporalTypes::TBOOL(), TemporalFunctions::FN##_temporal_temporal)); \
+    loader.RegisterFunction(ScalarFunction(NAME, {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TBOOL(), TemporalFunctions::FN##_temporal_temporal));
+    REG_TCMP_ORD("temporal_tlt", Tlt)
+    REG_TCMP_ORD("temporal_tle", Tle)
+    REG_TCMP_ORD("temporal_tgt", Tgt)
+    REG_TCMP_ORD("temporal_tge", Tge)
+#undef REG_TCMP_ORD
+
+    // tprecision and tsample — time-domain rebinning
+    for (auto &t : TemporalTypes::AllTypes()) {
+        loader.RegisterFunction(ScalarFunction("tprecision", {t, LogicalType::INTERVAL}, t, TemporalFunctions::Temporal_tprecision));
+        loader.RegisterFunction(ScalarFunction("tprecision", {t, LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ}, t, TemporalFunctions::Temporal_tprecision));
+        loader.RegisterFunction(ScalarFunction("tsample",    {t, LogicalType::INTERVAL}, t, TemporalFunctions::Temporal_tsample));
+        loader.RegisterFunction(ScalarFunction("tsample",    {t, LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ}, t, TemporalFunctions::Temporal_tsample));
+        loader.RegisterFunction(ScalarFunction("tsample",    {t, LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ, LogicalType::VARCHAR}, t, TemporalFunctions::Temporal_tsample));
+    }
+
+    // tboxes / splitNTboxes / splitEachNTboxes — tnumber → LIST(TBOX)
+    {
+        auto tbox_list = LogicalType::LIST(TboxType::TBOX());
+        for (auto &t : {TemporalTypes::TINT(), TemporalTypes::TFLOAT()}) {
+            loader.RegisterFunction(ScalarFunction("tboxes",           {t},                      tbox_list, TemporalFunctions::Tnumber_tboxes));
+            loader.RegisterFunction(ScalarFunction("splitNTboxes",     {t, LogicalType::INTEGER}, tbox_list, TemporalFunctions::Tnumber_split_n_tboxes));
+            loader.RegisterFunction(ScalarFunction("splitEachNTboxes", {t, LogicalType::INTEGER}, tbox_list, TemporalFunctions::Tnumber_split_each_n_tboxes));
+        }
+    }
 }
 
 struct TemporalUnnestBindData : public TableFunctionData {

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4796,6 +4796,82 @@ void TemporalFunctions::Tnumber_abs(DataChunk &args, ExpressionState &state, Vec
     TemporalUnary(args, result, [](Temporal *t) { return tnumber_abs(t); });
 }
 
+namespace {
+
+template <typename Producer>
+void RunTboxesEmit(DataChunk &args, Vector &result, Producer produce, bool has_n_arg) {
+    const idx_t row_count = args.size();
+    args.data[0].Flatten(row_count);
+    if (has_n_arg) args.data[1].Flatten(row_count);
+    auto in_data = FlatVector::GetData<string_t>(args.data[0]);
+    auto &valid_in = FlatVector::Validity(args.data[0]);
+
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &out_validity = FlatVector::Validity(result);
+
+    idx_t total = 0;
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!valid_in.RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            list_entries[row] = list_entry_t{total, 0};
+            continue;
+        }
+        int n = 0;
+        if (has_n_arg) {
+            auto &nv = args.data[1];
+            if (!FlatVector::Validity(nv).RowIsValid(row)) {
+                out_validity.SetInvalid(row);
+                list_entries[row] = list_entry_t{total, 0};
+                continue;
+            }
+            n = FlatVector::GetData<int32_t>(nv)[row];
+        }
+        Temporal *t = BlobToTemporal(in_data[row]);
+        int count = 0;
+        TBox *boxes = produce(t, n, &count);
+        free(t);
+        if (!boxes || count <= 0) {
+            list_entries[row] = list_entry_t{total, 0};
+            if (boxes) free(boxes);
+            continue;
+        }
+        ListVector::Reserve(result, total + count);
+        ListVector::SetListSize(result, total + count);
+        list_entries[row] = list_entry_t{total, static_cast<uint64_t>(count)};
+        auto &child = ListVector::GetEntry(result);
+        auto child_data = FlatVector::GetData<string_t>(child);
+        for (int k = 0; k < count; k++) {
+            string_t one(reinterpret_cast<const char *>(&boxes[k]), sizeof(TBox));
+            child_data[total + k] = StringVector::AddStringOrBlob(child, one);
+        }
+        total += count;
+        free(boxes);
+    }
+    if (row_count == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+} // namespace
+
+void TemporalFunctions::Tnumber_tboxes(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunTboxesEmit(args, result,
+        [](const Temporal *t, int /*unused*/, int *count) { return tnumber_tboxes(t, count); },
+        /*has_n_arg=*/false);
+}
+
+void TemporalFunctions::Tnumber_split_n_tboxes(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunTboxesEmit(args, result,
+        [](const Temporal *t, int n, int *count) { return tnumber_split_n_tboxes(t, n, count); },
+        /*has_n_arg=*/true);
+}
+
+void TemporalFunctions::Tnumber_split_each_n_tboxes(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunTboxesEmit(args, result,
+        [](const Temporal *t, int n, int *count) { return tnumber_split_each_n_tboxes(t, n, count); },
+        /*has_n_arg=*/true);
+}
+
 // Temporal_derivative is implemented later in this file in the Math
 // functions block (existed before the unary-tnumber additions).
 
@@ -4938,6 +5014,9 @@ void TemporalFunctions::Overlaps_temporal_temporal(DataChunk &args, ExpressionSt
 void TemporalFunctions::Adjacent_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
     TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return adjacent_temporal_temporal(a, b); });
 }
+void TemporalFunctions::Same_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempTempBoolPred(args, result, [](Temporal *a, Temporal *b) { return same_temporal_temporal(a, b); });
+}
 
 void TemporalFunctions::Contains_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
     TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return contains_temporal_tstzspan(t, s); });
@@ -4950,6 +5029,9 @@ void TemporalFunctions::Overlaps_temporal_tstzspan(DataChunk &args, ExpressionSt
 }
 void TemporalFunctions::Adjacent_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
     TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return adjacent_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Same_temporal_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempSpanBoolPred(args, result, [](Temporal *t, Span *s) { return same_temporal_tstzspan(t, s); });
 }
 
 // Span-temporal direction: MEOS only exposes the temporal-span functions,
@@ -4965,6 +5047,9 @@ void TemporalFunctions::Overlaps_tstzspan_temporal(DataChunk &args, ExpressionSt
 }
 void TemporalFunctions::Adjacent_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
     SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return adjacent_temporal_tstzspan(t, s); });
+}
+void TemporalFunctions::Same_tstzspan_temporal(DataChunk &args, ExpressionState &state, Vector &result) {
+    SpanTempBoolPred(args, result, [](Span *s, Temporal *t) { return same_tstzspan_temporal(s, t); });
 }
 
 /* ***************************************************
@@ -5198,6 +5283,9 @@ void TemporalFunctions::Overlaps_tnumber_numspan(DataChunk &args, ExpressionStat
 void TemporalFunctions::Adjacent_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) {
     TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return adjacent_tnumber_numspan(t, s); });
 }
+void TemporalFunctions::Same_tnumber_numspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<Span>(args, result, [](Temporal *t, Span *s) { return same_tnumber_numspan(t, s); });
+}
 // numspan × tnumber
 void TemporalFunctions::Contains_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
     BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return contains_numspan_tnumber(s, t); });
@@ -5210,6 +5298,9 @@ void TemporalFunctions::Overlaps_numspan_tnumber(DataChunk &args, ExpressionStat
 }
 void TemporalFunctions::Adjacent_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
     BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return adjacent_numspan_tnumber(s, t); });
+}
+void TemporalFunctions::Same_numspan_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<Span>(args, result, [](Span *s, Temporal *t) { return same_numspan_tnumber(s, t); });
 }
 // tnumber × tbox (uses TBox)
 void TemporalFunctions::Contains_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -5224,6 +5315,9 @@ void TemporalFunctions::Overlaps_tnumber_tbox(DataChunk &args, ExpressionState &
 void TemporalFunctions::Adjacent_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
     TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return adjacent_tnumber_tbox(t, b); });
 }
+void TemporalFunctions::Same_tnumber_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
+    TempBoxBoolPred<TBox>(args, result, [](Temporal *t, TBox *b) { return same_tnumber_tbox(t, b); });
+}
 // tbox × tnumber
 void TemporalFunctions::Contains_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
     BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return contains_tbox_tnumber(b, t); });
@@ -5236,6 +5330,9 @@ void TemporalFunctions::Overlaps_tbox_tnumber(DataChunk &args, ExpressionState &
 }
 void TemporalFunctions::Adjacent_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
     BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return adjacent_tbox_tnumber(b, t); });
+}
+void TemporalFunctions::Same_tbox_tnumber(DataChunk &args, ExpressionState &state, Vector &result) {
+    BoxTempBoolPred<TBox>(args, result, [](TBox *b, Temporal *t) { return same_tbox_tnumber(b, t); });
 }
 
 /* ***************************************************
@@ -5311,6 +5408,115 @@ DEFINE_TSPATIAL_STBOX_POS(Overback,   overback)
 #undef DEFINE_TSPATIAL_STBOX_POS
 
 /* ***************************************************
+ * tprecision / tsample — time-domain rebinning
+ ****************************************************/
+
+namespace {
+
+interpType ParseInterpString(const string_t &s) {
+    std::string str(s.GetData(), s.GetSize());
+    for (auto &c : str) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    if (str == "none" || str.empty())  return INTERP_NONE;
+    if (str == "discrete")             return DISCRETE;
+    if (str == "step")                 return STEP;
+    if (str == "linear")               return LINEAR;
+    throw InvalidInputException("Invalid interpolation: '" + str +
+        "' (expected one of: none, discrete, step, linear)");
+}
+
+constexpr TimestampTz DEFAULT_T_ORIGIN = 0;  // 2000-01-03 in MEOS internal repr
+
+} // namespace
+
+void TemporalFunctions::Temporal_tprecision(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t row_count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(row_count);
+    auto in_data = FlatVector::GetData<string_t>(args.data[0]);
+    auto dur_data = FlatVector::GetData<interval_t>(args.data[1]);
+    auto &v0 = FlatVector::Validity(args.data[0]);
+    auto &v1 = FlatVector::Validity(args.data[1]);
+    const bool has_origin = args.ColumnCount() > 2;
+    auto out_data = FlatVector::GetData<string_t>(result);
+    auto &out_validity = FlatVector::Validity(result);
+
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!v0.RowIsValid(row) || !v1.RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            continue;
+        }
+        TimestampTz origin = DEFAULT_T_ORIGIN;
+        if (has_origin) {
+            auto &ov = args.data[2];
+            if (!FlatVector::Validity(ov).RowIsValid(row)) {
+                out_validity.SetInvalid(row);
+                continue;
+            }
+            timestamp_tz_t t = FlatVector::GetData<timestamp_tz_t>(ov)[row];
+            origin = (TimestampTz) DuckDBToMeosTimestamp(t).value;
+        }
+        Temporal *temp = BlobToTemporal(in_data[row]);
+        MeosInterval mi = IntervaltToInterval(dur_data[row]);
+        Temporal *r = temporal_tprecision(temp, &mi, origin);
+        free(temp);
+        if (!r) { out_validity.SetInvalid(row); continue; }
+        size_t sz = temporal_mem_size(r);
+        string_t blob(reinterpret_cast<const char *>(r), sz);
+        out_data[row] = StringVector::AddStringOrBlob(result, blob);
+        free(r);
+    }
+    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+void TemporalFunctions::Temporal_tsample(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t row_count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(row_count);
+    auto in_data = FlatVector::GetData<string_t>(args.data[0]);
+    auto dur_data = FlatVector::GetData<interval_t>(args.data[1]);
+    auto &v0 = FlatVector::Validity(args.data[0]);
+    auto &v1 = FlatVector::Validity(args.data[1]);
+    const bool has_origin = args.ColumnCount() > 2;
+    const bool has_interp = args.ColumnCount() > 3;
+    auto out_data = FlatVector::GetData<string_t>(result);
+    auto &out_validity = FlatVector::Validity(result);
+
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!v0.RowIsValid(row) || !v1.RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            continue;
+        }
+        TimestampTz origin = DEFAULT_T_ORIGIN;
+        if (has_origin) {
+            auto &ov = args.data[2];
+            if (!FlatVector::Validity(ov).RowIsValid(row)) {
+                out_validity.SetInvalid(row);
+                continue;
+            }
+            timestamp_tz_t t = FlatVector::GetData<timestamp_tz_t>(ov)[row];
+            origin = (TimestampTz) DuckDBToMeosTimestamp(t).value;
+        }
+        interpType interp = DISCRETE;
+        if (has_interp) {
+            auto &iv = args.data[3];
+            if (!FlatVector::Validity(iv).RowIsValid(row)) {
+                out_validity.SetInvalid(row);
+                continue;
+            }
+            interp = ParseInterpString(FlatVector::GetData<string_t>(iv)[row]);
+        }
+        Temporal *temp = BlobToTemporal(in_data[row]);
+        MeosInterval mi = IntervaltToInterval(dur_data[row]);
+        Temporal *r = temporal_tsample(temp, &mi, origin, interp);
+        free(temp);
+        if (!r) { out_validity.SetInvalid(row); continue; }
+        size_t sz = temporal_mem_size(r);
+        string_t blob(reinterpret_cast<const char *>(r), sz);
+        out_data[row] = StringVector::AddStringOrBlob(result, blob);
+        free(r);
+    }
+    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+/* ***************************************************
  * Text functions on ttext
  ****************************************************/
 
@@ -5353,6 +5559,76 @@ void TemporalFunctions::Textcat_ttext_text(DataChunk &args, ExpressionState &sta
 void TemporalFunctions::Textcat_ttext_ttext(DataChunk &args, ExpressionState &state, Vector &result) {
     TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return textcat_ttext_ttext(a, b); });
 }
+
+/* ***************************************************
+ * Temporal comparison predicates returning Temporal
+ * (temporal_teq / tne / tlt / tle / tgt / tge)
+ *
+ * Each op routes value × t / t × value through TemporalBinaryV1/V; the
+ * temporal × temporal form goes through TemporalBinaryTT. ttext × text
+ * variants need text* allocation and use a manual BinaryExecutor block.
+ ****************************************************/
+
+#define DEFINE_TCMP_NUMERIC(OP, MEOS)                                                                                                       \
+void TemporalFunctions::OP##_int_tint(DataChunk &args, ExpressionState &state, Vector &result) {                                            \
+    TemporalBinaryV1<int32_t>(args, result, [](int32_t v, Temporal *t) { return MEOS##_int_tint(v, t); });                                  \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_tint_int(DataChunk &args, ExpressionState &state, Vector &result) {                                            \
+    TemporalBinaryV<int32_t>(args, result, [](Temporal *t, int32_t v) { return MEOS##_tint_int(t, v); });                                   \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_float_tfloat(DataChunk &args, ExpressionState &state, Vector &result) {                                        \
+    TemporalBinaryV1<double>(args, result, [](double v, Temporal *t) { return MEOS##_float_tfloat(v, t); });                                \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_tfloat_float(DataChunk &args, ExpressionState &state, Vector &result) {                                        \
+    TemporalBinaryV<double>(args, result, [](Temporal *t, double v) { return MEOS##_tfloat_float(t, v); });                                 \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_text_ttext(DataChunk &args, ExpressionState &state, Vector &result) {                                          \
+    BinaryExecutor::Execute<string_t, string_t, string_t>(                                                                                  \
+        args.data[0], args.data[1], result, args.size(),                                                                                    \
+        [&](string_t txt_str, string_t blob) -> string_t {                                                                                  \
+            text *txt = TextFromBlob(txt_str);                                                                                              \
+            Temporal *t = BlobToTemporal(blob);                                                                                             \
+            Temporal *r = MEOS##_text_ttext(txt, t);                                                                                        \
+            free(txt); free(t);                                                                                                             \
+            if (!r) throw InvalidInputException("MEOS " #MEOS "_text_ttext returned null");                                                 \
+            return TemporalToBlob(result, r);                                                                                               \
+        });                                                                                                                                  \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_ttext_text(DataChunk &args, ExpressionState &state, Vector &result) {                                          \
+    BinaryExecutor::Execute<string_t, string_t, string_t>(                                                                                  \
+        args.data[0], args.data[1], result, args.size(),                                                                                    \
+        [&](string_t blob, string_t txt_str) -> string_t {                                                                                  \
+            Temporal *t = BlobToTemporal(blob);                                                                                             \
+            text *txt = TextFromBlob(txt_str);                                                                                              \
+            Temporal *r = MEOS##_ttext_text(t, txt);                                                                                        \
+            free(t); free(txt);                                                                                                             \
+            if (!r) throw InvalidInputException("MEOS " #MEOS "_ttext_text returned null");                                                 \
+            return TemporalToBlob(result, r);                                                                                               \
+        });                                                                                                                                  \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_temporal_temporal(DataChunk &args, ExpressionState &state, Vector &result) {                                   \
+    TemporalBinaryTT(args, result, [](Temporal *a, Temporal *b) { return MEOS##_temporal_temporal(a, b); });                                \
+}
+
+#define DEFINE_TCMP_BOOL(OP, MEOS)                                                                                                          \
+void TemporalFunctions::OP##_bool_tbool(DataChunk &args, ExpressionState &state, Vector &result) {                                          \
+    TemporalBinaryV1<bool>(args, result, [](bool v, Temporal *t) { return MEOS##_bool_tbool(v, t); });                                      \
+}                                                                                                                                            \
+void TemporalFunctions::OP##_tbool_bool(DataChunk &args, ExpressionState &state, Vector &result) {                                          \
+    TemporalBinaryV<bool>(args, result, [](Temporal *t, bool v) { return MEOS##_tbool_bool(t, v); });                                       \
+}
+
+DEFINE_TCMP_BOOL(Teq, teq)
+DEFINE_TCMP_BOOL(Tne, tne)
+DEFINE_TCMP_NUMERIC(Teq, teq)
+DEFINE_TCMP_NUMERIC(Tne, tne)
+DEFINE_TCMP_NUMERIC(Tlt, tlt)
+DEFINE_TCMP_NUMERIC(Tle, tle)
+DEFINE_TCMP_NUMERIC(Tgt, tgt)
+DEFINE_TCMP_NUMERIC(Tge, tge)
+
+#undef DEFINE_TCMP_NUMERIC
+#undef DEFINE_TCMP_BOOL
 
 /* ***************************************************
  * Workaround functions

--- a/test/sql/parity/022_temporal_tprecision_tsample.test
+++ b/test/sql/parity/022_temporal_tprecision_tsample.test
@@ -1,0 +1,61 @@
+# name: test/sql/parity/022_temporal_tprecision_tsample.test
+# description: Temporal time-domain rebinning — tprecision and tsample on
+#              tnumber and ttext.
+# group: [sql]
+
+require mobilityduck
+
+require icu
+
+statement ok
+SET TimeZone='UTC'
+
+# tprecision(tfloat, interval) — bin-mean by default origin
+
+query I
+SELECT tprecision(tfloat '[1@2000-01-01, 5@2000-01-05]', INTERVAL '1 day');
+----
+[1.5@2000-01-01 00:00:00+00, 4.5@2000-01-04 00:00:00+00, 5@2000-01-05 00:00:00+00]
+
+# tprecision(tfloat, interval, timestamptz) — explicit origin
+
+query I
+SELECT tprecision(tfloat '[1@2000-01-01, 5@2000-01-05]', INTERVAL '1 day', TIMESTAMP '2000-01-01');
+----
+[1.5@2000-01-01 00:00:00+00, 4.5@2000-01-04 00:00:00+00, 5@2000-01-05 00:00:00+00]
+
+# tsample(tfloat, interval) — discrete by default
+
+query I
+SELECT tsample(tfloat '[1@2000-01-01, 5@2000-01-05]', INTERVAL '1 day');
+----
+{1@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00, 3@2000-01-03 00:00:00+00, 4@2000-01-04 00:00:00+00, 5@2000-01-05 00:00:00+00}
+
+# tsample with explicit linear interpolation
+
+query I
+SELECT tsample(tfloat '[1@2000-01-01, 5@2000-01-05]', INTERVAL '1 day', TIMESTAMP '2000-01-01', 'linear');
+----
+[1@2000-01-01 00:00:00+00, 5@2000-01-05 00:00:00+00]
+
+# tsample on tbool
+
+query I
+SELECT tsample(tbool '[t@2000-01-01, f@2000-01-03]', INTERVAL '12 hours', TIMESTAMP '2000-01-01');
+----
+{t@2000-01-01 00:00:00+00, t@2000-01-01 12:00:00+00, t@2000-01-02 00:00:00+00, t@2000-01-02 12:00:00+00, f@2000-01-03 00:00:00+00}
+
+# tsample on tint (tint defaults to step interpolation, so the last sample
+# carries the upper-end value)
+
+query I
+SELECT tsample(tint '[1@2000-01-01, 5@2000-01-05]', INTERVAL '2 days', TIMESTAMP '2000-01-01');
+----
+{1@2000-01-01 00:00:00+00, 1@2000-01-03 00:00:00+00, 5@2000-01-05 00:00:00+00}
+
+# Invalid interpolation rejected
+
+statement error
+SELECT tsample(tfloat '[1@2000-01-01]', INTERVAL '1 day', TIMESTAMP '2000-01-01', 'invalid');
+----
+Invalid interpolation

--- a/test/sql/parity/030_temporal_compops.test
+++ b/test/sql/parity/030_temporal_compops.test
@@ -1,39 +1,88 @@
 # name: test/sql/parity/030_temporal_compops.test
-# description: MobilityDB regression file 030_temporal_compops.test.sql adapted for MobilityDuck
+# description: Temporal comparison predicates returning Temporal — temporal_teq,
+#              temporal_tne, temporal_tlt, temporal_tle, temporal_tgt,
+#              temporal_tge across (base × t, t × base, t × t).
+#              MobilityDB also exposes these as `?=`/`?<>`/`?<` etc. operators;
+#              DuckDB's parser does not accept multi-character operator tokens
+#              (`?=`, `#=`), so only the named functions are registered here.
 # group: [sql]
-#
-# DuckDB's SQL parser does not accept `?` or `#` inside operator names,
-# so MobilityDB's `?=` / `?<>` / `?<` / `#=` / `#<>` / `#<` etc. forms
-# cannot be invoked from SQL. MobilityDuck exposes them as the named
-# scalar functions ever_eq / always_eq / ever_ne / always_ne / ever_lt
-# / always_lt / etc. — this parity test uses those forms.
 
 require mobilityduck
 
-# Ever-equal — value ever_eq temporal
+# temporal_teq with value × t (tint side)
 
 query I
-SELECT ever_eq(1, tint '1@2000-01-01');
+SELECT temporal_teq(1, tint '[1@2000-01-01, 2@2000-01-02]');
 ----
-true
-
-# Ever-not-equal — temporal ever_ne value
+[t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00]
 
 query I
-SELECT ever_ne(tint '[1@2000-01-01, 2@2000-01-02]', 1);
+SELECT temporal_teq(tint '[1@2000-01-01, 2@2000-01-02]', 1);
 ----
-true
+[t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00]
 
-# Always-equal — value always_eq temporal
+# temporal_teq on tbool
 
 query I
-SELECT always_eq(1, tint '1@2000-01-01');
+SELECT temporal_teq(true, tbool '[t@2000-01-01, f@2000-01-02]');
 ----
-true
+[t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00]
 
-# Always-less-than — temporal always_lt temporal
+# temporal_teq on tfloat (continuous interpolation crosses the threshold)
 
 query I
-SELECT always_lt(tint '[1@2000-01-01, 2@2000-01-02]', tint '[3@2000-01-01, 4@2000-01-02]');
+SELECT temporal_teq(2.5, tfloat '[1@2000-01-01, 5@2000-01-03]');
 ----
-true
+{[f@2000-01-01 00:00:00+00, t@2000-01-01 18:00:00+00], (f@2000-01-01 18:00:00+00, f@2000-01-03 00:00:00+00]}
+
+# temporal_teq on ttext
+
+query I
+SELECT temporal_tne('hello', ttext '["hello"@2000-01-01, "world"@2000-01-02]');
+----
+[f@2000-01-01 00:00:00+00, t@2000-01-02 00:00:00+00]
+
+# temporal_teq with two temporals (same shape)
+
+query I
+SELECT temporal_teq(tint '[1@2000-01-01, 2@2000-01-02]', tint '[1@2000-01-01, 3@2000-01-02]');
+----
+[t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00]
+
+# temporal_tlt — strict less-than
+
+query I
+SELECT temporal_tlt(tint '[1@2000-01-01, 5@2000-01-02]', 3);
+----
+[t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00]
+
+# temporal_tle vs temporal_tlt at the boundary value
+
+query I
+SELECT temporal_tle(tint '[3@2000-01-01]', 3);
+----
+[t@2000-01-01 00:00:00+00]
+
+query I
+SELECT temporal_tlt(tint '[3@2000-01-01]', 3);
+----
+[f@2000-01-01 00:00:00+00]
+
+# temporal_tge / temporal_tgt symmetric to tle / tlt
+
+query I
+SELECT temporal_tge(tint '[3@2000-01-01]', 3);
+----
+[t@2000-01-01 00:00:00+00]
+
+query I
+SELECT temporal_tgt(tint '[3@2000-01-01]', 3);
+----
+[f@2000-01-01 00:00:00+00]
+
+# Ordered comparisons on ttext
+
+query I
+SELECT temporal_tlt(ttext '["a"@2000-01-01, "z"@2000-01-02]', 'm');
+----
+[t@2000-01-01 00:00:00+00, f@2000-01-02 00:00:00+00]

--- a/test/sql/parity/032_temporal_boxops_followups.test
+++ b/test/sql/parity/032_temporal_boxops_followups.test
@@ -1,0 +1,65 @@
+# name: test/sql/parity/032_temporal_boxops_followups.test
+# description: Tail of temporal/032_temporal_boxops — named-function aliases
+#              (temporal_contains/contained/overlaps/adjacent) for the
+#              already-wired @>/<@/&&/-|- operators, plus tboxes /
+#              splitNTboxes / splitEachNTboxes.
+# group: [sql]
+
+require mobilityduck
+
+# Named-function aliases agree with the operator forms
+
+query I
+SELECT temporal_contains(tint '[1@2000-01-01, 5@2000-01-05]', tint '[2@2000-01-02, 3@2000-01-03]')
+     = (tint '[1@2000-01-01, 5@2000-01-05]' @> tint '[2@2000-01-02, 3@2000-01-03]');
+----
+true
+
+query I
+SELECT temporal_contained(tint '[2@2000-01-02, 3@2000-01-03]', tint '[1@2000-01-01, 5@2000-01-05]')
+     = (tint '[2@2000-01-02, 3@2000-01-03]' <@ tint '[1@2000-01-01, 5@2000-01-05]');
+----
+true
+
+query I
+SELECT temporal_overlaps(tint '[1@2000-01-01]', tint '[1@2000-01-01]');
+----
+true
+
+query I
+SELECT temporal_adjacent(tint '[1@2000-01-01, 2@2000-01-02]', tint '[3@2000-01-03, 4@2000-01-04]');
+----
+false
+
+# Aliases also work for (temporal × tstzspan)
+
+query I
+SELECT temporal_contains(tstzspan '[2000-01-01, 2000-01-10]', tint '[3@2000-01-03, 4@2000-01-04]');
+----
+true
+
+# Aliases on (tnumber × numspan) and (tnumber × tbox)
+
+query I
+SELECT temporal_overlaps(tint '[1@2000-01-01, 5@2000-01-05]', intspan '[2, 4)');
+----
+true
+
+# tboxes(tnumber) returns at least one tbox
+
+query I
+SELECT len(tboxes(tfloat '[1@2000-01-01, 2@2000-01-02]')) > 0;
+----
+true
+
+# splitNTboxes / splitEachNTboxes return non-empty lists for a sequence
+
+query I
+SELECT len(splitNTboxes(tfloat '[1@2000-01-01, 5@2000-01-05]', 2)) >= 1;
+----
+true
+
+query I
+SELECT len(splitEachNTboxes(tfloat '[1@2000-01-01, 2@2000-01-02, 3@2000-01-03, 4@2000-01-04, 5@2000-01-05]', 2)) >= 1;
+----
+true

--- a/test/sql/parity/032_temporal_same.test
+++ b/test/sql/parity/032_temporal_same.test
@@ -1,0 +1,78 @@
+# name: test/sql/parity/032_temporal_same.test
+# description: Same predicate (`~=`) and `temporal_same` named alias on
+#              temporal × {temporal, tstzspan, numspan, tbox} (and reverses).
+#              Closes the deferral from PR #72: temporal_boxops `temporal_same`
+#              is the last named-alias gap in that section, requiring new
+#              Same_* handlers (other 4 ops were already wired).
+# group: [sql]
+
+require mobilityduck
+
+# Same on temporal × temporal — operator and named alias agree
+
+query I
+SELECT (tint '[1@2000-01-01]' ~= tint '[1@2000-01-01]')
+     = temporal_same(tint '[1@2000-01-01]', tint '[1@2000-01-01]');
+----
+true
+
+# Same x temporal — different values
+
+query I
+SELECT temporal_same(tint '[1@2000-01-01]', tint '[2@2000-01-02]');
+----
+false
+
+# Same on tbool × tbool
+
+query I
+SELECT temporal_same(tbool '[t@2000-01-01]', tbool '[t@2000-01-01]');
+----
+true
+
+# Same on temporal × tstzspan (matching time domain)
+
+query I
+SELECT temporal_same(tint '[1@2000-01-01]', tstzspan '[2000-01-01, 2000-01-01]');
+----
+true
+
+query I
+SELECT (tstzspan '[2000-01-01, 2000-01-01]' ~= tint '[1@2000-01-01]');
+----
+true
+
+# Same on tnumber × numspan (matching value domain)
+
+query I
+SELECT temporal_same(tint '[1@2000-01-01, 5@2000-01-05]', intspan '[1, 6)');
+----
+true
+
+query I
+SELECT temporal_same(tint '[1@2000-01-01, 5@2000-01-05]', intspan '[2, 6)');
+----
+false
+
+# numspan × tnumber
+
+query I
+SELECT temporal_same(intspan '[1, 6)', tint '[1@2000-01-01, 5@2000-01-05]');
+----
+true
+
+# Same on tnumber × tbox
+
+query I
+SELECT temporal_same(tint '[1@2000-01-01, 5@2000-01-05]',
+                     tbox 'TBOXINT XT([1, 6),[2000-01-01, 2000-01-05])');
+----
+true
+
+# tbox × tnumber
+
+query I
+SELECT temporal_same(tbox 'TBOXINT XT([1, 6),[2000-01-01, 2000-01-05])',
+                     tint '[1@2000-01-01, 5@2000-01-05]');
+----
+true

--- a/test/sql/parity/034_temporal_posops.test
+++ b/test/sql/parity/034_temporal_posops.test
@@ -1,38 +1,71 @@
 # name: test/sql/parity/034_temporal_posops.test
-# description: MobilityDB regression file 034_temporal_posops.test.sql adapted for MobilityDuck
+# description: Named-function aliases for the temporal position predicates —
+#              temporal_before/after/overbefore/overafter (time axis) and
+#              temporal_left/right/overleft/overright (numeric axis on
+#              tnumber × {numspan, tbox, tnumber}).
 # group: [sql]
-#
-# DuckDB's SQL parser does not accept `#` inside operator names, so
-# MobilityDB's `<<#` / `#>>` / `&<#` / `#&>` time-position forms cannot
-# be invoked from SQL. MobilityDuck exposes them as the named scalar
-# functions before / after / overbefore / overafter — this parity test
-# uses those forms.
-#
-# Coverage: temporal × temporal, temporal × tstzspan, tstzspan ×
-# temporal. timestamptz × temporal is not directly registered; queries
-# that need it use a degenerate tstzspan (`[t, t]`) instead.
 
 require mobilityduck
 
-# timestamptz × temporal — emulated via degenerate tstzspan
-query I
-SELECT before(tstzspan '[2000-01-01, 2000-01-01]', tint '[1@2000-01-02, 2@2000-01-05]');
-----
-true
+# Time axis aliases agree with the existing named forms
 
-# temporal × tstzspan
 query I
-SELECT before(tint '[1@2000-01-01, 2@2000-01-02]', tstzspan '[2000-01-05, 2000-01-05]');
-----
-true
-
-# temporal × temporal
-query I
-SELECT before(tint '[1@2000-01-01, 2@2000-01-02]', tint '[3@2000-01-05, 4@2000-01-06]');
+SELECT temporal_before(tint '[1@2000-01-01]', tint '[1@2000-01-02]')
+     = before(tint '[1@2000-01-01]', tint '[1@2000-01-02]');
 ----
 true
 
 query I
-SELECT overbefore(tint '[1@2000-01-01, 2@2000-01-02]', tint '[1@2000-01-02, 2@2000-01-05]');
+SELECT temporal_after(tint '[1@2000-01-02]', tint '[1@2000-01-01]');
+----
+true
+
+query I
+SELECT temporal_overbefore(tstzspan '[2000-01-01, 2000-01-02]', tint '[1@2000-01-02]');
+----
+true
+
+query I
+SELECT temporal_overafter(tint '[1@2000-01-02]', tstzspan '[2000-01-01, 2000-01-02]');
+----
+true
+
+# Numeric axis on tnumber × numspan
+
+query I
+SELECT temporal_left(tint '[1@2000-01-01]', intspan '[5, 10)');
+----
+true
+
+query I
+SELECT temporal_right(tfloat '[10@2000-01-01]', floatspan '[1, 5)');
+----
+true
+
+# Aliases agree with the operator forms
+
+query I
+SELECT temporal_left(tint '[1@2000-01-01]', intspan '[5, 10)')
+     = (tint '[1@2000-01-01]' << intspan '[5, 10)');
+----
+true
+
+query I
+SELECT temporal_overleft(tint '[1@2000-01-01]', intspan '[5, 10)')
+     = (tint '[1@2000-01-01]' &< intspan '[5, 10)');
+----
+true
+
+# Numeric axis on tnumber × tbox
+
+query I
+SELECT temporal_left(tint '[1@2000-01-01]', tbox 'TBOXINT XT([5, 10),[2000-01-01, 2000-01-02])');
+----
+true
+
+# Numeric axis on tnumber × tnumber
+
+query I
+SELECT temporal_left(tint '[1@2000-01-01]', tint '[5@2000-01-01, 10@2000-01-02]');
 ----
 true


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDuck/blob/main/doc/contributing/reviewer-guide.md).

## Summary
Consolidates 5 individual parity PRs (previously #72, #73, #74, #78, #80) into one squashed commit.

- `temporal_* named aliases` for all temporal position predicates (before/after/overbefore/overafter)
- Temporal comparison predicates returning `Temporal` (teq/tne/tlt/tle/tgt/tge)
- Temporal boxops followups: named-function aliases + `tboxes` / `splitN` / `splitEachN`
- `tprecision` / `tsample` — temporal time-domain rebinning
- `temporal_same` — closes the topo-predicate gap

## Test plan
- [ ] `test/sql/parity/034_temporal_posops.test`
- [ ] `test/sql/parity/030_temporal_compops.test`
- [ ] Existing temporal test files unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)