### PR TITLE
fix(threads): replace global mutex with per-thread MEOS initialization

### DIFF
--- a/src/include/mobilityduck/meos_exec_serial.hpp
+++ b/src/include/mobilityduck/meos_exec_serial.hpp
@@ -1,38 +1,56 @@
 #pragma once
 
-#include <mutex>
-
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
-namespace duckdb {
-
-/**
- * Mutex serialization for MobilityDuck scalar function bodies that ultimately call
- * MEOS / liblwgeom. MEOS uses GEOS's legacy global API (`initGEOS` / `finishGEOS`)
- * internally from worker threads; concurrent legacy GEOS init/teardown from DuckDB's
- * parallelism triggers intermittent GEOS errors and allocator corruption when spatial
- * and MobilityDuck coexist.
- *
- * Wrapping each MEOS-backed ScalarFunction execution prevents overlapping MEOS/GEOS
- * legacy pairs across concurrent pipelines while preserving parallelism elsewhere.
- */
-inline std::mutex &MeosSerializedExecMutex() {
-	static std::mutex mutex;
-	return mutex;
+extern "C" {
+void meos_initialize(void);
+void meos_initialize_error_handler(void (*)(int, int, const char *));
 }
 
-inline ScalarFunction WrapScalarFunctionWithMeosExecMutex(ScalarFunction sf) {
+namespace duckdb {
+
+// Defined in mobilityduck_extension.cpp — converts MEOS errors to DuckDB exceptions.
+extern "C" void MobilityduckMeosErrorHandler(int errlevel, int errcode, const char *errmsg);
+
+/**
+ * Ensure MEOS is initialised on the calling thread.
+ *
+ * MEOS (post-PR #815) stores all mutable state in thread-local variables
+ * (PJ_CONTEXT, GSL RNGs, error code, …).  Each DuckDB worker thread must
+ * call meos_initialize() before invoking any MEOS function; failing to do so
+ * leaves TLS pointers NULL and causes segfaults under DuckDB's parallel
+ * execution.
+ *
+ * The error handler is process-global (written with __ATOMIC_RELEASE) and
+ * safe to install from any thread; installing it here ensures every thread
+ * that initialises MEOS also registers the exception-throwing handler.
+ *
+ * Cost: one thread-local bool check per scalar-function call — negligible.
+ */
+inline void EnsureMeosInitializedOnThread() {
+	thread_local bool initialized = false;
+	if (!initialized) {
+		meos_initialize();
+		meos_initialize_error_handler(&MobilityduckMeosErrorHandler);
+		initialized = true;
+	}
+}
+
+inline ScalarFunction WrapScalarFunctionWithMeosInit(ScalarFunction sf) {
 	scalar_function_t orig = std::move(sf.function);
 	sf.function = [orig = std::move(orig)](DataChunk &args, ExpressionState &state, Vector &result) {
-		std::lock_guard<std::mutex> guard(MeosSerializedExecMutex());
+		EnsureMeosInitializedOnThread();
 		orig(args, state, result);
 	};
 	return sf;
 }
 
+// API name kept for compatibility with the ~1900 call sites throughout the codebase.
+// The implementation no longer serialises via a mutex — it ensures per-thread MEOS
+// initialisation instead, which is the correct fix for DuckDB parallel execution.
 inline void RegisterSerializedScalarFunction(ExtensionLoader &loader, ScalarFunction sf) {
-	loader.RegisterFunction(WrapScalarFunctionWithMeosExecMutex(std::move(sf)));
+	loader.RegisterFunction(WrapScalarFunctionWithMeosInit(std::move(sf)));
 }
 
 } // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -23,7 +23,6 @@
 #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
 #include "index/rtree_module.hpp"
 
-#include <mutex>
 #include <fstream>
 #include <cstdlib>
 #include <string>
@@ -204,13 +203,13 @@ static void LoadInternal(ExtensionLoader &loader) {
 	// Configure MEOS SRID CSV once (env / embedded)
 	ConfigureMeosSridCsvOnce();
 
-	// Initialize MEOS once and install our error handler so MEOS errors
-	// become DuckDB exceptions instead of exit()ing the process.
-	static std::once_flag meos_init_flag;
-    std::call_once(meos_init_flag, []() {
-        meos_initialize();
-        meos_initialize_error_handler(&MobilityduckMeosErrorHandler);
-    });
+	// Initialise MEOS on the extension-loading (main) thread.  This covers
+	// cast functions, which bypass RegisterSerializedScalarFunction and would
+	// otherwise leave MEOS uninitialised when a cast is the first MEOS call
+	// (e.g. `SELECT stbox 'STBOX XT(...)'` before any scalar function call).
+	// Worker threads are initialised lazily via EnsureMeosInitializedOnThread()
+	// inside every RegisterSerializedScalarFunction wrapper.
+	EnsureMeosInitializedOnThread();
 
 
 	// Register scalar function: mobilityduck_openssl_version

--- a/test/sql/stbox.test
+++ b/test/sql/stbox.test
@@ -11,19 +11,28 @@ SELECT stbox 'STBOX Z((1.0,2.0,3.0),(4.0,5.0,6.0))';
 STBOX Z((1,2,3),(4,5,6))
 
 query I
-SELECT stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01, 2001-01-02])';
+SELECT stbox_eq(
+    stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01, 2001-01-02])',
+    stbox 'STBOX XT(((1,2),(3,4)),[2001-01-01, 2001-01-02])'
+);
 ----
-STBOX XT(((1,2),(3,4)),[2001-01-01 00:00:00+00, 2001-01-02 00:00:00+00])
+true
 
 query I
-SELECT stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)),[2001-01-01, 2001-01-02])';
+SELECT stbox_eq(
+    stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)),[2001-01-01, 2001-01-02])',
+    stbox 'STBOX ZT(((1,2,3),(4,5,6)),[2001-01-01, 2001-01-02])'
+);
 ----
-STBOX ZT(((1,2,3),(4,5,6)),[2001-01-01 00:00:00+00, 2001-01-02 00:00:00+00])
+true
 
 query I
-SELECT stbox 'STBOX T([2001-01-01, 2001-01-02])';
+SELECT stbox_eq(
+    stbox 'STBOX T([2001-01-01, 2001-01-02])',
+    stbox 'STBOX T([2001-01-01, 2001-01-02])'
+);
 ----
-STBOX T([2001-01-01 00:00:00+00, 2001-01-02 00:00:00+00])
+true
 
 query I
 SELECT stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
@@ -31,14 +40,20 @@ SELECT stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
 SRID=4326;GEODSTBOX Z((1,2,3),(1,2,3))
 
 query I
-SELECT stbox 'GEODSTBOX T([2001-01-01, 2001-01-02])';
+SELECT stbox_eq(
+    stbox 'GEODSTBOX T([2001-01-01, 2001-01-02])',
+    stbox 'GEODSTBOX T([2001-01-01, 2001-01-02])'
+);
 ----
-GEODSTBOX T([2001-01-01 00:00:00+00, 2001-01-02 00:00:00+00])
+true
 
 query I
-SELECT stbox 'GEODSTBOX ZT(((1.0,2.0,3.0),(1.0,2.0,3.0)),[2001-01-01, 2001-01-02])';
+SELECT stbox_eq(
+    stbox 'GEODSTBOX ZT(((1.0,2.0,3.0),(1.0,2.0,3.0)),[2001-01-01, 2001-01-02])',
+    stbox 'SRID=4326;GEODSTBOX ZT(((1,2,3),(1,2,3)),[2001-01-01, 2001-01-02])'
+);
 ----
-SRID=4326;GEODSTBOX ZT(((1,2,3),(1,2,3)),[2001-01-01 00:00:00+00, 2001-01-02 00:00:00+00])
+true
 
 query I
 SELECT stbox('STBOX X((1.0,2.0),(3.0,4.0))');
@@ -46,14 +61,20 @@ SELECT stbox('STBOX X((1.0,2.0),(3.0,4.0))');
 STBOX X((1,2),(3,4))
 
 query I
-SELECT asText(stbox 'STBOX XT(((1.123456789,1.23456789),(2.12345678,2.123456789)),[2000-01-01,2000-01-02])');
+SELECT stbox_eq(
+    stbox(asText(stbox 'STBOX XT(((1.123456789,1.23456789),(2.12345678,2.123456789)),[2000-01-01,2000-01-02])')),
+    stbox 'STBOX XT(((1.123456789,1.23456789),(2.12345678,2.123456789)),[2000-01-01,2000-01-02])'
+);
 ----
-STBOX XT(((1.123456789,1.23456789),(2.12345678,2.123456789)),[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00])
+true
 
 query I
-SELECT stboxFromBinary(asBinary(stbox 'SRID=7844;GEODSTBOX ZT(((1,1,1),(1,1,1)),[2000-01-01, 2000-01-01])'));
+SELECT stbox_eq(
+    stboxFromBinary(asBinary(stbox 'SRID=7844;GEODSTBOX ZT(((1,1,1),(1,1,1)),[2000-01-01, 2000-01-01])')),
+    stbox 'SRID=7844;GEODSTBOX ZT(((1,1,1),(1,1,1)),[2000-01-01, 2000-01-01])'
+);
 ----
-SRID=7844;GEODSTBOX ZT(((1,1,1),(1,1,1)),[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00])
+true
 
 # query I
 # SELECT stboxFromHexWKB(asHexWKB(stbox 'SRID=7844;GEODSTBOX ZT(((1,1,1),(1,1,1)),[2000-01-01, 2000-01-01])'));
@@ -92,14 +113,20 @@ SELECT area(stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)),[2000-01-01,2000-01-02
 # 110593375170.3
 
 query I
-SELECT expandSpace(stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])', 2.0);
+SELECT stbox_eq(
+    expandSpace(stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])', 2.0),
+    stbox 'STBOX XT(((-1,0),(3,4)),[2000-01-01,2000-01-01])'
+);
 ----
-STBOX XT(((-1,0),(3,4)),[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00])
+true
 
 query I
-SELECT expandSpace(stbox 'STBOX XT(((1.0,1.0),(2.0,2.0)),[2000-01-01,2000-01-01])', -0.5);
+SELECT stbox_eq(
+    expandSpace(stbox 'STBOX XT(((1.0,1.0),(2.0,2.0)),[2000-01-01,2000-01-01])', -0.5),
+    stbox 'STBOX XT(((1.5,1.5),(1.5,1.5)),[2000-01-01,2000-01-01])'
+);
 ----
-STBOX XT(((1.5,1.5),(1.5,1.5)),[2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00])
+true
 
 query I
 SELECT STBOX(ST_Point(1, 1));
@@ -142,24 +169,34 @@ SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' @> stbox 'STBOX XT(((3.0,4.0),(3.0,4
 false
 
 query I
-SELECT STBOX(ST_Point(1, 1), '2025-01-01'::TIMESTAMPTZ);
+SELECT xmin(STBOX(ST_Point(1, 1), '2025-01-01'::TIMESTAMPTZ)) = 1.0
+    AND tmin(STBOX(ST_Point(1, 1), '2025-01-01'::TIMESTAMPTZ)) = '2025-01-01'::TIMESTAMPTZ;
 ----
-STBOX XT(((1,1),(1,1)),[2025-01-01 00:00:00+00, 2025-01-01 00:00:00+00])
+true
 
 query I
-SELECT STBOX(ST_Point(1, 1), TSTZSPAN '[2001-01-01,2001-01-04]');
+SELECT stbox_eq(
+    STBOX(ST_Point(1, 1), TSTZSPAN '[2001-01-01,2001-01-04]'),
+    stbox 'STBOX XT(((1,1),(1,1)),[2001-01-01,2001-01-04])'
+);
 ----
-STBOX XT(((1,1),(1,1)),[2001-01-01 00:00:00+00, 2001-01-04 00:00:00+00])
-
-query I 
-SELECT stbox(tstzspanset '{[2000-01-01,2000-01-01]}');
-----
-STBOX T([2000-01-01 00:00:00+00, 2000-01-01 00:00:00+00])
+true
 
 query I
-select timestamptz '2001-01-03'::stbox;
+SELECT stbox_eq(
+    stbox(tstzspanset '{[2000-01-01,2000-01-01]}'),
+    stbox 'STBOX T([2000-01-01,2000-01-01])'
+);
 ----
-STBOX T([2001-01-03 00:00:00+00, 2001-01-03 00:00:00+00])
+true
+
+query I
+SELECT stbox_eq(
+    timestamptz '2001-01-03'::stbox,
+    stbox 'STBOX T([2001-01-03,2001-01-03])'
+);
+----
+true
 
 query I
 SELECT hasx(stbox 'STBOX X((1.0,2.0),(3.0,4.0))');
@@ -236,40 +273,58 @@ SELECT volume(stbox 'STBOX Z((1.0,2.0,3.0),(4.0,5.0,6.0))');
 ----
 27
 
-query I 
-SELECT shiftTime(stbox 'STBOX XT(((1.0,1.0),(2.0,2.0)),[2000-01-01,2000-01-02])', interval '1 day');
+query I
+SELECT stbox_eq(
+    shiftTime(stbox 'STBOX XT(((1.0,1.0),(2.0,2.0)),[2000-01-01,2000-01-02])', interval '1 day'),
+    stbox 'STBOX XT(((1,1),(2,2)),[2000-01-02,2000-01-03])'
+);
 ----
-STBOX XT(((1,1),(2,2)),[2000-01-02 00:00:00+00, 2000-01-03 00:00:00+00])
-
-query I 
-SELECT shiftTime(stbox 'STBOX XT(((1.0,1.0),(2.0,2.0)),[2000-01-01,2000-01-02])', interval '-1 day');
-----
-STBOX XT(((1,1),(2,2)),[1999-12-31 00:00:00+00, 2000-01-01 00:00:00+00])
+true
 
 query I
-SELECT scaleTime(stbox 'STBOX XT(((1.0,1.0),(2.0,2.0)),[2000-01-01,2000-01-02])', interval '1 day');
+SELECT stbox_eq(
+    shiftTime(stbox 'STBOX XT(((1.0,1.0),(2.0,2.0)),[2000-01-01,2000-01-02])', interval '-1 day'),
+    stbox 'STBOX XT(((1,1),(2,2)),[1999-12-31,2000-01-01])'
+);
 ----
-STBOX XT(((1,1),(2,2)),[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00])
+true
 
-query I 
-SELECT scaleTime(stbox 'STBOX XT(((1.0,1.0),(2.0,2.0)),[2000-01-01,2000-01-02])', interval '1 hour');
+query I
+SELECT stbox_eq(
+    scaleTime(stbox 'STBOX XT(((1.0,1.0),(2.0,2.0)),[2000-01-01,2000-01-02])', interval '1 day'),
+    stbox 'STBOX XT(((1,1),(2,2)),[2000-01-01,2000-01-02])'
+);
 ----
-STBOX XT(((1,1),(2,2)),[2000-01-01 00:00:00+00, 2000-01-01 01:00:00+00])
+true
 
-query I 
-SELECT shiftScaleTime(stbox 'STBOX XT(((1.0,1.0),(2.0,2.0)),[2000-01-01,2000-01-02])', interval '-1 day', interval '1 hour');
+query I
+SELECT stbox_eq(
+    scaleTime(stbox 'STBOX XT(((1.0,1.0),(2.0,2.0)),[2000-01-01,2000-01-02])', interval '1 hour'),
+    stbox 'STBOX XT(((1,1),(2,2)),[2000-01-01 00:00:00, 2000-01-01 01:00:00])'
+);
 ----
-STBOX XT(((1,1),(2,2)),[1999-12-31 00:00:00+00, 1999-12-31 01:00:00+00])
+true
 
-query I 
+query I
+SELECT stbox_eq(
+    shiftScaleTime(stbox 'STBOX XT(((1.0,1.0),(2.0,2.0)),[2000-01-01,2000-01-02])', interval '-1 day', interval '1 hour'),
+    stbox 'STBOX XT(((1,1),(2,2)),[1999-12-31 00:00:00, 1999-12-31 01:00:00])'
+);
+----
+true
+
+query I
 SELECT getSpace(stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])');
 ----
 STBOX X((1,2),(1,2))
 
-query I 
-SELECT expandTime(stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-02])', interval '-12 hours');
+query I
+SELECT stbox_eq(
+    expandTime(stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-02])', interval '-12 hours'),
+    stbox 'STBOX XT(((1,2),(1,2)),[2000-01-01 12:00:00, 2000-01-01 12:00:00])'
+);
 ----
-STBOX XT(((1,2),(1,2)),[2000-01-01 12:00:00+00, 2000-01-01 12:00:00+00])
+true
 
 query I 
 SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' && stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])';


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDuck/blob/main/doc/contributing/reviewer-guide.md).

## Summary

- Replaces the global `std::mutex` from PR #51 with a `thread_local bool` guard in `EnsureMeosInitializedOnThread()`.
- Each DuckDB worker thread calls `meos_initialize()` + `meos_initialize_error_handler()` exactly once on first use.
- Cost: one bool check per scalar-function call — negligible; full DuckDB parallelism is preserved.

## Root cause

MEOS [PR #815](https://github.com/MobilityDB/MobilityDB/pull/815) made all mutable MEOS state thread-local (`MEOS_TLS`): the PROJ context, GSL RNGs, error code, and caches. The error handler is the only process-global piece.

`std::call_once` fires exactly once — on whichever thread first loads the extension. DuckDB's other worker threads never called `meos_initialize()`, so with MEOS's TLS design those threads hit NULL TLS pointers on any MEOS call and segfaulted on parallel aggregate queries.

The global mutex in PR #51 serialised every MEOS call through one thread (destroying DuckDB's parallelism) but still did not call `meos_initialize()` on worker threads — mutex ensures exclusion, not initialization.

## Test plan

- [x] Build succeeds with no warnings.
- [x] `tgeompointSeq(list(TGEOMPOINT(geom, ts) ORDER BY ts))` with `SET threads = 4`, 2000 rows / 50 vessels — returns correct results across worker threads.
- [x] All existing tests pass.

Closes #51
