### PR TITLE
fix(bindings): fix distance return types; add + shift alias for tstzset/tstzspan+interval

### DIFF
--- a/src/include/time_util.hpp
+++ b/src/include/time_util.hpp
@@ -57,4 +57,15 @@ inline timestamp_tz_t MeosToDuckDBTimestamp(timestamp_tz_t meos_ts) {
     return duckdb_ts;
 }
 
-} 
+// Convert a MEOS temporal distance in seconds (double) to a DuckDB interval_t.
+// Days component is extracted first so that exact multiples of 86400 s display
+// as "N days" rather than "NNN:00:00".
+inline interval_t SecsToInterval(double secs) {
+    interval_t iv;
+    iv.months = 0;
+    iv.days   = static_cast<int32_t>(secs / 86400.0);
+    iv.micros = static_cast<int64_t>((secs - iv.days * 86400.0) * 1e6 + 0.5);
+    return iv;
+}
+
+}

--- a/src/temporal/set.cpp
+++ b/src/temporal/set.cpp
@@ -225,11 +225,14 @@ void SetTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             ScalarFunction("shift", {SetTypes::dateset(), LogicalType::INTEGER}, SetTypes::dateset(), SetFunctions::Numset_shift)
         );        
 
-        loader.RegisterFunction( 
+        loader.RegisterFunction(
             ScalarFunction("shift", {SetTypes::tstzset(), LogicalType::INTERVAL}, SetTypes::tstzset(), SetFunctions::Tstzset_shift)
         );
+        loader.RegisterFunction(
+            ScalarFunction("+", {SetTypes::tstzset(), LogicalType::INTERVAL}, SetTypes::tstzset(), SetFunctions::Tstzset_shift)
+        );
 
-        loader.RegisterFunction( 
+        loader.RegisterFunction(
             ScalarFunction("scale", {SetTypes::intset(), LogicalType::INTEGER}, SetTypes::intset(), SetFunctions::Numset_scale)
         );
 
@@ -677,9 +680,9 @@ void SetTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::INTEGER, SetFunctions::Distance_set_value));
     loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Distance_value_set));
     loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Distance_set_set));
-    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::DOUBLE, SetFunctions::Distance_set_value));
-    loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::DOUBLE, SetFunctions::Distance_value_set));
-    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::DOUBLE, SetFunctions::Distance_set_set));
+    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::INTERVAL, SetFunctions::Distance_set_value));
+    loader.RegisterFunction( ScalarFunction("set_distance", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::INTERVAL, SetFunctions::Distance_value_set));
+    loader.RegisterFunction( ScalarFunction("set_distance", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::INTERVAL, SetFunctions::Distance_set_set));
     loader.RegisterFunction( ScalarFunction("<->", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, SetFunctions::Distance_value_value));
     loader.RegisterFunction( ScalarFunction("<->", {LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::BIGINT, SetFunctions::Distance_value_value));
     loader.RegisterFunction( ScalarFunction("<->", {LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, SetFunctions::Distance_value_value));
@@ -697,9 +700,9 @@ void SetTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction( ScalarFunction("<->", {SetTypes::dateset(), LogicalType::DATE}, LogicalType::INTEGER, SetFunctions::Distance_set_value));
     loader.RegisterFunction( ScalarFunction("<->", {LogicalType::DATE, SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Distance_value_set));
     loader.RegisterFunction( ScalarFunction("<->", {SetTypes::dateset(), SetTypes::dateset()}, LogicalType::INTEGER, SetFunctions::Distance_set_set));
-    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::DOUBLE, SetFunctions::Distance_set_value));
-    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::DOUBLE, SetFunctions::Distance_value_set));
-    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::DOUBLE, SetFunctions::Distance_set_set));
+    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::tstzset(), LogicalType::TIMESTAMP_TZ}, LogicalType::INTERVAL, SetFunctions::Distance_set_value));
+    loader.RegisterFunction( ScalarFunction("<->", {LogicalType::TIMESTAMP_TZ, SetTypes::tstzset()}, LogicalType::INTERVAL, SetFunctions::Distance_value_set));
+    loader.RegisterFunction( ScalarFunction("<->", {SetTypes::tstzset(), SetTypes::tstzset()}, LogicalType::INTERVAL, SetFunctions::Distance_set_set));
 
     // --- set_eq / = ---
     loader.RegisterFunction( ScalarFunction("set_eq", {SetTypes::intset(), SetTypes::intset()}, LogicalType::BOOLEAN, SetFunctions::Set_eq));

--- a/src/temporal/set_functions.cpp
+++ b/src/temporal/set_functions.cpp
@@ -2783,14 +2783,14 @@ void SetFunctions::Distance_set_value(DataChunk &args, ExpressionState &state, V
         return;
     }
     if (alias == "tstzset") {
-        BinaryExecutor::ExecuteWithNulls<string_t, timestamp_tz_t, double>(
+        BinaryExecutor::ExecuteWithNulls<string_t, timestamp_tz_t, interval_t>(
             set_vec, val_vec, result, count,
-            [&](string_t blob, timestamp_tz_t ts, ValidityMask &mask, idx_t idx) -> double {
+            [&](string_t blob, timestamp_tz_t ts, ValidityMask &mask, idx_t idx) -> interval_t {
                 Set *s = CopySet(blob);
                 timestamp_tz_t ts_meos = DuckDBToMeosTimestamp(ts);
-                double r = distance_set_timestamptz(s, (TimestampTz)ts_meos.value);
+                double secs = distance_set_timestamptz(s, (TimestampTz)ts_meos.value);
                 free(s);
-                return r;
+                return SecsToInterval(secs);
             });
         return;
     }
@@ -2849,14 +2849,14 @@ void SetFunctions::Distance_value_set(DataChunk &args, ExpressionState &state, V
         return;
     }
     if (alias == "tstzset") {
-        BinaryExecutor::ExecuteWithNulls<timestamp_tz_t, string_t, double>(
+        BinaryExecutor::ExecuteWithNulls<timestamp_tz_t, string_t, interval_t>(
             val_vec, set_vec, result, count,
-            [&](timestamp_tz_t ts, string_t blob, ValidityMask &mask, idx_t idx) -> double {
+            [&](timestamp_tz_t ts, string_t blob, ValidityMask &mask, idx_t idx) -> interval_t {
                 Set *s = CopySet(blob);
                 timestamp_tz_t ts_meos = DuckDBToMeosTimestamp(ts);
-                double r = distance_set_timestamptz(s, (TimestampTz)ts_meos.value);
+                double secs = distance_set_timestamptz(s, (TimestampTz)ts_meos.value);
                 free(s);
-                return r;
+                return SecsToInterval(secs);
             });
         return;
     }
@@ -2920,15 +2920,15 @@ void SetFunctions::Distance_set_set(DataChunk &args, ExpressionState &state, Vec
         return;
     }
     if (alias == "tstzset") {
-        BinaryExecutor::ExecuteWithNulls<string_t, string_t, double>(
+        BinaryExecutor::ExecuteWithNulls<string_t, string_t, interval_t>(
             a, b, result, args.size(),
-            [&](string_t x, string_t y, ValidityMask &mask, idx_t idx) -> double {
+            [&](string_t x, string_t y, ValidityMask &mask, idx_t idx) -> interval_t {
                 Set *s1 = CopySet(x);
                 Set *s2 = CopySet(y);
-                double r = distance_tstzset_tstzset(s1, s2);
+                double secs = distance_tstzset_tstzset(s1, s2);
                 free(s1);
                 free(s2);
-                return r;
+                return SecsToInterval(secs);
             });
         return;
     }

--- a/src/temporal/span.cpp
+++ b/src/temporal/span.cpp
@@ -261,7 +261,9 @@ void SpanTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
         }
         else if( span_type == SpanTypes::TSTZSPAN() ){
             loader.RegisterFunction( ScalarFunction("shift", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Tstzspan_shift)
-            ); 
+            );
+            loader.RegisterFunction( ScalarFunction("+", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Tstzspan_shift)
+            );
 
             loader.RegisterFunction( ScalarFunction("expand", {span_type, LogicalType::INTERVAL}, span_type, SpanFunctions::Tstzspan_expand)
             );

--- a/src/temporal/span_functions.cpp
+++ b/src/temporal/span_functions.cpp
@@ -4492,9 +4492,9 @@ void SpanFunctions::Distance_span_value(DataChunk &args, ExpressionState &state,
     meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // distance between intspan and integer
-            BinaryExecutor::Execute<string_t, int32_t, double>(
+            BinaryExecutor::Execute<string_t, int32_t, int32_t>(
                 span_vec, args.data[1], result, args.size(),
-                [&](string_t span_blob, int32_t value) -> double {
+                [&](string_t span_blob, int32_t value) -> int32_t {
                     const uint8_t *span_data = reinterpret_cast<const uint8_t*>(span_blob.GetData());
                     size_t span_data_size = span_blob.GetSize();
                     uint8_t *span_data_copy = (uint8_t*)malloc(span_data_size);
@@ -4504,7 +4504,7 @@ void SpanFunctions::Distance_span_value(DataChunk &args, ExpressionState &state,
                         free(span_data_copy);
                         throw InvalidInputException("Invalid SPAN data: null pointer");
                     }
-                    int32_t distance = distance_span_value(span, Datum(value));
+                    int32_t distance = DatumGetInt32(distance_span_value(span, Datum(value)));
                     free(span_data_copy);
                     return distance;
             }
@@ -4512,19 +4512,19 @@ void SpanFunctions::Distance_span_value(DataChunk &args, ExpressionState &state,
             break;
         }
         case T_BIGINTSPAN: { // distance between bigintspan and bigint
-            BinaryExecutor::Execute<string_t, int64_t, double>(
+            BinaryExecutor::Execute<string_t, int64_t, int64_t>(
                 span_vec, args.data[1], result, args.size(),
-                [&](string_t span_blob, int64_t value) -> double {
+                [&](string_t span_blob, int64_t value) -> int64_t {
                     const uint8_t *span_data = reinterpret_cast<const uint8_t*>(span_blob.GetData());
                     size_t span_data_size = span_blob.GetSize();
                     uint8_t *span_data_copy = (uint8_t*)malloc(span_data_size);
                     memcpy(span_data_copy, span_data, span_data_size);
                     Span *span = reinterpret_cast<Span*>(span_data_copy);
                     if (!span) {
-                        free(span_data_copy);       
+                        free(span_data_copy);
                         throw InvalidInputException("Invalid SPAN data: null pointer");
-                    }       
-                    int64_t distance = distance_span_value(span, Datum(value));
+                    }
+                    int64_t distance = DatumGetInt64(distance_span_value(span, Datum(value)));
                     free(span_data_copy);
                     return distance;
                 }
@@ -4538,22 +4538,22 @@ void SpanFunctions::Distance_span_value(DataChunk &args, ExpressionState &state,
                     const uint8_t *span_data = reinterpret_cast<const uint8_t*>(span_blob.GetData());
                     size_t span_data_size = span_blob.GetSize();
                     uint8_t *span_data_copy = (uint8_t*)malloc(span_data_size);
-                    memcpy(span_data_copy, span_data, span_data_size);      
+                    memcpy(span_data_copy, span_data, span_data_size);
                     Span *span = reinterpret_cast<Span*>(span_data_copy);
                     if (!span) {
                         free(span_data_copy);
-                        throw InvalidInputException("Invalid FLOATSPAN data: null pointer");    
+                        throw InvalidInputException("Invalid FLOATSPAN data: null pointer");
                     }
                     double distance = distance_span_value(span, Float8GetDatum(value));
                     free(span_data_copy);
                     return distance;
                 });
-            break;  
+            break;
         }
         case T_DATESPAN: { // distance between datespan and date
-            BinaryExecutor::Execute<string_t, int32_t, double>(
+            BinaryExecutor::Execute<string_t, int32_t, int32_t>(
                 span_vec, args.data[1], result, args.size(),
-                [&](string_t span_blob, int32_t value) -> double {
+                [&](string_t span_blob, int32_t value) -> int32_t {
                     const uint8_t *span_data = reinterpret_cast<const uint8_t*>(span_blob.GetData());
                     size_t span_data_size = span_blob.GetSize();
                     uint8_t *span_data_copy = (uint8_t*)malloc(span_data_size);
@@ -4563,34 +4563,34 @@ void SpanFunctions::Distance_span_value(DataChunk &args, ExpressionState &state,
                         free(span_data_copy);
                         throw InvalidInputException("Invalid SPAN data: null pointer");
                     }
-                    int32_t distance = distance_span_value(span, Datum(value));
+                    int32_t distance = DatumGetInt32(distance_span_value(span, Datum(value)));
                     free(span_data_copy);
                     return distance;
                 });
-            break;  
+            break;
         }
-        case T_TSTZSPAN: { // distance between tstzspan and timestamptz
-            BinaryExecutor::Execute<string_t, timestamp_tz_t, double>(
+        case T_TSTZSPAN: { // distance between tstzspan and timestamptz → interval
+            BinaryExecutor::Execute<string_t, timestamp_tz_t, interval_t>(
                 span_vec, args.data[1], result, args.size(),
-                [&](string_t span_blob, timestamp_tz_t ts_duckdb) -> double {
+                [&](string_t span_blob, timestamp_tz_t ts_duckdb) -> interval_t {
                     const uint8_t *span_data = reinterpret_cast<const uint8_t*>(span_blob.GetData());
                     size_t span_data_size = span_blob.GetSize();
                     uint8_t *span_data_copy = (uint8_t*)malloc(span_data_size);
-                    memcpy(span_data_copy, span_data, span_data_size);  
+                    memcpy(span_data_copy, span_data, span_data_size);
                     timestamp_tz_t ts_meos = DuckDBToMeosTimestamp(ts_duckdb);
                     Span *span = reinterpret_cast<Span*>(span_data_copy);
                     if (!span) {
                         free(span_data_copy);
-                        throw InvalidInputException("Invalid TSTZSPAN data: null pointer"); 
+                        throw InvalidInputException("Invalid TSTZSPAN data: null pointer");
                     }
-                    double distance = distance_span_value(span, Datum(ts_meos.value));
+                    double secs = distance_span_timestamptz(span, (TimestampTz)ts_meos.value);
                     free(span_data_copy);
-                    return distance;
+                    return SecsToInterval(secs);
                 });
-            break;   
-        }   
+            break;
+        }
         default:
-            throw NotImplementedException("distance between SPAN and value: unsupported span type");    
+            throw NotImplementedException("distance between SPAN and value: unsupported span type");
 
     }
     if (args.size() == 1) {
@@ -4603,9 +4603,9 @@ void SpanFunctions::Distance_value_span(DataChunk &args, ExpressionState &state,
     meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // distance between integer and intspan
-            BinaryExecutor::Execute<int32_t, string_t, double>(
+            BinaryExecutor::Execute<int32_t, string_t, int32_t>(
                 args.data[0], span_vec, result, args.size(),
-                [&](int32_t value, string_t span_blob) -> double {
+                [&](int32_t value, string_t span_blob) -> int32_t {
                     const uint8_t *span_data = reinterpret_cast<const uint8_t*>(span_blob.GetData());
                     size_t span_data_size = span_blob.GetSize();
                     uint8_t *span_data_copy = (uint8_t*)malloc(span_data_size);
@@ -4615,7 +4615,7 @@ void SpanFunctions::Distance_value_span(DataChunk &args, ExpressionState &state,
                         free(span_data_copy);
                         throw InvalidInputException("Invalid SPAN data: null pointer");
                     }
-                    int32_t distance = distance_span_value(span, Datum(value));
+                    int32_t distance = DatumGetInt32(distance_span_value(span, Datum(value)));
                     free(span_data_copy);
                     return distance;
             }
@@ -4623,19 +4623,19 @@ void SpanFunctions::Distance_value_span(DataChunk &args, ExpressionState &state,
             break;
         }
         case T_BIGINTSPAN: { // distance between bigint and bigintspan
-            BinaryExecutor::Execute<int64_t, string_t, double>(
+            BinaryExecutor::Execute<int64_t, string_t, int64_t>(
                 args.data[0], span_vec, result, args.size(),
-                [&](int64_t value, string_t span_blob) -> double {
+                [&](int64_t value, string_t span_blob) -> int64_t {
                     const uint8_t *span_data = reinterpret_cast<const uint8_t*>(span_blob.GetData());
                     size_t span_data_size = span_blob.GetSize();
                     uint8_t *span_data_copy = (uint8_t*)malloc(span_data_size);
                     memcpy(span_data_copy, span_data, span_data_size);
                     Span *span = reinterpret_cast<Span*>(span_data_copy);
                     if (!span) {
-                        free(span_data_copy);       
-                        throw InvalidInputException("Invalid SPAN data: null pointer"); 
+                        free(span_data_copy);
+                        throw InvalidInputException("Invalid SPAN data: null pointer");
                     }
-                    int64_t distance = distance_span_value(span, Datum(value));
+                    int64_t distance = DatumGetInt64(distance_span_value(span, Datum(value)));
                     free(span_data_copy);
                     return distance;
                 }
@@ -4649,11 +4649,11 @@ void SpanFunctions::Distance_value_span(DataChunk &args, ExpressionState &state,
                     const uint8_t *span_data = reinterpret_cast<const uint8_t*>(span_blob.GetData());
                     size_t span_data_size = span_blob.GetSize();
                     uint8_t *span_data_copy = (uint8_t*)malloc(span_data_size);
-                    memcpy(span_data_copy, span_data, span_data_size);      
+                    memcpy(span_data_copy, span_data, span_data_size);
                     Span *span = reinterpret_cast<Span*>(span_data_copy);
                     if (!span) {
                         free(span_data_copy);
-                        throw InvalidInputException("Invalid FLOATSPAN data: null pointer");    
+                        throw InvalidInputException("Invalid FLOATSPAN data: null pointer");
                     }
                     double distance = distance_span_value(span, Float8GetDatum(value));
                     free(span_data_copy);
@@ -4662,9 +4662,9 @@ void SpanFunctions::Distance_value_span(DataChunk &args, ExpressionState &state,
             break;
         }
         case T_DATESPAN: { // distance between date and datespan
-            BinaryExecutor::Execute<int32_t, string_t, double>(
+            BinaryExecutor::Execute<int32_t, string_t, int32_t>(
                 args.data[0], span_vec, result, args.size(),
-                [&](int32_t value, string_t span_blob) -> double {
+                [&](int32_t value, string_t span_blob) -> int32_t {
                     const uint8_t *span_data = reinterpret_cast<const uint8_t*>(span_blob.GetData());
                     size_t span_data_size = span_blob.GetSize();
                     uint8_t *span_data_copy = (uint8_t*)malloc(span_data_size);
@@ -4674,29 +4674,29 @@ void SpanFunctions::Distance_value_span(DataChunk &args, ExpressionState &state,
                         free(span_data_copy);
                         throw InvalidInputException("Invalid SPAN data: null pointer");
                     }
-                    int32_t distance = distance_span_value(span, Datum(value));
+                    int32_t distance = DatumGetInt32(distance_span_value(span, Datum(value)));
                     free(span_data_copy);
                     return distance;
                 });
             break;
         }
-        case T_TSTZSPAN: { // distance between timestamptz and tstzspan
-            BinaryExecutor::Execute<timestamp_tz_t, string_t, double>(
+        case T_TSTZSPAN: { // distance between timestamptz and tstzspan → interval
+            BinaryExecutor::Execute<timestamp_tz_t, string_t, interval_t>(
                 args.data[0], span_vec, result, args.size(),
-                [&](timestamp_tz_t ts_duckdb, string_t span_blob) -> double {
+                [&](timestamp_tz_t ts_duckdb, string_t span_blob) -> interval_t {
                     const uint8_t *span_data = reinterpret_cast<const uint8_t*>(span_blob.GetData());
                     size_t span_data_size = span_blob.GetSize();
                     uint8_t *span_data_copy = (uint8_t*)malloc(span_data_size);
-                    memcpy(span_data_copy, span_data, span_data_size);  
+                    memcpy(span_data_copy, span_data, span_data_size);
                     timestamp_tz_t ts_meos = DuckDBToMeosTimestamp(ts_duckdb);
                     Span *span = reinterpret_cast<Span*>(span_data_copy);
                     if (!span) {
                         free(span_data_copy);
-                        throw InvalidInputException("Invalid TSTZSPAN data: null pointer"); 
+                        throw InvalidInputException("Invalid TSTZSPAN data: null pointer");
                     }
-                    double distance = distance_span_value(span, Datum(ts_meos.value));
+                    double secs = distance_span_timestamptz(span, (TimestampTz)ts_meos.value);
                     free(span_data_copy);
-                    return distance;
+                    return SecsToInterval(secs);
                 });
             break;
         }
@@ -4709,35 +4709,72 @@ void SpanFunctions::Distance_value_span(DataChunk &args, ExpressionState &state,
 }
 
 void SpanFunctions::Distance_span_span(DataChunk &args, ExpressionState &state, Vector &result) {
-    BinaryExecutor::ExecuteWithNulls<string_t, string_t, double>(
-        args.data[0], args.data[1], result, args.size(),
-        [&](string_t span1_blob, string_t span2_blob, ValidityMask &mask, idx_t idx) -> double {
-            const uint8_t *span1_data = reinterpret_cast<const uint8_t*>(span1_blob.GetData());
-            size_t span1_data_size = span1_blob.GetSize();
-            uint8_t *span1_data_copy = (uint8_t*)malloc(span1_data_size);
-            memcpy(span1_data_copy, span1_data, span1_data_size);
-            Span *span1 = reinterpret_cast<Span*>(span1_data_copy);
-            if (!span1) {
-                free(span1_data_copy);
-                throw InvalidInputException("Invalid SPAN data: null pointer");
-            }
-
-            const uint8_t *span2_data = reinterpret_cast<const uint8_t*>(span2_blob.GetData());
-            size_t span2_data_size = span2_blob.GetSize();
-            uint8_t *span2_data_copy = (uint8_t*)malloc(span2_data_size);
-            memcpy(span2_data_copy, span2_data, span2_data_size);
-            Span *span2 = reinterpret_cast<Span*>(span2_data_copy);
-            if (!span2) {
-                free(span2_data_copy);
-                throw InvalidInputException("Invalid SPAN data: null pointer");
-            }
-
-            double distance = distance_span_span(span1, span2);
-            free(span1);
-            free(span2);
-            return distance;
+    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(args.data[0].GetType().GetAlias());
+    switch (span_type) {
+        case T_INTSPAN:
+        case T_DATESPAN: {
+            BinaryExecutor::Execute<string_t, string_t, int32_t>(
+                args.data[0], args.data[1], result, args.size(),
+                [&](string_t s1_blob, string_t s2_blob) -> int32_t {
+                    uint8_t *c1 = (uint8_t*)malloc(s1_blob.GetSize());
+                    memcpy(c1, s1_blob.GetData(), s1_blob.GetSize());
+                    uint8_t *c2 = (uint8_t*)malloc(s2_blob.GetSize());
+                    memcpy(c2, s2_blob.GetData(), s2_blob.GetSize());
+                    int32_t d = DatumGetInt32(distance_span_span(
+                        reinterpret_cast<Span*>(c1), reinterpret_cast<Span*>(c2)));
+                    free(c1); free(c2);
+                    return d;
+                });
+            break;
         }
-    );
+        case T_BIGINTSPAN: {
+            BinaryExecutor::Execute<string_t, string_t, int64_t>(
+                args.data[0], args.data[1], result, args.size(),
+                [&](string_t s1_blob, string_t s2_blob) -> int64_t {
+                    uint8_t *c1 = (uint8_t*)malloc(s1_blob.GetSize());
+                    memcpy(c1, s1_blob.GetData(), s1_blob.GetSize());
+                    uint8_t *c2 = (uint8_t*)malloc(s2_blob.GetSize());
+                    memcpy(c2, s2_blob.GetData(), s2_blob.GetSize());
+                    int64_t d = DatumGetInt64(distance_span_span(
+                        reinterpret_cast<Span*>(c1), reinterpret_cast<Span*>(c2)));
+                    free(c1); free(c2);
+                    return d;
+                });
+            break;
+        }
+        case T_FLOATSPAN: {
+            BinaryExecutor::Execute<string_t, string_t, double>(
+                args.data[0], args.data[1], result, args.size(),
+                [&](string_t s1_blob, string_t s2_blob) -> double {
+                    uint8_t *c1 = (uint8_t*)malloc(s1_blob.GetSize());
+                    memcpy(c1, s1_blob.GetData(), s1_blob.GetSize());
+                    uint8_t *c2 = (uint8_t*)malloc(s2_blob.GetSize());
+                    memcpy(c2, s2_blob.GetData(), s2_blob.GetSize());
+                    double d = DatumGetFloat8(distance_span_span(
+                        reinterpret_cast<Span*>(c1), reinterpret_cast<Span*>(c2)));
+                    free(c1); free(c2);
+                    return d;
+                });
+            break;
+        }
+        case T_TSTZSPAN: {
+            BinaryExecutor::Execute<string_t, string_t, interval_t>(
+                args.data[0], args.data[1], result, args.size(),
+                [&](string_t s1_blob, string_t s2_blob) -> interval_t {
+                    uint8_t *c1 = (uint8_t*)malloc(s1_blob.GetSize());
+                    memcpy(c1, s1_blob.GetData(), s1_blob.GetSize());
+                    uint8_t *c2 = (uint8_t*)malloc(s2_blob.GetSize());
+                    memcpy(c2, s2_blob.GetData(), s2_blob.GetSize());
+                    double secs = distance_tstzspan_tstzspan(
+                        reinterpret_cast<Span*>(c1), reinterpret_cast<Span*>(c2));
+                    free(c1); free(c2);
+                    return SecsToInterval(secs);
+                });
+            break;
+        }
+        default:
+            throw NotImplementedException("distance(span, span): unsupported span type");
+    }
     if (args.size() == 1) {
         result.SetVectorType(VectorType::CONSTANT_VECTOR);
     }

--- a/test/sql/parity/009_time_ops.test
+++ b/test/sql/parity/009_time_ops.test
@@ -2,26 +2,15 @@
 # description: MobilityDB regression file 009_time_ops.test.sql adapted for MobilityDuck
 # group: [sql]
 #
-# Time-only specialisations of operators between dateset / datespan /
-# datespanset / tstzset / tstzspan / tstzspanset and timestamptz /
-# date — most of the surface is covered transitively by the existing
-# set / span / spanset operator registrations (containment, overlap,
-# union, intersection, difference, distance), which already pass in
-# the parity files for those types.
-#
-# What this file additionally exercises that is NOT yet bound:
-# - Time-shift arithmetic: `+ interval`, `- interval` between
-#   tstzset / tstzspan / tstzspanset and INTERVAL.
-# - Time-difference operator `<->` returning INTERVAL between
-#   timestamptz / tstzset / tstzspan / tstzspanset pairs (only the
-#   span-span / set-span / spanset-spanset distance variants are
-#   bound; the timestamptz-vs-time-type variants are not).
+# Time-shift arithmetic: `+ interval` for tstzset / tstzspan (alias for
+# shift); and time-distance `<->` returning INTERVAL for tstzset/tstzspan
+# pairs. Fixed in feat/distance-interval-types.
 
 require mobilityduck
 
-mode skip
-
-# tstzset / tstzspan / tstzspanset + interval (shift)
+# =============================================================================
+# + interval — shift alias for tstzset and tstzspan
+# =============================================================================
 
 query I
 SELECT tstzset '{2000-01-01}' + interval '1 day';
@@ -33,7 +22,9 @@ SELECT tstzspan '[2000-01-01, 2000-01-02]' + interval '1 day';
 ----
 [2000-01-02 00:00:00+00, 2000-01-03 00:00:00+00]
 
-# Time-difference distance
+# =============================================================================
+# <-> distance returning INTERVAL
+# =============================================================================
 
 query I
 SELECT timestamptz '2000-01-01' <-> tstzset '{2000-01-03}';
@@ -44,5 +35,3 @@ query I
 SELECT tstzspan '[2000-01-01, 2000-01-02]' <-> tstzspan '[2000-01-04, 2000-01-05]';
 ----
 2 days
-
-mode unskip


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDuck/blob/main/doc/contributing/reviewer-guide.md).

## Summary
- Integer and date span distance operators were registered with `INTEGER`/`BIGINT` return types but the C++ executor wrote `DOUBLE` values → `INTERNAL error` at runtime. Fixed by using `BinaryExecutor<..., int32_t/int64_t>` with `DatumGetInt32/Int64`.
- `tstzspan` distance was registered as `DOUBLE` but callers expect `INTERVAL` (e.g. `2 days`, not `172800.0`). Fixed to return `interval_t` via `SecsToInterval`.
- Added `+` and `shift` aliases for `tstzset`/`tstzspan` + `interval` (DuckDB cannot define custom infix operators, so `+` is registered as a named function alias).

## Test plan
- [ ] `intspan '[1,3]' <-> intspan '[5,7]'` returns `2` (INTEGER)
- [ ] `datespan '[2000-01-01,2000-01-03]' <-> datespan '[2000-01-10,2000-01-15]'` returns correct day count
- [ ] `tstzspan '[2000-01-01,2000-01-03]' <-> tstzspan '[2000-01-10,2000-01-15]'` returns `7 days` INTERVAL

🤖 Generated with [Claude Code](https://claude.com/claude-code)