### PR TITLE
feat(bindings): I/O and serialization parity — tbox WKB + tgeompoint round-trip

### DIFF
--- a/src/geo/tgeompoint.cpp
+++ b/src/geo/tgeompoint.cpp
@@ -1770,4 +1770,200 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     );
 }
 
+/* ***************************************************
+ * Round-trip I/O for tgeompoint: asEWKB / asHexWKB / asHexEWKB /
+ * asMFJSON and the matching tgeompointFromText / FromBinary / FromEWKB /
+ * FromHexWKB / FromHexEWKB / FromMFJSON constructors.
+ ****************************************************/
+
+namespace {
+
+/* MEOS WKB variant flag from meos_geo.h: 0 = base, 0x04 = extended (with SRID). */
+constexpr uint8_t WKB_BASE = 0x00;
+/* WKB_EXTENDED is provided by meos_geo.h as #define WKB_EXTENDED 0x04 */
+
+inline Temporal *BlobToTemp(string_t b) {
+    size_t sz = b.GetSize();
+    uint8_t *copy = (uint8_t *)malloc(sz);
+    memcpy(copy, b.GetData(), sz);
+    return reinterpret_cast<Temporal *>(copy);
+}
+
+string_t TempToResultBlob(Vector &result, Temporal *t) {
+    size_t sz = temporal_mem_size(t);
+    string_t blob(reinterpret_cast<const char *>(t), sz);
+    return StringVector::AddStringOrBlob(result, blob);
+}
+
+void TgeoAsWkbExec(DataChunk &args, ExpressionState &state, Vector &result, uint8_t variant) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            Temporal *t = BlobToTemp(input);
+            size_t sz = 0;
+            uint8_t *wkb = temporal_as_wkb(t, variant, &sz);
+            free(t);
+            if (!wkb || sz == 0) {
+                if (wkb) free(wkb);
+                throw InternalException("temporal_as_wkb returned null");
+            }
+            string_t blob(reinterpret_cast<const char *>(wkb), sz);
+            string_t stored = StringVector::AddStringOrBlob(result, blob);
+            free(wkb);
+            return stored;
+        });
+}
+
+void TgeoAsHexWkbExec(DataChunk &args, ExpressionState &state, Vector &result, uint8_t variant) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            Temporal *t = BlobToTemp(input);
+            size_t sz = 0;
+            char *hex = temporal_as_hexwkb(t, variant, &sz);
+            (void) sz;
+            free(t);
+            if (!hex) throw InternalException("temporal_as_hexwkb returned null");
+            string_t stored = StringVector::AddString(result, hex);
+            free(hex);
+            return stored;
+        });
+}
+
+void TgeoFromWkbExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() == 0) throw InvalidInputException("Empty WKB input");
+            uint8_t *wkb = (uint8_t *)malloc(input.GetSize());
+            memcpy(wkb, input.GetData(), input.GetSize());
+            Temporal *t = temporal_from_wkb(wkb, input.GetSize());
+            free(wkb);
+            if (!t) throw InvalidInputException("temporal_from_wkb: invalid WKB");
+            string_t stored = TempToResultBlob(result, t);
+            free(t);
+            return stored;
+        });
+}
+
+void TgeoFromHexWkbExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            std::string hex(input.GetData(), input.GetSize());
+            Temporal *t = temporal_from_hexwkb(hex.c_str());
+            if (!t) throw InvalidInputException("temporal_from_hexwkb: invalid hex-WKB");
+            string_t stored = TempToResultBlob(result, t);
+            free(t);
+            return stored;
+        });
+}
+
+void TgeoAsMfjsonExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    /* asMFJSON(tgeompoint[, with_bbox[, flags[, precision[, srs]]]]).
+     * MobilityDB defaults: with_bbox=false, flags=0, precision=15, srs=NULL. */
+    const idx_t row_count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(row_count);
+    auto in = FlatVector::GetData<string_t>(args.data[0]);
+    auto out_data = FlatVector::GetData<string_t>(result);
+    auto &out_validity = FlatVector::Validity(result);
+    const idx_t cc = args.ColumnCount();
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!FlatVector::Validity(args.data[0]).RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            continue;
+        }
+        Temporal *t = BlobToTemp(in[row]);
+        bool with_bbox = (cc > 1) ? FlatVector::GetData<bool>(args.data[1])[row] : false;
+        int flags = (cc > 2) ? FlatVector::GetData<int32_t>(args.data[2])[row] : 0;
+        int precision = (cc > 3) ? FlatVector::GetData<int32_t>(args.data[3])[row] : 15;
+        std::string srs;
+        const char *srs_cstr = nullptr;
+        if (cc > 4) {
+            string_t s = FlatVector::GetData<string_t>(args.data[4])[row];
+            srs.assign(s.GetData(), s.GetSize());
+            srs_cstr = srs.empty() ? nullptr : srs.c_str();
+        }
+        char *json = temporal_as_mfjson(t, with_bbox, flags, precision, srs_cstr);
+        free(t);
+        if (!json) {
+            out_validity.SetInvalid(row);
+            continue;
+        }
+        out_data[row] = StringVector::AddString(result, json);
+        free(json);
+    }
+    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+void TgeoFromMfjsonExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            std::string s(input.GetData(), input.GetSize());
+            Temporal *t = tgeompoint_from_mfjson(s.c_str());
+            if (!t) throw InvalidInputException("tgeompoint_from_mfjson: invalid MFJSON");
+            string_t stored = TempToResultBlob(result, t);
+            free(t);
+            return stored;
+        });
+}
+
+void TgeoFromTextExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            std::string s(input.GetData(), input.GetSize());
+            Temporal *t = tgeompoint_in(s.c_str());
+            if (!t) throw InvalidInputException("tgeompoint_in: invalid text");
+            string_t stored = TempToResultBlob(result, t);
+            free(t);
+            return stored;
+        });
+}
+
+} // namespace
+
+void TgeompointType::RegisterRoundtripIO(ExtensionLoader &loader) {
+    const auto T = TGEOMPOINT();
+    const auto V = LogicalType::VARCHAR;
+    const auto B = LogicalType::BLOB;
+    const auto BL = LogicalType::BOOLEAN;
+    const auto I = LogicalType::INTEGER;
+
+    /* asBinary / asEWKB — base WKB and extended WKB (with SRID) */
+    loader.RegisterFunction(ScalarFunction("asBinary", {T}, B,
+        [](DataChunk &a, ExpressionState &s, Vector &r) { TgeoAsWkbExec(a, s, r, WKB_BASE); }));
+    loader.RegisterFunction(ScalarFunction("asEWKB",   {T}, B,
+        [](DataChunk &a, ExpressionState &s, Vector &r) { TgeoAsWkbExec(a, s, r, WKB_EXTENDED); }));
+
+    /* asHexWKB / asHexEWKB */
+    loader.RegisterFunction(ScalarFunction("asHexWKB",  {T}, V,
+        [](DataChunk &a, ExpressionState &s, Vector &r) { TgeoAsHexWkbExec(a, s, r, WKB_BASE); }));
+    loader.RegisterFunction(ScalarFunction("asHexEWKB", {T}, V,
+        [](DataChunk &a, ExpressionState &s, Vector &r) { TgeoAsHexWkbExec(a, s, r, WKB_EXTENDED); }));
+
+    /* asMFJSON: 1..5 arg overloads */
+    loader.RegisterFunction(ScalarFunction("asMFJSON", {T},                     V, TgeoAsMfjsonExec));
+    loader.RegisterFunction(ScalarFunction("asMFJSON", {T, BL},                 V, TgeoAsMfjsonExec));
+    loader.RegisterFunction(ScalarFunction("asMFJSON", {T, BL, I},              V, TgeoAsMfjsonExec));
+    loader.RegisterFunction(ScalarFunction("asMFJSON", {T, BL, I, I},           V, TgeoAsMfjsonExec));
+    loader.RegisterFunction(ScalarFunction("asMFJSON", {T, BL, I, I, V},        V, TgeoAsMfjsonExec));
+
+    /* tgeompointFromText / FromEWKT — both route to tgeompoint_in (auto-detects EWKT prefix) */
+    loader.RegisterFunction(ScalarFunction("tgeompointFromText",  {V}, T, TgeoFromTextExec));
+    loader.RegisterFunction(ScalarFunction("tgeompointFromEWKT",  {V}, T, TgeoFromTextExec));
+
+    /* tgeompointFromBinary / FromEWKB — temporal_from_wkb auto-detects format */
+    loader.RegisterFunction(ScalarFunction("tgeompointFromBinary", {B}, T, TgeoFromWkbExec));
+    loader.RegisterFunction(ScalarFunction("tgeompointFromEWKB",   {B}, T, TgeoFromWkbExec));
+
+    /* tgeompointFromHexWKB / FromHexEWKB — temporal_from_hexwkb auto-detects */
+    loader.RegisterFunction(ScalarFunction("tgeompointFromHexWKB",  {V}, T, TgeoFromHexWkbExec));
+    loader.RegisterFunction(ScalarFunction("tgeompointFromHexEWKB", {V}, T, TgeoFromHexWkbExec));
+
+    /* tgeompointFromMFJSON */
+    loader.RegisterFunction(ScalarFunction("tgeompointFromMFJSON", {V}, T, TgeoFromMfjsonExec));
+}
+
 } // namespace duckdb

--- a/src/include/geo/tgeompoint.hpp
+++ b/src/include/geo/tgeompoint.hpp
@@ -18,6 +18,7 @@ struct TgeompointType {
     static void RegisterType(ExtensionLoader &loader);
     static void RegisterCastFunctions(ExtensionLoader &loader);
     static void RegisterScalarFunctions(ExtensionLoader &loader);
+    static void RegisterRoundtripIO(ExtensionLoader &loader);
 };
 
 } // namespace duckdb

--- a/src/include/temporal/tbox_functions.hpp
+++ b/src/include/temporal/tbox_functions.hpp
@@ -160,6 +160,15 @@ struct TboxFunctions {
     static void Tbox_gt(DataChunk &args, ExpressionState &state, Vector &result);
     static void Tbox_cmp(DataChunk &args, ExpressionState &state, Vector &result);
 
+    /* ***************************************************
+     * WKB / hex-WKB serialization + hashing
+     ****************************************************/
+    static void Tbox_as_wkb(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tbox_as_hexwkb(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tbox_from_wkb(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tbox_from_hexwkb(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tbox_hash(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tbox_hash_extended(DataChunk &args, ExpressionState &state, Vector &result);
 };
 
 } // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -249,6 +249,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	TgeompointType::RegisterType(loader);
 	TgeompointType::RegisterCastFunctions(loader);
 	TgeompointType::RegisterScalarFunctions(loader);
+	TgeompointType::RegisterRoundtripIO(loader);
 
 	TGeometryTypes::RegisterScalarFunctions(loader);
 	TGeometryTypes::RegisterTypes(loader);

--- a/src/temporal/tbox.cpp
+++ b/src/temporal/tbox.cpp
@@ -939,6 +939,28 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TboxFunctions::Tbox_gt
         )
     );
+
+    /* ***************************************************
+     * WKB / hex-WKB serialization + hashing
+     ****************************************************/
+    loader.RegisterFunction(ScalarFunction(
+        "asBinary", {TBOX()}, LogicalType::BLOB,
+        TboxFunctions::Tbox_as_wkb));
+    loader.RegisterFunction(ScalarFunction(
+        "asHexWKB", {TBOX()}, LogicalType::VARCHAR,
+        TboxFunctions::Tbox_as_hexwkb));
+    loader.RegisterFunction(ScalarFunction(
+        "tboxFromBinary", {LogicalType::BLOB}, TBOX(),
+        TboxFunctions::Tbox_from_wkb));
+    loader.RegisterFunction(ScalarFunction(
+        "tboxFromHexWKB", {LogicalType::VARCHAR}, TBOX(),
+        TboxFunctions::Tbox_from_hexwkb));
+    loader.RegisterFunction(ScalarFunction(
+        "tbox_hash", {TBOX()}, LogicalType::INTEGER,
+        TboxFunctions::Tbox_hash));
+    loader.RegisterFunction(ScalarFunction(
+        "tbox_hash_extended", {TBOX(), LogicalType::BIGINT}, LogicalType::BIGINT,
+        TboxFunctions::Tbox_hash_extended));
 }
 
 } // namespace duckdb

--- a/src/temporal/tbox_functions.cpp
+++ b/src/temporal/tbox_functions.cpp
@@ -1861,4 +1861,156 @@ void TboxFunctions::Tbox_cmp(DataChunk &args, ExpressionState &state, Vector &re
     }
 }
 
+/* ***************************************************
+ * WKB / hex-WKB serialization + hashing
+ ****************************************************/
+
+void TboxFunctions::Tbox_as_wkb(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() < sizeof(TBox)) {
+                throw InvalidInputException("asBinary: invalid TBox value");
+            }
+            uint8_t *copy = (uint8_t *)malloc(input.GetSize());
+            memcpy(copy, input.GetData(), input.GetSize());
+            TBox *tbox = reinterpret_cast<TBox *>(copy);
+            size_t wkb_size = 0;
+            uint8_t *wkb = tbox_as_wkb(tbox, WKB_EXTENDED, &wkb_size);
+            free(copy);
+            if (!wkb || wkb_size == 0) {
+                if (wkb) free(wkb);
+                throw InternalException("asBinary: tbox_as_wkb failed");
+            }
+            string_t ret(reinterpret_cast<const char *>(wkb), wkb_size);
+            string_t stored = StringVector::AddStringOrBlob(result, ret);
+            free(wkb);
+            return stored;
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+void TboxFunctions::Tbox_as_hexwkb(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() < sizeof(TBox)) {
+                throw InvalidInputException("asHexWKB: invalid TBox value");
+            }
+            uint8_t *copy = (uint8_t *)malloc(input.GetSize());
+            memcpy(copy, input.GetData(), input.GetSize());
+            TBox *tbox = reinterpret_cast<TBox *>(copy);
+            size_t hex_size = 0;
+            char *hex = tbox_as_hexwkb(tbox, WKB_EXTENDED, &hex_size);
+            (void)hex_size;
+            free(copy);
+            if (!hex) {
+                throw InternalException("asHexWKB: tbox_as_hexwkb failed");
+            }
+            string_t stored = StringVector::AddString(result, hex);
+            free(hex);
+            return stored;
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+void TboxFunctions::Tbox_from_wkb(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input_wkb) -> string_t {
+            if (input_wkb.GetSize() == 0) {
+                throw InvalidInputException("tboxFromBinary: empty input");
+            }
+            uint8_t *wkb = (uint8_t *)malloc(input_wkb.GetSize());
+            memcpy(wkb, input_wkb.GetData(), input_wkb.GetSize());
+            TBox *tbox = tbox_from_wkb(wkb, input_wkb.GetSize());
+            free(wkb);
+            if (!tbox) {
+                throw InvalidInputException("tboxFromBinary: invalid WKB");
+            }
+            size_t sz = sizeof(TBox);
+            uint8_t *out = (uint8_t *)malloc(sz);
+            memcpy(out, tbox, sz);
+            string_t ret(reinterpret_cast<const char *>(out), sz);
+            string_t stored = StringVector::AddStringOrBlob(result, ret);
+            free(out);
+            free(tbox);
+            return stored;
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+void TboxFunctions::Tbox_from_hexwkb(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input_hex) -> string_t {
+            std::string hex(input_hex.GetData(), input_hex.GetSize());
+            TBox *tbox = tbox_from_hexwkb(hex.c_str());
+            if (!tbox) {
+                throw InvalidInputException("tboxFromHexWKB: invalid hex-WKB");
+            }
+            size_t sz = sizeof(TBox);
+            uint8_t *out = (uint8_t *)malloc(sz);
+            memcpy(out, tbox, sz);
+            string_t ret(reinterpret_cast<const char *>(out), sz);
+            string_t stored = StringVector::AddStringOrBlob(result, ret);
+            free(out);
+            free(tbox);
+            return stored;
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+void TboxFunctions::Tbox_hash(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, int32_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> int32_t {
+            if (input.GetSize() < sizeof(TBox)) {
+                throw InvalidInputException("tbox_hash: invalid TBox value");
+            }
+            uint8_t *copy = (uint8_t *)malloc(input.GetSize());
+            memcpy(copy, input.GetData(), input.GetSize());
+            TBox *tbox = reinterpret_cast<TBox *>(copy);
+            uint32_t h = tbox_hash(tbox);
+            free(copy);
+            return static_cast<int32_t>(h);
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
+void TboxFunctions::Tbox_hash_extended(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, int64_t, int64_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t input, int64_t seed) -> int64_t {
+            if (input.GetSize() < sizeof(TBox)) {
+                throw InvalidInputException("tbox_hash_extended: invalid TBox value");
+            }
+            uint8_t *copy = (uint8_t *)malloc(input.GetSize());
+            memcpy(copy, input.GetData(), input.GetSize());
+            TBox *tbox = reinterpret_cast<TBox *>(copy);
+            uint64_t h = tbox_hash_extended(tbox, static_cast<uint64_t>(seed));
+            free(copy);
+            return static_cast<int64_t>(h);
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
 } // namespace duckdb

--- a/test/sql/parity/021_tbox_wkb_hash.test
+++ b/test/sql/parity/021_tbox_wkb_hash.test
@@ -1,0 +1,50 @@
+# name: test/sql/parity/021_tbox_wkb_hash.test
+# description: TBox WKB/hex-WKB serialization round-trip + hash bindings.
+# group: [sql]
+
+require mobilityduck
+
+# asHexWKB produces a non-empty hex string
+
+query I
+SELECT length(asHexWKB(tbox 'TBOXFLOAT XT([1.5, 2.5),[2000-01-01, 2000-01-03])')) > 0;
+----
+true
+
+# tboxFromHexWKB(asHexWKB(x)) round-trips to x
+
+query I
+SELECT tboxFromHexWKB(asHexWKB(tbox 'TBOXFLOAT XT([1.5, 2.5),[2000-01-01, 2000-01-03])'))
+     = tbox 'TBOXFLOAT XT([1.5, 2.5),[2000-01-01, 2000-01-03])';
+----
+true
+
+# tboxFromBinary(asBinary(x)) round-trips to x
+
+query I
+SELECT tboxFromBinary(asBinary(tbox 'TBOXFLOAT XT([1.5, 2.5),[2000-01-01, 2000-01-03])'))
+     = tbox 'TBOXFLOAT XT([1.5, 2.5),[2000-01-01, 2000-01-03])';
+----
+true
+
+# tbox_hash is deterministic and a hash of two distinct values differs
+
+query I
+SELECT tbox_hash(tbox 'TBOXFLOAT XT([1, 2),[2000-01-01, 2000-01-02])')
+     = tbox_hash(tbox 'TBOXFLOAT XT([1, 2),[2000-01-01, 2000-01-02])');
+----
+true
+
+query I
+SELECT tbox_hash(tbox 'TBOXFLOAT XT([1, 2),[2000-01-01, 2000-01-02])')
+    <> tbox_hash(tbox 'TBOXFLOAT XT([3, 4),[2000-01-01, 2000-01-02])');
+----
+true
+
+# tbox_hash_extended changes with seed
+
+query I
+SELECT tbox_hash_extended(tbox 'TBOXFLOAT XT([1, 2),[2000-01-01, 2000-01-02])', 1)
+    <> tbox_hash_extended(tbox 'TBOXFLOAT XT([1, 2),[2000-01-01, 2000-01-02])', 2);
+----
+true

--- a/test/sql/parity/053_tgeompoint_io.test
+++ b/test/sql/parity/053_tgeompoint_io.test
@@ -1,0 +1,95 @@
+# name: test/sql/parity/053_tgeompoint_io.test
+# description: Round-trip I/O for tgeompoint — asBinary / asEWKB / asHexWKB /
+#              asHexEWKB / asMFJSON producers and the matching
+#              tgeompointFromText / FromEWKT / FromBinary / FromEWKB /
+#              FromHexWKB / FromHexEWKB / FromMFJSON constructors.
+# group: [sql]
+
+require mobilityduck
+
+# Producers all return non-empty output
+
+query I
+SELECT octet_length(asBinary(tgeompoint '[POINT(0 0)@2000-01-01]')) > 0;
+----
+true
+
+query I
+SELECT octet_length(asEWKB(tgeompoint '[POINT(0 0)@2000-01-01]')) > 0;
+----
+true
+
+query I
+SELECT length(asHexWKB(tgeompoint '[POINT(0 0)@2000-01-01]')) > 0;
+----
+true
+
+query I
+SELECT length(asHexEWKB(tgeompoint '[POINT(0 0)@2000-01-01]')) > 0;
+----
+true
+
+query I
+SELECT length(asMFJSON(tgeompoint '[POINT(0 0)@2000-01-01]')) > 0;
+----
+true
+
+# Round-trips: producer + consumer reconstructs the same value
+
+query I
+SELECT tgeompointFromBinary(asBinary(tgeompoint '[POINT(0 0)@2000-01-01]'))
+     = tgeompoint '[POINT(0 0)@2000-01-01]';
+----
+true
+
+query I
+SELECT tgeompointFromEWKB(asEWKB(tgeompoint '[POINT(0 0)@2000-01-01]'))
+     = tgeompoint '[POINT(0 0)@2000-01-01]';
+----
+true
+
+query I
+SELECT tgeompointFromHexWKB(asHexWKB(tgeompoint '[POINT(0 0)@2000-01-01]'))
+     = tgeompoint '[POINT(0 0)@2000-01-01]';
+----
+true
+
+query I
+SELECT tgeompointFromHexEWKB(asHexEWKB(tgeompoint '[POINT(0 0)@2000-01-01]'))
+     = tgeompoint '[POINT(0 0)@2000-01-01]';
+----
+true
+
+query I
+SELECT tgeompointFromMFJSON(asMFJSON(tgeompoint '[POINT(0 0)@2000-01-01]'))
+     = tgeompoint '[POINT(0 0)@2000-01-01]';
+----
+true
+
+# Text round-trip
+
+query I
+SELECT tgeompointFromText('[POINT(0 0)@2000-01-01]')
+     = tgeompoint '[POINT(0 0)@2000-01-01]';
+----
+true
+
+query I
+SELECT tgeompointFromEWKT(asEWKT(tgeompoint '[POINT(0 0)@2000-01-01]'))
+     = tgeompoint '[POINT(0 0)@2000-01-01]';
+----
+true
+
+# asMFJSON with bbox flag
+
+query I
+SELECT length(asMFJSON(tgeompoint '[POINT(0 0)@2000-01-01]', TRUE)) >= length(asMFJSON(tgeompoint '[POINT(0 0)@2000-01-01]', FALSE));
+----
+true
+
+# asMFJSON with full options (bbox, flags, precision, srs)
+
+query I
+SELECT length(asMFJSON(tgeompoint '[POINT(0 0)@2000-01-01]', FALSE, 0, 6, 'EPSG:4326')) > 0;
+----
+true


### PR DESCRIPTION
## Summary
Consolidates 2 individual parity PRs (previously #70, #83) into one squashed commit.

- tbox WKB/hex-WKB serialization + hashing
- tgeompoint round-trip I/O: Binary / EWKB / HexWKB / HexEWKB / MFJSON

## Test plan
- [ ] Round-trip encoding tests
- [ ] No regressions in existing I/O tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)