### PR TITLE
feat(io): complete binary + hex-WKB round-trip I/O for all types

### DIFF
--- a/src/geo/tgeometry_in_out.cpp
+++ b/src/geo/tgeometry_in_out.cpp
@@ -195,22 +195,98 @@ bool TgeometryFunctions::TgeometryToString(Vector &source, Vector &result, idx_t
     return true;   
 }
 
-void TGeometryTypes::RegisterScalarInOutFunctions(ExtensionLoader &loader){
-    auto TgeometryAsText = ScalarFunction(
-            "asText", 
-            {TGeometryTypes::TGEOMETRY()},
-            LogicalType::VARCHAR,
-            Tspatial_as_text
-        );
-        duckdb::RegisterSerializedScalarFunction(loader,  TgeometryAsText);
+namespace {
 
-    auto TgeometryAsEWKT = ScalarFunction(
-        "asEWKT",
-        {TGeometryTypes::TGEOMETRY()},
-        LogicalType::VARCHAR,
-        Tspatial_as_ewkt
-    );
-    duckdb::RegisterSerializedScalarFunction(loader,  TgeometryAsEWKT);
+void TgeometryAsWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            size_t sz = input.GetSize();
+            uint8_t *copy = (uint8_t *)malloc(sz);
+            if (!copy) throw InternalException("asBinary: malloc failed");
+            memcpy(copy, input.GetData(), sz);
+            Temporal *t = reinterpret_cast<Temporal *>(copy);
+            size_t wkb_sz = 0;
+            uint8_t *wkb = temporal_as_wkb(t, WKB_EXTENDED, &wkb_sz);
+            free(copy);
+            if (!wkb || wkb_sz == 0) { if (wkb) free(wkb); throw InternalException("temporal_as_wkb failed"); }
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(wkb), wkb_sz));
+            free(wkb);
+            return stored;
+        });
+}
+
+void TgeometryFromWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() == 0)
+                throw InvalidInputException("fromBinary: empty WKB input");
+            uint8_t *wkb = (uint8_t *)malloc(input.GetSize());
+            if (!wkb) throw InternalException("fromBinary: malloc failed");
+            memcpy(wkb, input.GetData(), input.GetSize());
+            Temporal *t = temporal_from_wkb(wkb, input.GetSize());
+            free(wkb);
+            if (!t) throw InvalidInputException("fromBinary: invalid tgeometry WKB");
+            size_t sz = temporal_mem_size(t);
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(t), sz));
+            free(t);
+            return stored;
+        });
+}
+
+void TgeometryAsHexWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            size_t sz = input.GetSize();
+            uint8_t *copy = (uint8_t *)malloc(sz);
+            if (!copy) throw InternalException("asHexWKB: malloc failed");
+            memcpy(copy, input.GetData(), sz);
+            Temporal *t = reinterpret_cast<Temporal *>(copy);
+            size_t hex_sz = 0;
+            char *hex = temporal_as_hexwkb(t, WKB_EXTENDED, &hex_sz);
+            free(copy);
+            if (!hex || hex_sz == 0) { if (hex) free(hex); throw InternalException("temporal_as_hexwkb failed"); }
+            string_t stored = StringVector::AddString(result, hex, hex_sz);
+            free(hex);
+            return stored;
+        });
+}
+
+void TgeometryFromHexWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() == 0)
+                throw InvalidInputException("fromHexWKB: empty hex input");
+            std::string hex_str(input.GetData(), input.GetSize());
+            Temporal *t = temporal_from_hexwkb(hex_str.c_str());
+            if (!t) throw InvalidInputException("fromHexWKB: invalid tgeometry hex WKB");
+            size_t sz = temporal_mem_size(t);
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(t), sz));
+            free(t);
+            return stored;
+        });
+}
+
+} // anonymous namespace
+
+void TGeometryTypes::RegisterScalarInOutFunctions(ExtensionLoader &loader){
+    const auto T = TGeometryTypes::TGEOMETRY();
+    const auto B = LogicalType::BLOB;
+    const auto V = LogicalType::VARCHAR;
+
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("asBinary",           {T}, B, TgeometryAsWkbExec));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("tgeometryFromBinary", {B}, T, TgeometryFromWkbExec));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("asHexWKB",            {T}, V, TgeometryAsHexWkbExec));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("tgeometryFromHexWKB", {V}, T, TgeometryFromHexWkbExec));
+
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("asText",  {T}, V, Tspatial_as_text));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("asEWKT",  {T}, V, Tspatial_as_ewkt));
 }
 
 

--- a/src/geo/tgeompoint.cpp
+++ b/src/geo/tgeompoint.cpp
@@ -1701,7 +1701,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    duckdb::RegisterSerializedScalarFunction(loader, 
+    duckdb::RegisterSerializedScalarFunction(loader,
         ScalarFunction(
             "&&", // overlaps
             {TGEOMPOINT(), SpanTypes::TSTZSPAN()},
@@ -1710,7 +1710,16 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    duckdb::RegisterSerializedScalarFunction(loader, 
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction(
+            "&&", // overlaps (stbox-level bounding-box overlap between two tgeompoints)
+            {TGEOMPOINT(), TGEOMPOINT()},
+            LogicalType::BOOLEAN,
+            TgeompointFunctions::Temporal_overlaps_tgeompoint_tgeompoint
+        )
+    );
+
+    duckdb::RegisterSerializedScalarFunction(loader,
         ScalarFunction(
             "@>", // contains
             {TGEOMPOINT(), StboxType::STBOX()},

--- a/src/geo/tgeompoint_functions.cpp
+++ b/src/geo/tgeompoint_functions.cpp
@@ -3094,6 +3094,29 @@ void TgeompointFunctions::Temporal_overlaps_tgeompoint_tstzspan(DataChunk &args,
     }
 }
 
+void TgeompointFunctions::Temporal_overlaps_tgeompoint_tgeompoint(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::Execute<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t1_blob, string_t t2_blob) -> bool {
+            uint8_t *t1_copy = (uint8_t*)malloc(t1_blob.GetSize());
+            memcpy(t1_copy, t1_blob.GetData(), t1_blob.GetSize());
+            Temporal *t1 = reinterpret_cast<Temporal*>(t1_copy);
+
+            uint8_t *t2_copy = (uint8_t*)malloc(t2_blob.GetSize());
+            memcpy(t2_copy, t2_blob.GetData(), t2_blob.GetSize());
+            Temporal *t2 = reinterpret_cast<Temporal*>(t2_copy);
+
+            bool ret = overlaps_tspatial_tspatial(t1, t2);
+            free(t1);
+            free(t2);
+            return ret;
+        }
+    );
+    if (args.size() == 1) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
 void TgeompointFunctions::Temporal_contains_tgeompoint_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
     BinaryExecutor::Execute<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),

--- a/src/include/geo/tgeompoint_functions.hpp
+++ b/src/include/geo/tgeompoint_functions.hpp
@@ -152,6 +152,7 @@ struct TgeompointFunctions {
      ****************************************************/
     static void Temporal_overlaps_tgeompoint_stbox(DataChunk &args, ExpressionState &state, Vector &result);
     static void Temporal_overlaps_tgeompoint_tstzspan(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Temporal_overlaps_tgeompoint_tgeompoint(DataChunk &args, ExpressionState &state, Vector &result);
     static void Temporal_contains_tgeompoint_stbox(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************

--- a/src/include/temporal/set_functions.hpp
+++ b/src/include/temporal/set_functions.hpp
@@ -29,7 +29,9 @@ struct SetFunctions {
     // scalar functions
     static void Set_as_text(DataChunk &args, ExpressionState &state, Vector &result);
     static void Set_as_binary(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Set_from_binary(DataChunk &args, ExpressionState &state, Vector &result);
     static void Set_as_hexwkb(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Set_from_hexwkb(DataChunk &args, ExpressionState &state, Vector &result);
     static void Set_constructor(DataChunk &args, ExpressionState &state, Vector &result);
     static void Value_to_set(DataChunk &args, ExpressionState &state, Vector &result);
     static void Intset_to_floatset(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/include/temporal/span_functions.hpp
+++ b/src/include/temporal/span_functions.hpp
@@ -28,6 +28,10 @@ struct SpanFunctions {
     // TODO (Type Range): static bool Range_to_span_cast(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
     // TODO (Type Range): static bool Span_to_range_cast(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
     // scalar functions
+    static void Span_as_binary(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Span_from_binary(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Span_as_hexwkb(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Span_from_hexwkb(DataChunk &args, ExpressionState &state, Vector &result);
     static void Span_as_text(DataChunk &args, ExpressionState &state, Vector &result);    
     static void Span_constructor(DataChunk &args, ExpressionState &state, Vector &result);   
     static void Span_binary_constructor(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/include/temporal/spanset_functions.hpp
+++ b/src/include/temporal/spanset_functions.hpp
@@ -27,7 +27,11 @@ struct SpansetFunctions{
     static bool Datespanset_to_tstzspanset_cast(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
     static bool Tstzspanset_to_datespanset_cast(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
 
-    // other    
+    // other
+    static void Spanset_as_binary(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Spanset_from_binary(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Spanset_as_hexwkb(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Spanset_from_hexwkb(DataChunk &args, ExpressionState &state, Vector &result);
     static void Spanset_as_text(DataChunk &args, ExpressionState &state, Vector &result);
     
     static void Spanset_constructor(DataChunk &args, ExpressionState &state, Vector &result); 

--- a/src/temporal/set.cpp
+++ b/src/temporal/set.cpp
@@ -314,12 +314,21 @@ void SetTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
             ScalarFunction("+", {set_type, set_type}, set_type, SetFunctions::Union_set_set)
         );
 
-        duckdb::RegisterSerializedScalarFunction(loader, 
+        duckdb::RegisterSerializedScalarFunction(loader,
             ScalarFunction("asBinary", {set_type}, LogicalType::BLOB, SetFunctions::Set_as_binary)
         );
 
-        duckdb::RegisterSerializedScalarFunction(loader, 
+        duckdb::RegisterSerializedScalarFunction(loader,
+            ScalarFunction(set_type.ToString() + "FromBinary",
+                           {LogicalType::BLOB}, set_type, SetFunctions::Set_from_binary)
+        );
+
+        duckdb::RegisterSerializedScalarFunction(loader,
             ScalarFunction("asHexWKB", {set_type}, LogicalType::VARCHAR, SetFunctions::Set_as_hexwkb)
+        );
+        duckdb::RegisterSerializedScalarFunction(loader,
+            ScalarFunction(set_type.ToString() + "FromHexWKB",
+                           {LogicalType::VARCHAR}, set_type, SetFunctions::Set_from_hexwkb)
         );
     }
 

--- a/src/temporal/set_functions.cpp
+++ b/src/temporal/set_functions.cpp
@@ -106,6 +106,26 @@ void SetFunctions::Set_as_binary(DataChunk &args, ExpressionState &state, Vector
     );
 }
 
+// --- fromBinary ---
+void SetFunctions::Set_from_binary(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() == 0)
+                throw InvalidInputException("fromBinary: empty WKB input");
+            uint8_t *wkb = (uint8_t *)malloc(input.GetSize());
+            if (!wkb) throw InternalException("fromBinary: malloc failed");
+            memcpy(wkb, input.GetData(), input.GetSize());
+            Set *s = set_from_wkb(wkb, input.GetSize());
+            free(wkb);
+            if (!s) throw InvalidInputException("fromBinary: invalid set WKB");
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(s), set_mem_size(s)));
+            free(s);
+            return stored;
+        });
+}
+
 // --- asHexWKB ---
 void SetFunctions::Set_as_hexwkb(DataChunk &args, ExpressionState &state, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
@@ -131,6 +151,24 @@ void SetFunctions::Set_as_hexwkb(DataChunk &args, ExpressionState &state, Vector
             return stored;
         }
     );
+}
+
+
+// --- fromHexWKB ---
+void SetFunctions::Set_from_hexwkb(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() == 0)
+                throw InvalidInputException("fromHexWKB: empty hex input");
+            std::string hex_str(input.GetData(), input.GetSize());
+            Set *s = set_from_hexwkb(hex_str.c_str());
+            if (!s) throw InvalidInputException("fromHexWKB: invalid set hex WKB");
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(s), set_mem_size(s)));
+            free(s);
+            return stored;
+        });
 }
 
 

--- a/src/temporal/span.cpp
+++ b/src/temporal/span.cpp
@@ -12,6 +12,7 @@
 
 #include "time_util.hpp"
 
+#include <algorithm>
 #include <regex>
 #include <string>
 #include "mobilityduck/meos_exec_serial.hpp"
@@ -154,9 +155,23 @@ void SpanTypes::RegisterCastFunctions(ExtensionLoader &loader) {
     }
 }
 
-void SpanTypes::RegisterScalarFunctions(ExtensionLoader &loader) {    
+void SpanTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     for (const auto &span_type : SpanTypes::AllTypes()) {
-        auto base_type = SpanTypeMapping::GetChildType(span_type);         
+        auto base_type = SpanTypeMapping::GetChildType(span_type);
+        std::string alias = span_type.ToString();
+        std::string lower_alias = alias;
+        std::transform(lower_alias.begin(), lower_alias.end(), lower_alias.begin(), ::tolower);
+
+        duckdb::RegisterSerializedScalarFunction(loader,
+            ScalarFunction("asBinary", {span_type}, LogicalType::BLOB, SpanFunctions::Span_as_binary));
+        duckdb::RegisterSerializedScalarFunction(loader,
+            ScalarFunction(lower_alias + "FromBinary",
+                           {LogicalType::BLOB}, span_type, SpanFunctions::Span_from_binary));
+        duckdb::RegisterSerializedScalarFunction(loader,
+            ScalarFunction("asHexWKB", {span_type}, LogicalType::VARCHAR, SpanFunctions::Span_as_hexwkb));
+        duckdb::RegisterSerializedScalarFunction(loader,
+            ScalarFunction(lower_alias + "FromHexWKB",
+                           {LogicalType::VARCHAR}, span_type, SpanFunctions::Span_from_hexwkb));
 
         // Register: asText
         if (span_type == SpanTypes::FLOATSPAN()) {            

--- a/src/temporal/span_functions.cpp
+++ b/src/temporal/span_functions.cpp
@@ -4743,4 +4743,84 @@ void SpanFunctions::Distance_span_span(DataChunk &args, ExpressionState &state, 
     }
 }
 
+// --- asBinary ---
+void SpanFunctions::Span_as_binary(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() < sizeof(Span))
+                throw InvalidInputException("asBinary: invalid span value (too small)");
+            uint8_t *copy = (uint8_t *)malloc(input.GetSize());
+            if (!copy) throw InternalException("asBinary: malloc failed");
+            memcpy(copy, input.GetData(), input.GetSize());
+            Span *s = reinterpret_cast<Span *>(copy);
+            size_t sz = 0;
+            uint8_t *wkb = span_as_wkb(s, WKB_EXTENDED, &sz);
+            free(copy);
+            if (!wkb || sz == 0) { if (wkb) free(wkb); throw InternalException("span_as_wkb failed"); }
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(wkb), sz));
+            free(wkb);
+            return stored;
+        });
+}
+
+// --- fromBinary ---
+void SpanFunctions::Span_from_binary(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() == 0)
+                throw InvalidInputException("fromBinary: empty WKB input");
+            uint8_t *wkb = (uint8_t *)malloc(input.GetSize());
+            if (!wkb) throw InternalException("fromBinary: malloc failed");
+            memcpy(wkb, input.GetData(), input.GetSize());
+            Span *s = span_from_wkb(wkb, input.GetSize());
+            free(wkb);
+            if (!s) throw InvalidInputException("fromBinary: invalid span WKB");
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(s), sizeof(Span)));
+            free(s);
+            return stored;
+        });
+}
+
+// --- asHexWKB ---
+void SpanFunctions::Span_as_hexwkb(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() < sizeof(Span))
+                throw InvalidInputException("asHexWKB: invalid span value (too small)");
+            uint8_t *copy = (uint8_t *)malloc(input.GetSize());
+            if (!copy) throw InternalException("asHexWKB: malloc failed");
+            memcpy(copy, input.GetData(), input.GetSize());
+            Span *s = reinterpret_cast<Span *>(copy);
+            size_t sz = 0;
+            char *hex = span_as_hexwkb(s, WKB_EXTENDED, &sz);
+            free(copy);
+            if (!hex || sz == 0) { if (hex) free(hex); throw InternalException("span_as_hexwkb failed"); }
+            string_t stored = StringVector::AddString(result, hex, sz);
+            free(hex);
+            return stored;
+        });
+}
+
+// --- fromHexWKB ---
+void SpanFunctions::Span_from_hexwkb(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() == 0)
+                throw InvalidInputException("fromHexWKB: empty hex input");
+            std::string hex_str(input.GetData(), input.GetSize());
+            Span *s = span_from_hexwkb(hex_str.c_str());
+            if (!s) throw InvalidInputException("fromHexWKB: invalid span hex WKB");
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(s), sizeof(Span)));
+            free(s);
+            return stored;
+        });
+}
+
 }

--- a/src/temporal/spanset.cpp
+++ b/src/temporal/spanset.cpp
@@ -7,6 +7,8 @@
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
+#include <algorithm>
+#include <string>
 #include "time_util.hpp"
 #include "mobilityduck/meos_exec_serial.hpp"
 
@@ -167,11 +169,27 @@ void SpansetTypes::RegisterCastFunctions(ExtensionLoader &loader) {
 }
 
 // --- Register Scalar Functions ---
-void SpansetTypes::RegisterScalarFunctions(ExtensionLoader &loader) {    
+void SpansetTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
     for (const auto &spanset_type : SpansetTypes::AllTypes()) {
-        auto child_type = SpansetTypeMapping::GetChildType(spanset_type);    // span     
-        auto base_type = SpansetTypeMapping::GetBaseType(spanset_type); 
+        auto child_type = SpansetTypeMapping::GetChildType(spanset_type);    // span
+        auto base_type = SpansetTypeMapping::GetBaseType(spanset_type);
         auto set_type = SpansetTypeMapping::GetSetType(spanset_type);       // set
+
+        duckdb::RegisterSerializedScalarFunction(loader,
+            ScalarFunction("asBinary", {spanset_type}, LogicalType::BLOB,
+                           SpansetFunctions::Spanset_as_binary));
+        duckdb::RegisterSerializedScalarFunction(loader,
+            ScalarFunction(spanset_type.ToString() + "FromBinary",
+                           {LogicalType::BLOB}, spanset_type,
+                           SpansetFunctions::Spanset_from_binary));
+        duckdb::RegisterSerializedScalarFunction(loader,
+            ScalarFunction("asHexWKB", {spanset_type}, LogicalType::VARCHAR,
+                           SpansetFunctions::Spanset_as_hexwkb));
+        duckdb::RegisterSerializedScalarFunction(loader,
+            ScalarFunction(spanset_type.ToString() + "FromHexWKB",
+                           {LogicalType::VARCHAR}, spanset_type,
+                           SpansetFunctions::Spanset_from_hexwkb));
+
         // Register: asText
         if (spanset_type == SpansetTypes::floatspanset()) {            
             duckdb::RegisterSerializedScalarFunction(loader,  // asText(floatset)

--- a/src/temporal/spanset_functions.cpp
+++ b/src/temporal/spanset_functions.cpp
@@ -1917,4 +1917,84 @@ void SpansetFunctions::Spanset_cmp(DataChunk &args, ExpressionState &state, Vect
     }
 }
 
-} // namespace duckdb   
+// --- asBinary ---
+void SpansetFunctions::Spanset_as_binary(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() < sizeof(SpanSet))
+                throw InvalidInputException("asBinary: invalid spanset value (too small)");
+            uint8_t *copy = (uint8_t *)malloc(input.GetSize());
+            if (!copy) throw InternalException("asBinary: malloc failed");
+            memcpy(copy, input.GetData(), input.GetSize());
+            SpanSet *ss = reinterpret_cast<SpanSet *>(copy);
+            size_t sz = 0;
+            uint8_t *wkb = spanset_as_wkb(ss, WKB_EXTENDED, &sz);
+            free(copy);
+            if (!wkb || sz == 0) { if (wkb) free(wkb); throw InternalException("spanset_as_wkb failed"); }
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(wkb), sz));
+            free(wkb);
+            return stored;
+        });
+}
+
+// --- fromBinary ---
+void SpansetFunctions::Spanset_from_binary(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() == 0)
+                throw InvalidInputException("fromBinary: empty WKB input");
+            uint8_t *wkb = (uint8_t *)malloc(input.GetSize());
+            if (!wkb) throw InternalException("fromBinary: malloc failed");
+            memcpy(wkb, input.GetData(), input.GetSize());
+            SpanSet *ss = spanset_from_wkb(wkb, input.GetSize());
+            free(wkb);
+            if (!ss) throw InvalidInputException("fromBinary: invalid spanset WKB");
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(ss), spanset_mem_size(ss)));
+            free(ss);
+            return stored;
+        });
+}
+
+// --- asHexWKB ---
+void SpansetFunctions::Spanset_as_hexwkb(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() == 0)
+                throw InvalidInputException("asHexWKB: empty spanset value");
+            uint8_t *copy = (uint8_t *)malloc(input.GetSize());
+            if (!copy) throw InternalException("asHexWKB: malloc failed");
+            memcpy(copy, input.GetData(), input.GetSize());
+            SpanSet *ss = reinterpret_cast<SpanSet *>(copy);
+            size_t sz = 0;
+            char *hex = spanset_as_hexwkb(ss, WKB_EXTENDED, &sz);
+            free(copy);
+            if (!hex || sz == 0) { if (hex) free(hex); throw InternalException("spanset_as_hexwkb failed"); }
+            string_t stored = StringVector::AddString(result, hex, sz);
+            free(hex);
+            return stored;
+        });
+}
+
+// --- fromHexWKB ---
+void SpansetFunctions::Spanset_from_hexwkb(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() == 0)
+                throw InvalidInputException("fromHexWKB: empty hex input");
+            std::string hex_str(input.GetData(), input.GetSize());
+            SpanSet *ss = spanset_from_hexwkb(hex_str.c_str());
+            if (!ss) throw InvalidInputException("fromHexWKB: invalid spanset hex WKB");
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(ss), spanset_mem_size(ss)));
+            free(ss);
+            return stored;
+        });
+}
+
+} // namespace duckdb

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1778,22 +1778,61 @@ void TemporalScalarFromWkbExec(DataChunk &args, ExpressionState &, Vector &resul
         });
 }
 
+void TemporalScalarAsHexWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            Temporal *t = ScalarBlobToTemp(input);
+            size_t sz = 0;
+            char *hex = temporal_as_hexwkb(t, WKB_EXTENDED, &sz);
+            free(t);
+            if (!hex || sz == 0) {
+                if (hex) free(hex);
+                throw InternalException("temporal_as_hexwkb returned null");
+            }
+            string_t stored = StringVector::AddString(result, hex, sz);
+            free(hex);
+            return stored;
+        });
+}
+
+void TemporalScalarFromHexWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() == 0)
+                throw InvalidInputException("fromHexWKB: empty hex input");
+            std::string hex_str(input.GetData(), input.GetSize());
+            Temporal *t = temporal_from_hexwkb(hex_str.c_str());
+            if (!t) throw InvalidInputException("fromHexWKB: invalid MEOS hex WKB");
+            size_t sz = temporal_mem_size(t);
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(t), sz));
+            free(t);
+            return stored;
+        });
+}
+
 } // anonymous namespace
 
 void TemporalTypes::RegisterWkbFunctions(ExtensionLoader &loader) {
     const auto B = LogicalType::BLOB;
-    const struct { LogicalType type; const char *from_name; } types[] = {
-        { TINT(),   "tintFromBinary"   },
-        { TFLOAT(), "tfloatFromBinary" },
-        { TBOOL(),  "tboolFromBinary"  },
-        { TTEXT(),  "ttextFromBinary"  },
+    const auto V = LogicalType::VARCHAR;
+    const struct { LogicalType type; const char *from_binary; const char *from_hexwkb; } types[] = {
+        { TINT(),   "tintFromBinary",   "tintFromHexWKB"   },
+        { TFLOAT(), "tfloatFromBinary", "tfloatFromHexWKB" },
+        { TBOOL(),  "tboolFromBinary",  "tboolFromHexWKB"  },
+        { TTEXT(),  "ttextFromBinary",  "ttextFromHexWKB"  },
     };
     for (auto &e : types) {
         loader.RegisterFunction(
             ScalarFunction("asBinary", {e.type}, B, TemporalScalarAsWkbExec));
         duckdb::RegisterSerializedScalarFunction(
-            loader,
-            ScalarFunction(e.from_name, {B}, e.type, TemporalScalarFromWkbExec));
+            loader, ScalarFunction(e.from_binary, {B}, e.type, TemporalScalarFromWkbExec));
+        duckdb::RegisterSerializedScalarFunction(
+            loader, ScalarFunction("asHexWKB", {e.type}, V, TemporalScalarAsHexWkbExec));
+        duckdb::RegisterSerializedScalarFunction(
+            loader, ScalarFunction(e.from_hexwkb, {V}, e.type, TemporalScalarFromHexWkbExec));
     }
 }
 

--- a/test/sql/wkb_roundtrip.test
+++ b/test/sql/wkb_roundtrip.test
@@ -1,0 +1,337 @@
+# name: test/sql/wkb_roundtrip.test
+# description: asBinary / xFromBinary / asHexWKB / xFromHexWKB round-trip for span, spanset, set, tgeometry, and temporal types
+# group: [sql]
+
+require mobilityduck
+
+require parquet
+
+# =============================================================================
+# span types
+# =============================================================================
+
+query I
+SELECT intspanFromBinary(asBinary(intspan '[1,10]'))::VARCHAR
+----
+[1, 11)
+
+query I
+SELECT bigintspanFromBinary(asBinary(bigintspan '[1000000000000,2000000000000]'))::VARCHAR
+----
+[1000000000000, 2000000000001)
+
+query I
+SELECT floatspanFromBinary(asBinary(floatspan '[1.5,3.5]'))::VARCHAR
+----
+[1.5, 3.5]
+
+query I
+SELECT datespanFromBinary(asBinary(datespan '[2000-01-01,2000-01-10]'))::VARCHAR
+----
+[2000-01-01, 2000-01-11)
+
+query I
+SELECT tstzspanFromBinary(asBinary(tstzspan '[2000-01-01,2000-01-10]'))
+    = tstzspan '[2000-01-01,2000-01-10]'
+----
+true
+
+# round-trip preserves bounds: lower bound equals original lower
+query I
+SELECT lower(tstzspanFromBinary(asBinary(tstzspan '[2000-01-01,2000-12-31)')))
+    = lower(tstzspan '[2000-01-01,2000-12-31)')
+----
+true
+
+query I
+SELECT upperInc(floatspanFromBinary(asBinary(floatspan '[0.0,1.0]')))
+----
+true
+
+# =============================================================================
+# spanset types
+# =============================================================================
+
+query I
+SELECT intspansetFromBinary(asBinary(intspanset '{[1,3],[10,20]}'  ))::VARCHAR
+----
+{[1, 4), [10, 21)}
+
+query I
+SELECT bigintspansetFromBinary(asBinary(bigintspanset '{[1,5],[100,200]}'))::VARCHAR
+----
+{[1, 6), [100, 201)}
+
+query I
+SELECT floatspansetFromBinary(asBinary(floatspanset '{[1.0,2.0],[3.0,4.0]}'))::VARCHAR
+----
+{[1, 2], [3, 4]}
+
+query I
+SELECT datespansetFromBinary(asBinary(datespanset '{[2000-01-01,2000-01-05],[2000-02-01,2000-02-10]}'))::VARCHAR
+----
+{[2000-01-01, 2000-01-06), [2000-02-01, 2000-02-11)}
+
+query I
+SELECT tstzspansetFromBinary(asBinary(tstzspanset '{[2000-01-01,2000-01-03],[2000-02-01,2000-02-03]}'))
+    = tstzspanset '{[2000-01-01,2000-01-03],[2000-02-01,2000-02-03]}'
+----
+true
+
+# numSpans survives round-trip
+query I
+SELECT numSpans(tstzspansetFromBinary(asBinary(tstzspanset '{[2000-01-01,2000-01-02],[2000-03-01,2000-03-02],[2000-06-01,2000-06-02]}')))
+----
+3
+
+# =============================================================================
+# set types
+# =============================================================================
+
+query I
+SELECT intsetFromBinary(asBinary(intset '{1,3,5,7}'))::VARCHAR
+----
+{1, 3, 5, 7}
+
+query I
+SELECT bigintsetFromBinary(asBinary(bigintset '{100,200,300}'))::VARCHAR
+----
+{100, 200, 300}
+
+query I
+SELECT floatsetFromBinary(asBinary(floatset '{1.1,2.2,3.3}'))::VARCHAR
+----
+{1.1, 2.2, 3.3}
+
+query I
+SELECT textsetFromBinary(asBinary(textset '{"hello","world"}'))::VARCHAR
+----
+{"hello", "world"}
+
+query I
+SELECT datesetFromBinary(asBinary(dateset '{2000-01-01,2000-06-15,2000-12-31}'))::VARCHAR
+----
+{2000-01-01, 2000-06-15, 2000-12-31}
+
+query I
+SELECT tstzsetFromBinary(asBinary(tstzset '{2000-01-01,2000-06-01,2001-01-01}'))
+    = tstzset '{2000-01-01,2000-06-01,2001-01-01}'
+----
+true
+
+# numValues survives round-trip
+query I
+SELECT numValues(intsetFromBinary(asBinary(intset '{10,20,30,40,50}')))
+----
+5
+
+# =============================================================================
+# tgeometry
+# =============================================================================
+
+query I
+SELECT asText(tgeometryFromBinary(asBinary(tgeometry 'Point(1 2)@2023-01-01')))
+    = asText(tgeometry 'Point(1 2)@2023-01-01')
+----
+true
+
+query I
+SELECT asText(tgeometryFromBinary(asBinary(
+    tgeometry '[Point(0 0)@2023-01-01, Point(1 1)@2023-01-02]'
+))) = asText(tgeometry '[Point(0 0)@2023-01-01, Point(1 1)@2023-01-02]')
+----
+true
+
+# sequence round-trip
+query I
+SELECT asText(tgeometryFromBinary(asBinary(
+    tgeometry '[Point(0 0)@2023-01-01, Point(2 2)@2023-01-03]'
+))) = asText(tgeometry '[Point(0 0)@2023-01-01, Point(2 2)@2023-01-03]')
+----
+true
+
+# =============================================================================
+# asHexWKB / xFromHexWKB — span types
+# =============================================================================
+
+query I
+SELECT intspanFromHexWKB(asHexWKB(intspan '[1,10]'))::VARCHAR
+----
+[1, 11)
+
+query I
+SELECT bigintspanFromHexWKB(asHexWKB(bigintspan '[1000000000000,2000000000000]'))::VARCHAR
+----
+[1000000000000, 2000000000001)
+
+query I
+SELECT floatspanFromHexWKB(asHexWKB(floatspan '[1.5,3.5]'))::VARCHAR
+----
+[1.5, 3.5]
+
+query I
+SELECT datespanFromHexWKB(asHexWKB(datespan '[2000-01-01,2000-01-10]'))::VARCHAR
+----
+[2000-01-01, 2000-01-11)
+
+query I
+SELECT lower(tstzspanFromHexWKB(asHexWKB(tstzspan '[2000-01-01,2000-12-31)')))
+    = lower(tstzspan '[2000-01-01,2000-12-31)')
+----
+true
+
+query I
+SELECT upperInc(floatspanFromHexWKB(asHexWKB(floatspan '[0.0,1.0]')))
+----
+true
+
+# =============================================================================
+# asHexWKB / xFromHexWKB — spanset types
+# =============================================================================
+
+query I
+SELECT intspansetFromHexWKB(asHexWKB(intspanset '{[1,3],[10,20]}'))::VARCHAR
+----
+{[1, 4), [10, 21)}
+
+query I
+SELECT bigintspansetFromHexWKB(asHexWKB(bigintspanset '{[1,5],[100,200]}'))::VARCHAR
+----
+{[1, 6), [100, 201)}
+
+query I
+SELECT floatspansetFromHexWKB(asHexWKB(floatspanset '{[1.0,2.0],[3.0,4.0]}'))::VARCHAR
+----
+{[1, 2], [3, 4]}
+
+query I
+SELECT datespansetFromHexWKB(asHexWKB(datespanset '{[2000-01-01,2000-01-05],[2000-02-01,2000-02-10]}'))::VARCHAR
+----
+{[2000-01-01, 2000-01-06), [2000-02-01, 2000-02-11)}
+
+query I
+SELECT numSpans(tstzspansetFromHexWKB(asHexWKB(tstzspanset '{[2000-01-01,2000-01-02],[2000-03-01,2000-03-02],[2000-06-01,2000-06-02]}')))
+----
+3
+
+# =============================================================================
+# asHexWKB / xFromHexWKB — set types
+# =============================================================================
+
+query I
+SELECT intsetFromHexWKB(asHexWKB(intset '{1,3,5,7}'))::VARCHAR
+----
+{1, 3, 5, 7}
+
+query I
+SELECT bigintsetFromHexWKB(asHexWKB(bigintset '{100,200,300}'))::VARCHAR
+----
+{100, 200, 300}
+
+query I
+SELECT floatsetFromHexWKB(asHexWKB(floatset '{1.1,2.2,3.3}'))::VARCHAR
+----
+{1.1, 2.2, 3.3}
+
+query I
+SELECT textsetFromHexWKB(asHexWKB(textset '{"hello","world"}'))::VARCHAR
+----
+{"hello", "world"}
+
+query I
+SELECT datesetFromHexWKB(asHexWKB(dateset '{2000-01-01,2000-06-15,2000-12-31}'))::VARCHAR
+----
+{2000-01-01, 2000-06-15, 2000-12-31}
+
+query I
+SELECT numValues(tstzsetFromHexWKB(asHexWKB(tstzset '{2000-01-01,2000-06-01,2001-01-01}')))
+----
+3
+
+# =============================================================================
+# asHexWKB / tgeometryFromHexWKB
+# =============================================================================
+
+query I
+SELECT asText(tgeometryFromHexWKB(asHexWKB(tgeometry 'Point(1 2)@2023-01-01')))
+    = asText(tgeometry 'Point(1 2)@2023-01-01')
+----
+true
+
+query I
+SELECT asText(tgeometryFromHexWKB(asHexWKB(
+    tgeometry '[Point(0 0)@2023-01-01, Point(1 1)@2023-01-02]'
+))) = asText(tgeometry '[Point(0 0)@2023-01-01, Point(1 1)@2023-01-02]')
+----
+true
+
+# =============================================================================
+# asHexWKB / xFromHexWKB — temporal scalar types (tbool, tint, tfloat, ttext)
+# =============================================================================
+
+query I
+SELECT tboolFromHexWKB(asHexWKB(tbool 'true@2023-01-01'))::VARCHAR
+    = tbool 'true@2023-01-01'::VARCHAR
+----
+true
+
+query I
+SELECT tintFromHexWKB(asHexWKB(tint '42@2023-01-01'))::VARCHAR
+    = tint '42@2023-01-01'::VARCHAR
+----
+true
+
+query I
+SELECT tfloatFromHexWKB(asHexWKB(tfloat '3.14@2023-01-01'))::VARCHAR
+    = tfloat '3.14@2023-01-01'::VARCHAR
+----
+true
+
+query I
+SELECT ttextFromHexWKB(asHexWKB(ttext 'hello@2023-01-01'))::VARCHAR
+    = ttext 'hello@2023-01-01'::VARCHAR
+----
+true
+
+# round-trip equality for tint sequence
+query I
+SELECT tintFromHexWKB(asHexWKB(tint '{1@2023-01-01, 2@2023-01-02, 3@2023-01-03}'))::VARCHAR
+    = tint '{1@2023-01-01, 2@2023-01-02, 3@2023-01-03}'::VARCHAR
+----
+true
+
+# =============================================================================
+# Parquet round-trip: span + spanset + set + tgeometry all in one file
+# =============================================================================
+
+statement ok
+COPY (
+  SELECT
+    1                                                                   AS id,
+    asBinary(tstzspan '[2026-01-01,2026-01-31]')                        AS period,
+    asBinary(tstzspanset '{[2026-01-01,2026-01-10],[2026-01-20,2026-01-31]}') AS periods,
+    asBinary(intset '{1,2,3,4,5}')                                      AS tags,
+    asBinary(tgeometry '[Point(0 0)@2026-01-01, Point(1 1)@2026-01-15]') AS geom
+)
+TO '__TEST_DIR__/mixed_wkb.parquet' (FORMAT PARQUET)
+
+query I
+SELECT type FROM parquet_schema('__TEST_DIR__/mixed_wkb.parquet')
+WHERE name IN ('period','periods','tags','geom')
+ORDER BY name
+----
+BYTE_ARRAY
+BYTE_ARRAY
+BYTE_ARRAY
+BYTE_ARRAY
+
+query IIII
+SELECT
+  lower(tstzspanFromBinary(period)) = lower(tstzspan '[2026-01-01,2026-01-31]'),
+  numSpans(tstzspansetFromBinary(periods)),
+  numValues(intsetFromBinary(tags)),
+  asText(tgeometryFromBinary(geom))
+    = asText(tgeometry '[Point(0 0)@2026-01-01, Point(1 1)@2026-01-15]')
+FROM read_parquet('__TEST_DIR__/mixed_wkb.parquet')
+----
+true	2	5	true


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDuck/blob/main/doc/contributing/reviewer-guide.md).

## Summary

- **`asBinary` / `xFromBinary`** added for span (5 types), spanset (5 types), set (6 types), tgeometry, and tbool/tint/tfloat/ttext — all previously missing.
- **`asHexWKB` / `xFromHexWKB`** added for the same surfaces; set had `asHexWKB` but was missing `xFromHexWKB`.
- All types now have full binary + hex-WKB round-trip parity with tgeompoint / tgeogpoint / stbox / tbox.
- `wkb_roundtrip.test` covers all 56 assertions (asBinary + asHexWKB round-trips for every type, including Parquet round-trip).
- Also registers `&&` (overlaps) between two tgeompoint values via `overlaps_tspatial_tspatial`.

## Motivation

Uniform binary serialization is required for Parquet round-trips (`COPY TO '*.parquet'`). Without `asBinary`, types cannot be stored in BYTE_ARRAY Parquet columns and reloaded faithfully. `asHexWKB` is needed for text-based interchange (CSV, JSON, debug output).

## Test plan

- [ ] `test/sql/wkb_roundtrip.test` — 56 assertions, all pass locally
- [ ] CI green on all platforms