### PR TITLE
feat(parity): timeSplit / valueSplit / quadSplit emitters

### DIFF
--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -9,6 +9,8 @@
 #include "temporal/span.hpp"
 #include "geo/stbox.hpp"
 #include "geo/tgeompoint.hpp"
+#include "geo/tgeometry.hpp"
+#include "time_util.hpp"
 
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/common/exception.hpp"
@@ -125,6 +127,10 @@ void TemporalTypes::RegisterCastFunctions(ExtensionLoader &loader) {
 
 }
 }
+
+void TemporalTimeSplitExec(DataChunk &, ExpressionState &, Vector &);
+template <bool> void TnumberValueSplitExec(DataChunk &, ExpressionState &, Vector &);
+void StboxQuadSplitExec(DataChunk &, ExpressionState &, Vector &);
 
 void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     for (auto &type : TemporalTypes::AllTypes()) {
@@ -1596,6 +1602,163 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     loader.RegisterFunction(ScalarFunction("||", {LogicalType::VARCHAR, TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_text_ttext));
     loader.RegisterFunction(ScalarFunction("||", {TemporalTypes::TTEXT(), LogicalType::VARCHAR}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_ttext_text));
     loader.RegisterFunction(ScalarFunction("||", {TemporalTypes::TTEXT(), TemporalTypes::TTEXT()}, TemporalTypes::TTEXT(), TemporalFunctions::Textcat_ttext_ttext));
+
+    // timeSplit(temporal, interval, timestamptz) -> LIST<temporal>
+    for (const auto &ttype : {TemporalTypes::TINT(), TemporalTypes::TFLOAT(),
+                              TemporalTypes::TBOOL(), TemporalTypes::TTEXT(),
+                              TgeompointType::TGEOMPOINT(),
+                              TGeometryTypes::TGEOMETRY()}) {
+        loader.RegisterFunction(ScalarFunction("timeSplit",
+            {ttype, LogicalType::INTERVAL, LogicalType::TIMESTAMP_TZ},
+            LogicalType::LIST(ttype),
+            TemporalTimeSplitExec));
+    }
+
+    // valueSplit(tnumber, size, origin) -> LIST<tnumber>
+    loader.RegisterFunction(ScalarFunction("valueSplit",
+        {TemporalTypes::TINT(), LogicalType::INTEGER, LogicalType::INTEGER},
+        LogicalType::LIST(TemporalTypes::TINT()),
+        TnumberValueSplitExec<true>));
+    loader.RegisterFunction(ScalarFunction("valueSplit",
+        {TemporalTypes::TFLOAT(), LogicalType::DOUBLE, LogicalType::DOUBLE},
+        LogicalType::LIST(TemporalTypes::TFLOAT()),
+        TnumberValueSplitExec<false>));
+
+    // quadSplit(stbox) -> LIST<stbox>
+    loader.RegisterFunction(ScalarFunction("quadSplit",
+        {StboxType::STBOX()}, LogicalType::LIST(StboxType::STBOX()),
+        StboxQuadSplitExec));
+}
+
+// LIST<temporal> emitter — shared by the *Split family.
+inline void EmitTemporalList(Vector &result, idx_t row_idx, Temporal **parts,
+                             int count, idx_t &total_offset,
+                             list_entry_t *list_entries, Vector &child_vector,
+                             ValidityMask &result_validity) {
+    if (!parts || count <= 0) {
+        if (parts) free(parts);
+        result_validity.SetInvalid(row_idx);
+        return;
+    }
+    ListVector::SetListSize(result, total_offset + count);
+    list_entries[row_idx] = list_entry_t{total_offset, (uint64_t) count};
+    auto *child_data = FlatVector::GetData<string_t>(child_vector);
+    for (int j = 0; j < count; ++j) {
+        size_t sz = temporal_mem_size(parts[j]);
+        child_data[total_offset + j] = StringVector::AddStringOrBlob(
+            child_vector, reinterpret_cast<const char *>(parts[j]), sz);
+        free(parts[j]);
+    }
+    free(parts);
+    total_offset += count;
+}
+
+void TemporalTimeSplitExec(DataChunk &args, ExpressionState &, Vector &result) {
+    const idx_t row_count = args.size();
+    for (idx_t c = 0; c < args.ColumnCount(); ++c) args.data[c].Flatten(row_count);
+    auto &result_validity = FlatVector::Validity(result);
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &child_vector = ListVector::GetEntry(result);
+    child_vector.SetVectorType(VectorType::FLAT_VECTOR);
+    ListVector::Reserve(result, row_count);
+    idx_t total_offset = 0;
+
+    auto temp_data = FlatVector::GetData<string_t>(args.data[0]);
+    auto iv_data = FlatVector::GetData<interval_t>(args.data[1]);
+    auto torigin_data = FlatVector::GetData<timestamp_tz_t>(args.data[2]);
+    for (idx_t i = 0; i < row_count; ++i) {
+        if (FlatVector::IsNull(args.data[0], i) || FlatVector::IsNull(args.data[1], i) ||
+            FlatVector::IsNull(args.data[2], i)) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        Temporal *t = (Temporal *) malloc(temp_data[i].GetSize());
+        memcpy(t, temp_data[i].GetData(), temp_data[i].GetSize());
+        MeosInterval iv = IntervaltToInterval(iv_data[i]);
+        timestamp_tz_t tor = DuckDBToMeosTimestamp(torigin_data[i]);
+        TimestampTz *time_bins = nullptr;
+        int count = 0;
+        Temporal **parts = temporal_time_split(t, &iv, (TimestampTz) tor.value,
+                                               &time_bins, &count);
+        free(t);
+        if (time_bins) free(time_bins);
+        EmitTemporalList(result, i, parts, count, total_offset, list_entries,
+                         child_vector, result_validity);
+    }
+}
+
+template <bool IS_INT>
+void TnumberValueSplitExec(DataChunk &args, ExpressionState &, Vector &result) {
+    const idx_t row_count = args.size();
+    for (idx_t c = 0; c < args.ColumnCount(); ++c) args.data[c].Flatten(row_count);
+    auto &result_validity = FlatVector::Validity(result);
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &child_vector = ListVector::GetEntry(result);
+    child_vector.SetVectorType(VectorType::FLAT_VECTOR);
+    ListVector::Reserve(result, row_count);
+    idx_t total_offset = 0;
+
+    auto temp_data = FlatVector::GetData<string_t>(args.data[0]);
+    for (idx_t i = 0; i < row_count; ++i) {
+        if (FlatVector::IsNull(args.data[0], i) || FlatVector::IsNull(args.data[1], i) ||
+            FlatVector::IsNull(args.data[2], i)) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        Temporal *t = (Temporal *) malloc(temp_data[i].GetSize());
+        memcpy(t, temp_data[i].GetData(), temp_data[i].GetSize());
+        Datum size_d, origin_d;
+        if (IS_INT) {
+            size_d = Int32GetDatum(FlatVector::GetData<int32_t>(args.data[1])[i]);
+            origin_d = Int32GetDatum(FlatVector::GetData<int32_t>(args.data[2])[i]);
+        } else {
+            size_d = Float8GetDatum(FlatVector::GetData<double>(args.data[1])[i]);
+            origin_d = Float8GetDatum(FlatVector::GetData<double>(args.data[2])[i]);
+        }
+        Datum *bins = nullptr;
+        int count = 0;
+        Temporal **parts = tnumber_value_split(t, size_d, origin_d, &bins, &count);
+        free(t);
+        if (bins) free(bins);
+        EmitTemporalList(result, i, parts, count, total_offset, list_entries,
+                         child_vector, result_validity);
+    }
+}
+
+void StboxQuadSplitExec(DataChunk &args, ExpressionState &, Vector &result) {
+    const idx_t row_count = args.size();
+    args.data[0].Flatten(row_count);
+    auto &result_validity = FlatVector::Validity(result);
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &child_vector = ListVector::GetEntry(result);
+    child_vector.SetVectorType(VectorType::FLAT_VECTOR);
+    ListVector::Reserve(result, row_count);
+    idx_t total_offset = 0;
+    auto box_data = FlatVector::GetData<string_t>(args.data[0]);
+    for (idx_t i = 0; i < row_count; ++i) {
+        if (FlatVector::IsNull(args.data[0], i)) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        STBox box;
+        memcpy(&box, box_data[i].GetData(), sizeof(STBox));
+        int count = 0;
+        STBox *quads = stbox_quad_split(&box, &count);
+        if (!quads || count <= 0) {
+            if (quads) free(quads);
+            result_validity.SetInvalid(i);
+            continue;
+        }
+        ListVector::SetListSize(result, total_offset + count);
+        list_entries[i] = list_entry_t{total_offset, (uint64_t) count};
+        auto *child_data = FlatVector::GetData<string_t>(child_vector);
+        for (int j = 0; j < count; ++j) {
+            child_data[total_offset + j] = StringVector::AddStringOrBlob(
+                child_vector, reinterpret_cast<const char *>(&quads[j]), sizeof(STBox));
+        }
+        free(quads);
+        total_offset += count;
+    }
 }
 
 struct TemporalUnnestBindData : public TableFunctionData {

--- a/test/sql/parity/065_split_complement.test
+++ b/test/sql/parity/065_split_complement.test
@@ -1,0 +1,132 @@
+# name: test/sql/parity/065_split_complement.test
+# description: Split-emitter complement to G/G2 — partition a
+# temporal value (or stbox) along the value / time / space axis
+# and emit the resulting LIST<temporal | stbox>.
+#
+#   timeSplit(temp, interval, ts)        — for all 6 temporal types
+#                                          available on main (tint/tfloat/
+#                                          tbool/ttext/tgeompoint/tgeometry).
+#                                          Wraps temporal_time_split.
+#   valueSplit(tnumber, size, origin)    — for tint and tfloat. Wraps
+#                                          tnumber_value_split.
+#   quadSplit(stbox)                     — splits an stbox into its
+#                                          4 quadrants (2D) or 8
+#                                          octants (3D). Wraps
+#                                          stbox_quad_split.
+#
+# Deferred to a follow-up:
+#   spaceSplit / spaceTimeSplit / valueTimeSplit — these need a
+#   second emission channel for the per-bin side-array (geometry
+#   list / Datum list); the existing single-LIST<temporal> return
+#   shape would drop that information silently.
+#
+# MobilityDB returns these as `SETOF (temporal, bin)`; MobilityDuck's
+# scalar funcs return `LIST<temporal>` — drop the bins (users can
+# compute them via the existing `bins` / `timeBins` / `valueBins`
+# emitters if they need them).
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# timeSplit — temporal partitioning along the time axis.
+# =============================================================================
+
+query I
+SELECT len(timeSplit(
+  '{1@2000-01-01, 5@2000-01-05, 10@2000-01-10}'::tint,
+  INTERVAL '2 days', '2000-01-01'::TIMESTAMPTZ)) > 0;
+----
+true
+
+query I
+SELECT len(timeSplit(
+  '{1.0@2000-01-01, 5.0@2000-01-05}'::tfloat,
+  INTERVAL '2 days', '2000-01-01'::TIMESTAMPTZ)) > 0;
+----
+true
+
+query I
+SELECT len(timeSplit(
+  '{true@2000-01-01, false@2000-01-05}'::tbool,
+  INTERVAL '2 days', '2000-01-01'::TIMESTAMPTZ)) > 0;
+----
+true
+
+query I
+SELECT len(timeSplit(
+  '{"a"@2000-01-01, "b"@2000-01-05}'::ttext,
+  INTERVAL '2 days', '2000-01-01'::TIMESTAMPTZ)) > 0;
+----
+true
+
+query I
+SELECT len(timeSplit(
+  '{Point(0 0)@2000-01-01, Point(5 5)@2000-01-05}'::tgeompoint,
+  INTERVAL '2 days', '2000-01-01'::TIMESTAMPTZ)) > 0;
+----
+true
+
+query I
+SELECT len(timeSplit(
+  '{Point(0 0)@2000-01-01, Point(5 5)@2000-01-05}'::tgeometry,
+  INTERVAL '2 days', '2000-01-01'::TIMESTAMPTZ)) > 0;
+----
+true
+
+# Result element type matches input.
+query I
+SELECT typeof(timeSplit(
+  '{1@2000-01-01, 5@2000-01-05}'::tint,
+  INTERVAL '2 days', '2000-01-01'::TIMESTAMPTZ));
+----
+TINT[]
+
+query I
+SELECT typeof(timeSplit(
+  '{Point(0 0)@2000-01-01, Point(1 1)@2000-01-02}'::tgeompoint,
+  INTERVAL '2 days', '2000-01-01'::TIMESTAMPTZ));
+----
+TGEOMPOINT[]
+
+# =============================================================================
+# valueSplit — partition a tnumber along the value axis.
+# =============================================================================
+
+query I
+SELECT len(valueSplit(
+  '{1@2000-01-01, 5@2000-01-05, 10@2000-01-10}'::tint, 3, 0));
+----
+3
+
+query I
+SELECT len(valueSplit(
+  '{1.0@2000-01-01, 5.0@2000-01-05}'::tfloat, 2.0, 0.0));
+----
+2
+
+query I
+SELECT typeof(valueSplit(
+  '{1@2000-01-01, 5@2000-01-05}'::tint, 3, 0));
+----
+TINT[]
+
+# =============================================================================
+# quadSplit(stbox) — 4 quadrants for 2D, 8 octants for 3D.
+# =============================================================================
+
+query I
+SELECT len(quadSplit('STBOX X((0,0),(4,4))'::stbox));
+----
+4
+
+query I
+SELECT len(quadSplit('STBOX Z((0,0,0),(4,4,4))'::stbox));
+----
+8
+
+# Each quadrant is itself an stbox.
+query I
+SELECT typeof(quadSplit('STBOX X((0,0),(4,4))'::stbox));
+----
+STBOX[]


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDuck/blob/main/doc/contributing/reviewer-guide.md).

## Summary
- `timeSplit(temp, interval, ts)` — temporal partitioning along the time axis for 6 temporal types (tint/tfloat/tbool/ttext/tgeompoint/tgeometry). Wraps `temporal_time_split`.
- `valueSplit(tint|tfloat, size, origin)` — partition a tnumber along the value axis. Wraps `tnumber_value_split`.
- `quadSplit(stbox)` — 4 quadrants in 2D, 8 octants in 3D. Wraps `stbox_quad_split`.
- Adds `EmitTemporalList` helper that takes `Temporal**` + count from MEOS and writes into a `LIST<temporal>` child vector.
- Three split variants deferred (`valueTimeSplit`, `spaceSplit`, `spaceTimeSplit`) because they emit a parallel side-array of bins that a single `LIST<temporal>` return shape would silently drop; users can compose with existing `bins`/`timeBins`/`valueBins` emitters.

## Test plan
- [ ] `065_split_complement.test` passes
- [ ] `len(timeSplit('{1@2000-01-01, 5@2000-01-05}'::tint, '2 days', '2000-01-01'::TIMESTAMPTZ)) > 0`
- [ ] `len(valueSplit('{1@…, 5@…, 10@…}'::tint, 3, 0)) = 3`
- [ ] `len(quadSplit('STBOX X((0,0),(4,4))'::stbox)) = 4`
- [ ] `len(quadSplit('STBOX Z((0,0,0),(4,4,4))'::stbox)) = 8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)