### PR TITLE
feat(bindings): temporal analytics parity — simplify / similarity / tnumber math

### DIFF
--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -224,6 +224,11 @@ struct TemporalFunctions {
      * Unary tnumber functions
      ****************************************************/
     static void Tnumber_abs(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tnumber_delta_value(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tnumber_trend(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tfloat_exp(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tfloat_ln(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tfloat_log10(DataChunk &args, ExpressionState &state, Vector &result);
     // Temporal_derivative declared in the math-functions block below.
     static void Tfloat_degrees(DataChunk &args, ExpressionState &state, Vector &result);
     static void Tfloat_radians(DataChunk &args, ExpressionState &state, Vector &result);
@@ -368,6 +373,8 @@ struct TemporalFunctions {
     static void Temporal_frechet_distance(DataChunk &args, ExpressionState &state, Vector &result);
     static void Temporal_dyntimewarp_distance(DataChunk &args, ExpressionState &state, Vector &result);
     static void Temporal_hausdorff_distance(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_frechet_path(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_dyntimewarp_path(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
      * tnumber × {numspan, tbox} topological predicates
@@ -492,6 +499,14 @@ struct TemporalFunctions {
      ****************************************************/
     static void Temporal_round(DataChunk &args, ExpressionState &state, Vector &result);
     static void Temporal_derivative(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
+     * Analytics — trajectory/temporal simplification
+     ****************************************************/
+    static void Temporal_simplify_min_dist(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_simplify_min_tdelta(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_simplify_max_dist(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_simplify_dp(DataChunk &args, ExpressionState &state, Vector &result);
 };
 
 } // namespace duckdb

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -9,6 +9,7 @@
 #include "temporal/span.hpp"
 #include "geo/stbox.hpp"
 #include "geo/tgeompoint.hpp"
+#include "geo/tgeometry.hpp"
 
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/common/exception.hpp"
@@ -1352,6 +1353,47 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("degrees", {TemporalTypes::TFLOAT(), LogicalType::BOOLEAN}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_degrees));
     loader.RegisterFunction(ScalarFunction("radians", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_radians));
 
+    // Unary tfloat math functions
+    loader.RegisterFunction(ScalarFunction("exp",   {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_exp));
+    loader.RegisterFunction(ScalarFunction("ln",    {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_ln));
+    loader.RegisterFunction(ScalarFunction("log10", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tfloat_log10));
+
+    // deltaValue / trend on tnumber
+    loader.RegisterFunction(ScalarFunction("deltaValue", {TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Tnumber_delta_value));
+    loader.RegisterFunction(ScalarFunction("deltaValue", {TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Tnumber_delta_value));
+    loader.RegisterFunction(ScalarFunction("trend",      {TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Tnumber_trend));
+    loader.RegisterFunction(ScalarFunction("trend",      {TemporalTypes::TFLOAT()}, TemporalTypes::TINT(),   TemporalFunctions::Tnumber_trend));
+
+    // Named-function aliases for the arithmetic operators (MobilityDB exposes
+    // both `+`/`-`/`*`/`/` and `tnumber_add`/`sub`/`mult`/`div`).
+    loader.RegisterFunction(ScalarFunction("tnumber_add",  {LogicalType::INTEGER,    TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Add_int_tint));
+    loader.RegisterFunction(ScalarFunction("tnumber_add",  {TemporalTypes::TINT(),   LogicalType::INTEGER},    TemporalTypes::TINT(),   TemporalFunctions::Add_tint_int));
+    loader.RegisterFunction(ScalarFunction("tnumber_add",  {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("tnumber_add",  {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     TemporalTypes::TFLOAT(), TemporalFunctions::Add_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("tnumber_add",  {TemporalTypes::TINT(),   TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Add_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("tnumber_add",  {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Add_tnumber_tnumber));
+
+    loader.RegisterFunction(ScalarFunction("tnumber_sub",  {LogicalType::INTEGER,    TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Sub_int_tint));
+    loader.RegisterFunction(ScalarFunction("tnumber_sub",  {TemporalTypes::TINT(),   LogicalType::INTEGER},    TemporalTypes::TINT(),   TemporalFunctions::Sub_tint_int));
+    loader.RegisterFunction(ScalarFunction("tnumber_sub",  {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("tnumber_sub",  {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     TemporalTypes::TFLOAT(), TemporalFunctions::Sub_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("tnumber_sub",  {TemporalTypes::TINT(),   TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Sub_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("tnumber_sub",  {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Sub_tnumber_tnumber));
+
+    loader.RegisterFunction(ScalarFunction("tnumber_mult", {LogicalType::INTEGER,    TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Mult_int_tint));
+    loader.RegisterFunction(ScalarFunction("tnumber_mult", {TemporalTypes::TINT(),   LogicalType::INTEGER},    TemporalTypes::TINT(),   TemporalFunctions::Mult_tint_int));
+    loader.RegisterFunction(ScalarFunction("tnumber_mult", {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("tnumber_mult", {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     TemporalTypes::TFLOAT(), TemporalFunctions::Mult_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("tnumber_mult", {TemporalTypes::TINT(),   TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Mult_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("tnumber_mult", {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Mult_tnumber_tnumber));
+
+    loader.RegisterFunction(ScalarFunction("tnumber_div",  {LogicalType::INTEGER,    TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Div_int_tint));
+    loader.RegisterFunction(ScalarFunction("tnumber_div",  {TemporalTypes::TINT(),   LogicalType::INTEGER},    TemporalTypes::TINT(),   TemporalFunctions::Div_tint_int));
+    loader.RegisterFunction(ScalarFunction("tnumber_div",  {LogicalType::DOUBLE,     TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_float_tfloat));
+    loader.RegisterFunction(ScalarFunction("tnumber_div",  {TemporalTypes::TFLOAT(), LogicalType::DOUBLE},     TemporalTypes::TFLOAT(), TemporalFunctions::Div_tfloat_float));
+    loader.RegisterFunction(ScalarFunction("tnumber_div",  {TemporalTypes::TINT(),   TemporalTypes::TINT()},   TemporalTypes::TINT(),   TemporalFunctions::Div_tnumber_tnumber));
+    loader.RegisterFunction(ScalarFunction("tnumber_div",  {TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()}, TemporalTypes::TFLOAT(), TemporalFunctions::Div_tnumber_tnumber));
+
     // tnumber distance and nearest-approach-distance.
     //
     // Value-distance variants `<-> ` for (tint, INTEGER), (INTEGER, tint),
@@ -1464,7 +1506,41 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(ScalarFunction("frechetDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_frechet_distance));
         loader.RegisterFunction(ScalarFunction("discreteFrechet", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_frechet_distance));
         loader.RegisterFunction(ScalarFunction("dynTimeWarp",     {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_dyntimewarp_distance));
+        loader.RegisterFunction(ScalarFunction("dynTimeWarpDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_dyntimewarp_distance));
         loader.RegisterFunction(ScalarFunction("hausdorffDistance", {t, t}, LogicalType::DOUBLE, TemporalFunctions::Temporal_hausdorff_distance));
+        loader.RegisterFunction(ScalarFunction("frechetDistancePath", {t, t},
+            LogicalType::LIST(LogicalType::STRUCT({{"i", LogicalType::INTEGER}, {"j", LogicalType::INTEGER}})),
+            TemporalFunctions::Temporal_frechet_path));
+        loader.RegisterFunction(ScalarFunction("dynTimeWarpPath", {t, t},
+            LogicalType::LIST(LogicalType::STRUCT({{"i", LogicalType::INTEGER}, {"j", LogicalType::INTEGER}})),
+            TemporalFunctions::Temporal_dyntimewarp_path));
+    }
+    // similarity path on tgeompoint
+    {
+        auto tg = TgeompointType::TGEOMPOINT();
+        auto path_type = LogicalType::LIST(LogicalType::STRUCT({{"i", LogicalType::INTEGER}, {"j", LogicalType::INTEGER}}));
+        loader.RegisterFunction(ScalarFunction("frechetDistancePath", {tg, tg}, path_type, TemporalFunctions::Temporal_frechet_path));
+        loader.RegisterFunction(ScalarFunction("dynTimeWarpPath",     {tg, tg}, path_type, TemporalFunctions::Temporal_dyntimewarp_path));
+    }
+
+    // simplify family (subtype-agnostic but only meaningful on linear temporal types)
+    for (const auto &t : {TemporalTypes::TFLOAT(), TgeompointType::TGEOMPOINT(),
+                          TGeometryTypes::TGEOMETRY()}) {
+        loader.RegisterFunction(ScalarFunction("douglasPeuckerSimplify",
+            {t, LogicalType::DOUBLE}, t, TemporalFunctions::Temporal_simplify_dp));
+        loader.RegisterFunction(ScalarFunction("douglasPeuckerSimplify",
+            {t, LogicalType::DOUBLE, LogicalType::BOOLEAN}, t,
+            TemporalFunctions::Temporal_simplify_dp));
+        loader.RegisterFunction(ScalarFunction("maxDistSimplify",
+            {t, LogicalType::DOUBLE}, t, TemporalFunctions::Temporal_simplify_max_dist));
+        loader.RegisterFunction(ScalarFunction("maxDistSimplify",
+            {t, LogicalType::DOUBLE, LogicalType::BOOLEAN}, t,
+            TemporalFunctions::Temporal_simplify_max_dist));
+        loader.RegisterFunction(ScalarFunction("minDistSimplify",
+            {t, LogicalType::DOUBLE}, t, TemporalFunctions::Temporal_simplify_min_dist));
+        loader.RegisterFunction(ScalarFunction("minTimeDeltaSimplify",
+            {t, LogicalType::INTERVAL}, t,
+            TemporalFunctions::Temporal_simplify_min_tdelta));
     }
 
     // tnumber × {numspan, tbox} topological predicates (4 ops × 8 shape pairs)

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -4796,6 +4796,26 @@ void TemporalFunctions::Tnumber_abs(DataChunk &args, ExpressionState &state, Vec
     TemporalUnary(args, result, [](Temporal *t) { return tnumber_abs(t); });
 }
 
+void TemporalFunctions::Tnumber_delta_value(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tnumber_delta_value(t); });
+}
+
+void TemporalFunctions::Tnumber_trend(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tnumber_trend(t); });
+}
+
+void TemporalFunctions::Tfloat_exp(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tfloat_exp(t); });
+}
+
+void TemporalFunctions::Tfloat_ln(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tfloat_ln(t); });
+}
+
+void TemporalFunctions::Tfloat_log10(DataChunk &args, ExpressionState &state, Vector &result) {
+    TemporalUnary(args, result, [](Temporal *t) { return tfloat_log10(t); });
+}
+
 // Temporal_derivative is implemented later in this file in the Math
 // functions block (existed before the unary-tnumber additions).
 
@@ -5147,6 +5167,148 @@ void TemporalFunctions::Temporal_dyntimewarp_distance(DataChunk &args, Expressio
 }
 void TemporalFunctions::Temporal_hausdorff_distance(DataChunk &args, ExpressionState &state, Vector &result) {
     TempTempDoublePred(args, result, [](Temporal *a, Temporal *b) { return temporal_hausdorff_distance(a, b); });
+}
+
+namespace {
+
+void RunSimilarityPath(DataChunk &args, Vector &result,
+                      Match *(*path_fn)(const Temporal *, const Temporal *, int *),
+                      const char *fn_name) {
+    const idx_t row_count = args.size();
+    args.data[0].Flatten(row_count);
+    args.data[1].Flatten(row_count);
+
+    auto in_a = FlatVector::GetData<string_t>(args.data[0]);
+    auto in_b = FlatVector::GetData<string_t>(args.data[1]);
+    auto &valid_a = FlatVector::Validity(args.data[0]);
+    auto &valid_b = FlatVector::Validity(args.data[1]);
+
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &out_validity = FlatVector::Validity(result);
+
+    idx_t total = 0;
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!valid_a.RowIsValid(row) || !valid_b.RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            list_entries[row] = list_entry_t{total, 0};
+            continue;
+        }
+        Temporal *a = BlobToTemporal(in_a[row]);
+        Temporal *b = BlobToTemporal(in_b[row]);
+        int count = 0;
+        Match *matches = path_fn(a, b, &count);
+        free(a); free(b);
+        if (!matches || count <= 0) {
+            list_entries[row] = list_entry_t{total, 0};
+            if (matches) free(matches);
+            continue;
+        }
+        ListVector::Reserve(result, total + count);
+        ListVector::SetListSize(result, total + count);
+        list_entries[row] = list_entry_t{total, static_cast<uint64_t>(count)};
+        auto &child_struct = ListVector::GetEntry(result);
+        auto &struct_children = StructVector::GetEntries(child_struct);
+        auto i_data = FlatVector::GetData<int32_t>(*struct_children[0]);
+        auto j_data = FlatVector::GetData<int32_t>(*struct_children[1]);
+        for (int k = 0; k < count; k++) {
+            i_data[total + k] = matches[k].i;
+            j_data[total + k] = matches[k].j;
+        }
+        total += count;
+        free(matches);
+    }
+    if (row_count == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+    (void) fn_name;
+}
+
+} // namespace
+
+void TemporalFunctions::Temporal_frechet_path(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunSimilarityPath(args, result, &temporal_frechet_path, "frechetDistancePath");
+}
+
+void TemporalFunctions::Temporal_dyntimewarp_path(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunSimilarityPath(args, result, &temporal_dyntimewarp_path, "dynTimeWarpPath");
+}
+
+/* ***************************************************
+ * Temporal simplification — Douglas-Peucker, min/max-dist,
+ * min-time-delta.
+ ****************************************************/
+
+void TemporalFunctions::Temporal_simplify_dp(DataChunk &args, ExpressionState &state, Vector &result) {
+    if (args.ColumnCount() >= 3) {
+        TernaryExecutor::ExecuteWithNulls<string_t, double, bool, string_t>(
+            args.data[0], args.data[1], args.data[2], result, args.size(),
+            [&](string_t blob, double eps, bool sync, ValidityMask &mask, idx_t idx) -> string_t {
+                Temporal *t = BlobToTemporal(blob);
+                Temporal *r = temporal_simplify_dp(t, eps, sync);
+                free(t);
+                if (!r) { mask.SetInvalid(idx); return string_t(); }
+                return TemporalToBlob(result, r);
+            });
+    } else {
+        BinaryExecutor::ExecuteWithNulls<string_t, double, string_t>(
+            args.data[0], args.data[1], result, args.size(),
+            [&](string_t blob, double eps, ValidityMask &mask, idx_t idx) -> string_t {
+                Temporal *t = BlobToTemporal(blob);
+                Temporal *r = temporal_simplify_dp(t, eps, true);
+                free(t);
+                if (!r) { mask.SetInvalid(idx); return string_t(); }
+                return TemporalToBlob(result, r);
+            });
+    }
+}
+
+void TemporalFunctions::Temporal_simplify_max_dist(DataChunk &args, ExpressionState &state, Vector &result) {
+    if (args.ColumnCount() >= 3) {
+        TernaryExecutor::ExecuteWithNulls<string_t, double, bool, string_t>(
+            args.data[0], args.data[1], args.data[2], result, args.size(),
+            [&](string_t blob, double eps, bool sync, ValidityMask &mask, idx_t idx) -> string_t {
+                Temporal *t = BlobToTemporal(blob);
+                Temporal *r = temporal_simplify_max_dist(t, eps, sync);
+                free(t);
+                if (!r) { mask.SetInvalid(idx); return string_t(); }
+                return TemporalToBlob(result, r);
+            });
+    } else {
+        BinaryExecutor::ExecuteWithNulls<string_t, double, string_t>(
+            args.data[0], args.data[1], result, args.size(),
+            [&](string_t blob, double eps, ValidityMask &mask, idx_t idx) -> string_t {
+                Temporal *t = BlobToTemporal(blob);
+                Temporal *r = temporal_simplify_max_dist(t, eps, true);
+                free(t);
+                if (!r) { mask.SetInvalid(idx); return string_t(); }
+                return TemporalToBlob(result, r);
+            });
+    }
+}
+
+void TemporalFunctions::Temporal_simplify_min_dist(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, double, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, double dist, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(blob);
+            Temporal *r = temporal_simplify_min_dist(t, dist);
+            free(t);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
+}
+
+void TemporalFunctions::Temporal_simplify_min_tdelta(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, interval_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t blob, interval_t iv, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(blob);
+            MeosInterval interv = IntervaltToInterval(iv);
+            Temporal *r = temporal_simplify_min_tdelta(t, &interv);
+            free(t);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return TemporalToBlob(result, r);
+        });
 }
 
 /* ***************************************************

--- a/test/sql/parity/026b_tnumber_mathfuncs_followups.test
+++ b/test/sql/parity/026b_tnumber_mathfuncs_followups.test
@@ -1,0 +1,78 @@
+# name: test/sql/parity/026b_tnumber_mathfuncs_followups.test
+# description: Tail of temporal/026_tnumber_mathfuncs — exp/ln/log10,
+#              deltaValue, trend, and the named-function aliases for the
+#              tnumber arithmetic operators.
+# group: [sql]
+
+require mobilityduck
+
+# Unary tfloat math: ln(e) ≈ 1, log10(100) = 2, exp(0) = 1
+
+query I
+SELECT round(ln(tfloat '[1@2000-01-01, 2.71828182845905@2000-01-02]'), 6);
+----
+[0@2000-01-01 00:00:00+00, 1@2000-01-02 00:00:00+00]
+
+query I
+SELECT log10(tfloat '[1@2000-01-01, 100@2000-01-02]');
+----
+[0@2000-01-01 00:00:00+00, 2@2000-01-02 00:00:00+00]
+
+query I
+SELECT round(exp(tfloat '[0@2000-01-01, 1@2000-01-02]'), 6);
+----
+[1@2000-01-01 00:00:00+00, 2.718282@2000-01-02 00:00:00+00]
+
+# deltaValue — successive differences
+
+query I
+SELECT deltaValue(tint '[1@2000-01-01, 5@2000-01-02, 3@2000-01-03]');
+----
+[4@2000-01-01 00:00:00+00, -2@2000-01-02 00:00:00+00, -2@2000-01-03 00:00:00+00)
+
+query I
+SELECT round(deltaValue(tfloat '[1@2000-01-01, 5@2000-01-02, 3@2000-01-03]'), 6);
+----
+Interp=Step;[4@2000-01-01 00:00:00+00, -2@2000-01-02 00:00:00+00, -2@2000-01-03 00:00:00+00)
+
+# trend — sign of slope (returns tint even on tfloat per MobilityDB)
+
+query I
+SELECT trend(tfloat '[1@2000-01-01, 5@2000-01-02, 3@2000-01-03]');
+----
+[1@2000-01-01 00:00:00+00, -1@2000-01-02 00:00:00+00, -1@2000-01-03 00:00:00+00]
+
+# Named aliases for the arithmetic operators
+
+query I
+SELECT tnumber_add(tint '[1@2000-01-01]', 10);
+----
+[11@2000-01-01 00:00:00+00]
+
+query I
+SELECT tnumber_sub(tfloat '[10@2000-01-01]', 5.0);
+----
+[5@2000-01-01 00:00:00+00]
+
+query I
+SELECT tnumber_mult(2.0, tfloat '[3@2000-01-01]');
+----
+[6@2000-01-01 00:00:00+00]
+
+query I
+SELECT tnumber_div(tfloat '[10@2000-01-01]', 5.0);
+----
+[2@2000-01-01 00:00:00+00]
+
+# Aliases agree with the operator forms
+
+query I
+SELECT tnumber_add(tfloat '[3@2000-01-01]', 4.0) = (tfloat '[3@2000-01-01]' + 4.0);
+----
+true
+
+query I
+SELECT tnumber_mult(tint '[5@2000-01-01]', tint '[2@2000-01-01]')
+     = (tint '[5@2000-01-01]' * tint '[2@2000-01-01]');
+----
+true

--- a/test/sql/parity/038b_similarity_followups.test
+++ b/test/sql/parity/038b_similarity_followups.test
@@ -1,0 +1,49 @@
+# name: test/sql/parity/038b_similarity_followups.test
+# description: dynTimeWarpDistance alias + frechetDistancePath +
+#              dynTimeWarpPath (tnumber and tgeompoint).
+# group: [sql]
+
+require mobilityduck
+
+# dynTimeWarpDistance: MobilityDB-canonical name, same handler as dynTimeWarp
+
+query I
+SELECT dynTimeWarpDistance(tfloat '[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', tfloat '[1@2000-01-01, 3@2000-01-03]');
+----
+0
+
+# Equivalence with the existing alias
+
+query I
+SELECT dynTimeWarpDistance(tfloat '[1@2000-01-01, 5@2000-01-02]', tfloat '[2@2000-01-01, 3@2000-01-02]')
+     = dynTimeWarp(tfloat '[1@2000-01-01, 5@2000-01-02]', tfloat '[2@2000-01-01, 3@2000-01-02]');
+----
+true
+
+# frechetDistancePath returns LIST(STRUCT(i INTEGER, j INTEGER))
+
+query I
+SELECT frechetDistancePath(tfloat '[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', tfloat '[1@2000-01-01, 3@2000-01-03]');
+----
+[{'i': 1, 'j': 1}, {'i': 0, 'j': 0}]
+
+# dynTimeWarpPath same shape
+
+query I
+SELECT dynTimeWarpPath(tfloat '[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', tfloat '[1@2000-01-01, 3@2000-01-03]');
+----
+[{'i': 1, 'j': 1}, {'i': 0, 'j': 0}]
+
+# Path on tgeompoint trajectories
+
+query I
+SELECT frechetDistancePath(tgeompoint '[POINT(0 0)@2000-01-01, POINT(1 1)@2000-01-02]', tgeompoint '[POINT(0 0)@2000-01-01, POINT(2 2)@2000-01-02]');
+----
+[{'i': 1, 'j': 1}, {'i': 0, 'j': 0}]
+
+# Path length matches min(n1, n2) for already-aligned inputs
+
+query I
+SELECT len(dynTimeWarpPath(tfloat '[1@2000-01-01, 2@2000-01-02]', tfloat '[10@2000-01-01, 20@2000-01-02]'));
+----
+2

--- a/test/sql/parity/046_temporal_analytics.test
+++ b/test/sql/parity/046_temporal_analytics.test
@@ -1,0 +1,62 @@
+# name: test/sql/parity/046_temporal_analytics.test
+# description: Trajectory / temporal simplification — minDistSimplify,
+#              minTimeDeltaSimplify, maxDistSimplify, douglasPeuckerSimplify.
+# group: [sql]
+
+require mobilityduck
+
+# minDistSimplify(tfloat, float) — drop in-between instants closer than threshold
+
+query I
+SELECT minDistSimplify(tfloat '[1@2000-01-01, 2@2000-01-02, 3@2000-01-03, 4@2000-01-04]', 0.5);
+----
+[1@2000-01-01 00:00:00+00, 4@2000-01-04 00:00:00+00]
+
+# minDistSimplify on tgeompoint trajectory
+
+query I
+SELECT asEWKT(minDistSimplify(tgeompoint '[POINT(0 0)@2000-01-01, POINT(0.1 0)@2000-01-02, POINT(5 0)@2000-01-03]', 1));
+----
+[POINT(0 0)@2000-01-01 00:00:00+00, POINT(5 0)@2000-01-03 00:00:00+00]
+
+# minTimeDeltaSimplify(tfloat, interval) — drop instants spaced closer than threshold
+
+query I
+SELECT minTimeDeltaSimplify(tfloat '[1@2000-01-01, 2@2000-01-01 12:00:00, 3@2000-01-02]', INTERVAL '6 hours');
+----
+[1@2000-01-01 00:00:00+00, 3@2000-01-02 00:00:00+00]
+
+# maxDistSimplify(tfloat, float) — collinear points collapse under default sync
+
+query I
+SELECT maxDistSimplify(tfloat '[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', 0.1);
+----
+[1@2000-01-01 00:00:00+00, 3@2000-01-03 00:00:00+00]
+
+# maxDistSimplify(tfloat, float, bool) — explicit synchronized=false
+
+query I
+SELECT maxDistSimplify(tfloat '[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', 0.1, FALSE);
+----
+[1@2000-01-01 00:00:00+00, 3@2000-01-03 00:00:00+00]
+
+# maxDistSimplify on tgeompoint
+
+query I
+SELECT asEWKT(maxDistSimplify(tgeompoint '[POINT(0 0)@2000-01-01, POINT(1 0)@2000-01-02, POINT(2 0)@2000-01-03]', 0.5));
+----
+[POINT(0 0)@2000-01-01 00:00:00+00, POINT(2 0)@2000-01-03 00:00:00+00]
+
+# douglasPeuckerSimplify(tfloat, float)
+
+query I
+SELECT douglasPeuckerSimplify(tfloat '[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]', 0.1);
+----
+[1@2000-01-01 00:00:00+00, 3@2000-01-03 00:00:00+00]
+
+# douglasPeuckerSimplify(tgeompoint, float, bool)
+
+query I
+SELECT asEWKT(douglasPeuckerSimplify(tgeompoint '[POINT(0 0)@2000-01-01, POINT(1 0)@2000-01-02, POINT(2 0)@2000-01-03]', 0.1, TRUE));
+----
+[POINT(0 0)@2000-01-01 00:00:00+00, POINT(2 0)@2000-01-03 00:00:00+00]


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDuck/blob/main/doc/contributing/reviewer-guide.md).

## Summary
Consolidates 3 individual parity PRs (previously #67, #68, #71) into one squashed commit.

- Trajectory/temporal simplification: simplify, simplifyDP, simplifyMaxDist
- Similarity follow-ups: path matchings (frechet/DTW path emitters) + canonical name
- tnumber math followups: exp/ln/log10, deltaValue, trend, named-function aliases

## Test plan
- [ ] Parity test files for each analytics group
- [ ] No regressions in existing temporal tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)