### PR TITLE
fix: sync MEOS API drift (meosType→MeosType + spatial-rel arg drop)

### DIFF
--- a/src/geo/tgeompoint_functions.cpp
+++ b/src/geo/tgeompoint_functions.cpp
@@ -454,7 +454,7 @@ void TgeompointFunctions::Tgeompoint_sequence_constructor(DataChunk &args, Expre
     
     auto arg_count = args.ColumnCount();
     auto row_count = args.size();
-    meosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
+    MeosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
     interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
     bool lower_inc = true;
     bool upper_inc = true;
@@ -2438,7 +2438,17 @@ void TgeompointFunctions::Tcontains_geo_tgeo(DataChunk &args, ExpressionState &s
             throw InvalidInputException("Invalid TGEOMPOINT data: null pointer");
         }
 
-        Temporal *ret = tcontains_geo_tgeo(gs, tgeom, restr, at_value);
+        Temporal *ret = tcontains_geo_tgeo(gs, tgeom);
+
+        if (ret && restr) {
+
+            Temporal *restricted = temporal_restrict_value(ret, (Datum)at_value, true);
+
+            free(ret);
+
+            ret = restricted;
+
+        }
         free(tgeom);
         free(gs);
         if (!ret) {
@@ -2500,7 +2510,17 @@ void TgeompointFunctions::Tdisjoint_geo_tgeo(DataChunk &args, ExpressionState &s
                 throw InvalidInputException("Invalid TGEOMPOINT data: null pointer");
             }
 
-            Temporal *ret = tdisjoint_geo_tgeo(gs, tgeom, restr, at_value);
+            Temporal *ret = tdisjoint_geo_tgeo(gs, tgeom);
+
+            if (ret && restr) {
+
+                Temporal *restricted = temporal_restrict_value(ret, (Datum)at_value, true);
+
+                free(ret);
+
+                ret = restricted;
+
+            }
             free(tgeom);
             free(gs);
             if (!ret) {
@@ -2545,7 +2565,17 @@ void TgeompointFunctions::Tdisjoint_tgeo_geo(DataChunk &args, ExpressionState &s
                 throw InvalidInputException("Invalid TGEOMPOINT data: null pointer");
             }
 
-            Temporal *ret = tdisjoint_tgeo_geo(tgeom, gs, restr, at_value);
+            Temporal *ret = tdisjoint_tgeo_geo(tgeom, gs);
+
+            if (ret && restr) {
+
+                Temporal *restricted = temporal_restrict_value(ret, (Datum)at_value, true);
+
+                free(ret);
+
+                ret = restricted;
+
+            }
             free(tgeom);
             free(gs);
             if (!ret) {
@@ -2594,7 +2624,17 @@ void TgeompointFunctions::Tdisjoint_tgeo_tgeo(DataChunk &args, ExpressionState &
                 throw InvalidInputException("Invalid TGEOMPOINT data: null pointer");
             }
 
-            Temporal *ret = tdisjoint_tgeo_tgeo(tgeom1, tgeom2, restr, at_value);
+            Temporal *ret = tdisjoint_tgeo_tgeo(tgeom1, tgeom2);
+
+            if (ret && restr) {
+
+                Temporal *restricted = temporal_restrict_value(ret, (Datum)at_value, true);
+
+                free(ret);
+
+                ret = restricted;
+
+            }
             free(tgeom1);
             free(tgeom2);
             if (!ret) {
@@ -2639,7 +2679,17 @@ void TgeompointFunctions::Tintersects_geo_tgeo(DataChunk &args, ExpressionState 
                 throw InvalidInputException("Invalid TGEOMPOINT data: null pointer");
             }
 
-            Temporal *ret = tintersects_geo_tgeo(gs, tgeom, restr, at_value);
+            Temporal *ret = tintersects_geo_tgeo(gs, tgeom);
+
+            if (ret && restr) {
+
+                Temporal *restricted = temporal_restrict_value(ret, (Datum)at_value, true);
+
+                free(ret);
+
+                ret = restricted;
+
+            }
             free(tgeom);
             free(gs);
             if (!ret) {
@@ -2684,7 +2734,17 @@ void TgeompointFunctions::Tintersects_tgeo_geo(DataChunk &args, ExpressionState 
                 throw InvalidInputException("Invalid TGEOMPOINT data: null pointer");
             }
 
-            Temporal *ret = tintersects_tgeo_geo(tgeom, gs, restr, at_value);
+            Temporal *ret = tintersects_tgeo_geo(tgeom, gs);
+
+            if (ret && restr) {
+
+                Temporal *restricted = temporal_restrict_value(ret, (Datum)at_value, true);
+
+                free(ret);
+
+                ret = restricted;
+
+            }
             free(tgeom);
             free(gs);
             if (!ret) {
@@ -2733,7 +2793,17 @@ void TgeompointFunctions::Tintersects_tgeo_tgeo(DataChunk &args, ExpressionState
                 throw InvalidInputException("Invalid TGEOMPOINT data: null pointer");
             }
 
-            Temporal *ret = tintersects_tgeo_tgeo(tgeom1, tgeom2, restr, at_value);
+            Temporal *ret = tintersects_tgeo_tgeo(tgeom1, tgeom2);
+
+            if (ret && restr) {
+
+                Temporal *restricted = temporal_restrict_value(ret, (Datum)at_value, true);
+
+                free(ret);
+
+                ret = restricted;
+
+            }
             free(tgeom1);
             free(tgeom2);
             if (!ret) {
@@ -2778,7 +2848,17 @@ void TgeompointFunctions::Ttouches_geo_tgeo(DataChunk &args, ExpressionState &st
                 throw InvalidInputException("Invalid TGEOMPOINT data: null pointer");
             }
 
-            Temporal *ret = ttouches_geo_tgeo(gs, tgeom, restr, at_value);
+            Temporal *ret = ttouches_geo_tgeo(gs, tgeom);
+
+            if (ret && restr) {
+
+                Temporal *restricted = temporal_restrict_value(ret, (Datum)at_value, true);
+
+                free(ret);
+
+                ret = restricted;
+
+            }
             free(tgeom);
             free(gs);
             if (!ret) {
@@ -2823,7 +2903,17 @@ void TgeompointFunctions::Ttouches_tgeo_geo(DataChunk &args, ExpressionState &st
                 throw InvalidInputException("Invalid TGEOMPOINT data: null pointer");
             }
 
-            Temporal *ret = ttouches_tgeo_geo(tgeom, gs, restr, at_value);
+            Temporal *ret = ttouches_tgeo_geo(tgeom, gs);
+
+            if (ret && restr) {
+
+                Temporal *restricted = temporal_restrict_value(ret, (Datum)at_value, true);
+
+                free(ret);
+
+                ret = restricted;
+
+            }
             free(tgeom);
             free(gs);
             if (!ret) {
@@ -2871,7 +2961,12 @@ void TgeompointFunctions::Tdwithin_tgeo_tgeo(DataChunk &args, ExpressionState &s
                 free(tgeom2_data_copy);
                 throw InvalidInputException("Invalid TGEOMPOINT data: null pointer");
             }
-            Temporal *ret = tdwithin_tgeo_tgeo(tgeom1, tgeom2, dist, restr, at_value);
+            Temporal *ret = tdwithin_tgeo_tgeo(tgeom1, tgeom2, dist);
+            if (ret && restr) {
+                Temporal *restricted = temporal_restrict_value(ret, (Datum)at_value, true);
+                free(ret);
+                ret = restricted;
+            }
             if (!ret) {
                 free(tgeom1);
                 free(tgeom2);
@@ -2918,7 +3013,17 @@ void TgeompointFunctions::Tdwithin_tgeo_geo(DataChunk &args, ExpressionState &st
                 throw InvalidInputException("Invalid geometry format: " + geometry_blob.GetString());
             }
 
-            Temporal *ret = tdwithin_tgeo_geo(tgeom, gs, dist, restr, at_value);
+            Temporal *ret = tdwithin_tgeo_geo(tgeom, gs, dist);
+
+            if (ret && restr) {
+
+                Temporal *restricted = temporal_restrict_value(ret, (Datum)at_value, true);
+
+                free(ret);
+
+                ret = restricted;
+
+            }
             free(tgeom);
             free(gs);
             if (!ret) {
@@ -2963,7 +3068,17 @@ void TgeompointFunctions::Tdwithin_geo_tgeo(DataChunk &args, ExpressionState &st
                 throw InvalidInputException("Invalid TGEOMPOINT data: null pointer");
             }
 
-            Temporal *ret = tdwithin_geo_tgeo(gs, tgeom, dist, restr, at_value);
+            Temporal *ret = tdwithin_geo_tgeo(gs, tgeom, dist);
+
+            if (ret && restr) {
+
+                Temporal *restricted = temporal_restrict_value(ret, (Datum)at_value, true);
+
+                free(ret);
+
+                ret = restricted;
+
+            }
             free(tgeom);
             free(gs);
             if (!ret) {

--- a/src/include/index/rtree_module.hpp
+++ b/src/include/index/rtree_module.hpp
@@ -70,7 +70,7 @@ public:
 
     bool TryMatchDistanceFunction(const unique_ptr<Expression> &expr, vector<reference<Expression>> &bindings) const;
 
-    meosType GetBboxType() const { return bbox_type_; }
+    MeosType GetBboxType() const { return bbox_type_; }
     size_t GetBboxSize() const { return bbox_size_; }
 
 
@@ -84,7 +84,7 @@ private:
     RTree *rtree_;
     void *boxes;
 
-    meosType bbox_type_;
+    MeosType bbox_type_;
     size_t bbox_size_;
 
     size_t current_size_ = 0;

--- a/src/include/temporal/set.hpp
+++ b/src/include/temporal/set.hpp
@@ -34,7 +34,7 @@ struct SetTypes {
 };
 
 struct SetTypeMapping {
-    static meosType GetMeosTypeFromAlias(const std::string &alias);
+    static MeosType GetMeosTypeFromAlias(const std::string &alias);
     static LogicalType GetChildType(const LogicalType &type);
 };
 

--- a/src/include/temporal/span.hpp
+++ b/src/include/temporal/span.hpp
@@ -30,7 +30,7 @@ struct SpanTypes {
 
 
 struct SpanTypeMapping {
-    static meosType GetMeosTypeFromAlias(const std::string &alias);
+    static MeosType GetMeosTypeFromAlias(const std::string &alias);
     static LogicalType GetChildType(const LogicalType &type);
 };
 

--- a/src/include/temporal/spanset.hpp
+++ b/src/include/temporal/spanset.hpp
@@ -31,7 +31,7 @@ struct SpansetTypes {
 };
 
 struct SpansetTypeMapping {
-    static meosType GetMeosTypeFromAlias(const std::string &alias);
+    static MeosType GetMeosTypeFromAlias(const std::string &alias);
     static LogicalType GetChildType(const LogicalType &type);
     static LogicalType GetBaseType(const LogicalType &type);
     static LogicalType GetSetType(const LogicalType &type);

--- a/src/include/temporal/tbox_functions.hpp
+++ b/src/include/temporal/tbox_functions.hpp
@@ -26,13 +26,13 @@ struct TboxFunctions {
      * Constructor functions
      ****************************************************/
     template <typename TA>
-    static void NumberTimestamptzToTboxExecutor(Vector &value, Vector &t, meosType basetype, Vector &result, idx_t count);
+    static void NumberTimestamptzToTboxExecutor(Vector &value, Vector &t, MeosType basetype, Vector &result, idx_t count);
     static void Number_timestamptz_to_tbox(DataChunk &args, ExpressionState &state, Vector &result);
 
     static void Numspan_timestamptz_to_tbox(DataChunk &args, ExpressionState &state, Vector &result);
 
     template <typename TA>
-    static void NumberTstzspanToTboxExecutor(Vector &value, Vector &span_str, meosType basetype, Vector &result, idx_t count);
+    static void NumberTstzspanToTboxExecutor(Vector &value, Vector &span_str, MeosType basetype, Vector &result, idx_t count);
     static void Number_tstzspan_to_tbox(DataChunk &args, ExpressionState &state, Vector &result);;
 
     static void Numspan_tstzspan_to_tbox(DataChunk &args, ExpressionState &state, Vector &result);
@@ -41,7 +41,7 @@ struct TboxFunctions {
      * Conversion functions + cast functions: [TYPE] -> TBOX
      ****************************************************/
     template <typename TA>
-    static void NumberToTboxExecutor(Vector &value, meosType basetype, Vector &result, idx_t count);
+    static void NumberToTboxExecutor(Vector &value, MeosType basetype, Vector &result, idx_t count);
     static void Number_to_tbox(DataChunk &args, ExpressionState &state, Vector &result);
     static bool Number_to_tbox_cast(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
 
@@ -115,7 +115,7 @@ struct TboxFunctions {
     static void Tbox_shift_scale_time(DataChunk &args, ExpressionState &state, Vector &result);
 
     template <typename TB>
-    static void TboxExpandValueExecutor(Vector &tbox, Vector &value, meosType basetype, Vector &result, idx_t count);
+    static void TboxExpandValueExecutor(Vector &tbox, Vector &value, MeosType basetype, Vector &result, idx_t count);
     static void Tbox_expand_value(DataChunk &args, ExpressionState &state, Vector &result);
 
     static void Tbox_expand_time(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/include/temporal/temporal_functions.hpp
+++ b/src/include/temporal/temporal_functions.hpp
@@ -14,11 +14,11 @@ class ExtensionLoader;
 
 typedef struct {
     char *alias;
-    meosType temptype;
+    MeosType temptype;
 } alias_type_struct;
 
 struct TemporalHelpers {
-    static meosType GetTemptypeFromAlias(const char *alias);
+    static MeosType GetTemptypeFromAlias(const char *alias);
     static vector<Value> TempArrToArray(Temporal **temparr, int32_t count, LogicalType element_type);
 };
 
@@ -551,7 +551,7 @@ struct TemporalFunctions {
      * Workaround functions
      ****************************************************/
     template <typename T>
-    static void Temporal_dump_common(DataChunk &args, Vector &result, meosType basetype);
+    static void Temporal_dump_common(DataChunk &args, Vector &result, MeosType basetype);
     static void Temporal_dump(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************

--- a/src/temporal/set.cpp
+++ b/src/temporal/set.cpp
@@ -60,8 +60,8 @@ const std::vector<LogicalType> &SetTypes::AllTypes() {
     return types;
 }
 
-meosType SetTypeMapping::GetMeosTypeFromAlias(const std::string &alias) {
-    static const std::unordered_map<std::string, meosType> alias_to_type = {
+MeosType SetTypeMapping::GetMeosTypeFromAlias(const std::string &alias) {
+    static const std::unordered_map<std::string, MeosType> alias_to_type = {
         {"intset", T_INTSET},
         {"bigintset", T_BIGINTSET},
         {"floatset", T_FLOATSET},
@@ -815,10 +815,10 @@ void SetTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
 // --- Unnest ---
 struct SetUnnestBindData : public TableFunctionData {
     string_t blob;
-    meosType set_type;
+    MeosType set_type;
     LogicalType return_type;
 
-    SetUnnestBindData(string_t blob, meosType set_type, LogicalType return_type)
+    SetUnnestBindData(string_t blob, MeosType set_type, LogicalType return_type)
         : blob(std::move(blob)), set_type(set_type), return_type(std::move(return_type)) {}
 };
 

--- a/src/temporal/set_functions.cpp
+++ b/src/temporal/set_functions.cpp
@@ -207,7 +207,7 @@ bool SetFunctions::Text_to_set(Vector &source, Vector &result, idx_t count, Cast
     result.SetVectorType(VectorType::FLAT_VECTOR);
 
     auto target_type = result.GetType();
-    meosType set_type = SetTypeMapping::GetMeosTypeFromAlias(target_type.GetAlias());
+    MeosType set_type = SetTypeMapping::GetMeosTypeFromAlias(target_type.GetAlias());
 
     UnaryExecutor::Execute<string_t, string_t>(
         source, result, count,
@@ -301,7 +301,7 @@ void SetFunctions::Set_constructor(DataChunk &args, ExpressionState &state, Vect
                 }
             }
 
-            meosType base_type = settype_basetype(meos_type);            
+            MeosType base_type = settype_basetype(meos_type);            
             Set *s = set_make_free(values, (int)length, base_type, true);
                         
             size_t size = set_mem_size(s);            
@@ -320,7 +320,7 @@ static inline void Write_set(Vector &result, idx_t row, Set *s) {
     free(s);
 }
 
-static inline void Value_to_set_core(Vector &source, Vector &result, idx_t count, meosType base_type) {
+static inline void Value_to_set_core(Vector &source, Vector &result, idx_t count, MeosType base_type) {
     source.Flatten(count);
     result.SetVectorType(VectorType::FLAT_VECTOR);
     
@@ -409,8 +409,8 @@ static inline void Value_to_set_core(Vector &source, Vector &result, idx_t count
 
 bool SetFunctions::Value_to_set_cast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
     auto target_type = result.GetType();
-    meosType set_type  = SetTypeMapping::GetMeosTypeFromAlias(target_type.GetAlias());
-    meosType base_type = settype_basetype(set_type);
+    MeosType set_type  = SetTypeMapping::GetMeosTypeFromAlias(target_type.GetAlias());
+    MeosType base_type = settype_basetype(set_type);
 
     Value_to_set_core(source, result, count, base_type);
     return true;
@@ -420,8 +420,8 @@ bool SetFunctions::Value_to_set_cast(Vector &source, Vector &result, idx_t count
 void SetFunctions::Value_to_set(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &source = args.data[0];
     auto out_type = result.GetType();
-    meosType set_type  = SetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
-    meosType base_type = settype_basetype(set_type);
+    MeosType set_type  = SetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
+    MeosType base_type = settype_basetype(set_type);
 
     Value_to_set_core(source, result, args.size(), base_type);
 }
@@ -960,7 +960,7 @@ void SetFunctions::Set_values(DataChunk &args, ExpressionState &state, Vector &r
 void SetFunctions::Numset_shift(DataChunk &args, ExpressionState &state, Vector &result) {    
     auto &set_vec  = args.data[0];
     auto out_type  = result.GetType();    
-    meosType set_type  = SetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
+    MeosType set_type  = SetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
 
     switch (set_type) {
         case T_INTSET: { // shift(intset, integer) -> intset
@@ -1035,7 +1035,7 @@ void SetFunctions::Tstzset_shift(DataChunk &args, ExpressionState &state, Vector
 void SetFunctions::Numset_scale(DataChunk &args, ExpressionState &state, Vector &result){
     auto &set_vec  = args.data[0];
     auto out_type  = result.GetType();    
-    meosType set_type  = SetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
+    MeosType set_type  = SetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
 
     switch (set_type) {
         case T_INTSET: { // scale(intset, integer) -> intset
@@ -1113,7 +1113,7 @@ void SetFunctions::Numset_shift_scale(DataChunk &args, ExpressionState &state, V
     auto &wd_vec  = args.data[2];
 
     auto out_type  = result.GetType();
-    meosType set_type = SetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
+    MeosType set_type = SetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
 
     switch (set_type) {
         case T_INTSET: { // shift_scale(intset, integer, integer) -> intset

--- a/src/temporal/span.cpp
+++ b/src/temporal/span.cpp
@@ -59,8 +59,8 @@ const std::vector<LogicalType> &SpanTypes::AllTypes() {
     return types;
 }
 
-meosType SpanTypeMapping::GetMeosTypeFromAlias(const std::string &alias) {
-    static const std::unordered_map<std::string, meosType> alias_to_type = {
+MeosType SpanTypeMapping::GetMeosTypeFromAlias(const std::string &alias) {
+    static const std::unordered_map<std::string, MeosType> alias_to_type = {
         {"INTSPAN", T_INTSPAN},
         {"BIGINTSPAN", T_BIGINTSPAN},
         {"FLOATSPAN", T_FLOATSPAN},

--- a/src/temporal/span_functions.cpp
+++ b/src/temporal/span_functions.cpp
@@ -88,7 +88,7 @@ bool SpanFunctions::Text_to_span(Vector &source, Vector &result, idx_t count, Ca
     std::string type_alias = result_type.GetAlias();
     
     // Map the alias to the correct MEOS type
-    meosType target_meos_type = SpanTypeMapping::GetMeosTypeFromAlias(type_alias);
+    MeosType target_meos_type = SpanTypeMapping::GetMeosTypeFromAlias(type_alias);
     
     if (target_meos_type == T_UNKNOWN) {
         throw InvalidInputException("Unknown span type: " + type_alias);
@@ -203,7 +203,7 @@ void SpanFunctions::Span_constructor(DataChunk &args, ExpressionState &state, Ve
     auto &result_type = result.GetType();
     std::string type_alias = result_type.GetAlias();
     
-    meosType target_meos_type = SpanTypeMapping::GetMeosTypeFromAlias(type_alias);
+    MeosType target_meos_type = SpanTypeMapping::GetMeosTypeFromAlias(type_alias);
     
     if (target_meos_type == T_UNKNOWN) {
         throw InvalidInputException("Unknown span type: " + type_alias);
@@ -239,9 +239,9 @@ void SpanFunctions::Span_constructor(DataChunk &args, ExpressionState &state, Ve
 
 
 // --- Span binary constructor ---
-static string_t Span_make_blob(Datum lower_dat, Datum upper_dat, bool lower_inc, bool upper_inc, meosType span_type,
+static string_t Span_make_blob(Datum lower_dat, Datum upper_dat, bool lower_inc, bool upper_inc, MeosType span_type,
                                Vector &result) {
-    meosType basetype = spantype_basetype(span_type);
+    MeosType basetype = spantype_basetype(span_type);
     Span *span = span_make(lower_dat, upper_dat, lower_inc, upper_inc, basetype);
     if (span == NULL) {
         throw InvalidInputException("Failed to create span from bounds");
@@ -260,7 +260,7 @@ void SpanFunctions::Span_binary_constructor(DataChunk &args, ExpressionState &st
     Vector *args3 = args.ColumnCount() == 4 ? &args.data[3] : nullptr;
 
     auto out_type = result.GetType();
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
     const idx_t count = args.size();
 
     switch (span_type) {
@@ -369,7 +369,7 @@ static inline void Write_span(Vector &result, idx_t row, Span *s) {
     free(s);
 }
 
-static void Value_to_span_core(Vector &source, Vector &result, idx_t count, meosType base_type){
+static void Value_to_span_core(Vector &source, Vector &result, idx_t count, MeosType base_type){
     source.Flatten(count);
     result.SetVectorType(VectorType::FLAT_VECTOR);
 
@@ -440,16 +440,16 @@ static void Value_to_span_core(Vector &source, Vector &result, idx_t count, meos
 void SpanFunctions::Value_to_span(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &source = args.data[0];
     auto out_type = result.GetType();
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
-    meosType base_type = spantype_basetype(span_type);
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
+    MeosType base_type = spantype_basetype(span_type);
 
     Value_to_span_core(source, result, args.size(), base_type);
 
 }
 
 bool SpanFunctions::Value_to_span_cast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(result.GetType().GetAlias());
-    meosType base_type = spantype_basetype(span_type);
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(result.GetType().GetAlias());
+    MeosType base_type = spantype_basetype(span_type);
     Value_to_span_core(source, result, count, base_type);
     return true;
 }
@@ -1054,7 +1054,7 @@ void SpanFunctions::Tstzspan_duration(DataChunk &args, ExpressionState &state, V
         });
 }
 
-static inline string_t Numspan_expand_common(const string_t &blob, Datum value, meosType validate_span_type, Vector &result) {
+static inline string_t Numspan_expand_common(const string_t &blob, Datum value, MeosType validate_span_type, Vector &result) {
     const uint8_t *data = (const uint8_t *)blob.GetData();
     size_t size = blob.GetSize();
     
@@ -1100,7 +1100,7 @@ static inline string_t Tstzspan_expand_common(const string_t &blob, interval_t d
 void SpanFunctions::Numspan_expand(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
     auto out_type  = result.GetType();    
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
     
     switch (span_type) {
         case T_INTSPAN: { // expand(intspan, integer) -> intspan
@@ -1146,7 +1146,7 @@ void SpanFunctions::Numspan_expand(DataChunk &args, ExpressionState &state, Vect
 void SpanFunctions::Tstzspan_expand(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
     auto out_type  = result.GetType();    
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
     BinaryExecutor::Execute<string_t, interval_t, string_t>(
         span_vec, args.data[1], result, args.size(),
         [&](string_t blob, interval_t value) -> string_t {
@@ -1158,7 +1158,7 @@ void SpanFunctions::Tstzspan_expand(DataChunk &args, ExpressionState &state, Vec
 }
 
 static inline string_t Numspan_shift_common(const string_t &blob, Datum shift_datum,
-                                        meosType validate_span_type, Vector &result) {
+                                        MeosType validate_span_type, Vector &result) {
     const uint8_t *data = (const uint8_t *)blob.GetData();
     size_t size = blob.GetSize();
     
@@ -1206,7 +1206,7 @@ static inline string_t Tstzspan_shift_common(const string_t &blob, interval_t du
 void SpanFunctions::Numspan_shift(DataChunk &args, ExpressionState &state, Vector &result) {    
     auto &span_vec = args.data[0];
     auto out_type  = result.GetType();    
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
     
     switch (span_type) {
         case T_INTSPAN: { // shift(intspan, integer) -> intspan
@@ -1249,7 +1249,7 @@ void SpanFunctions::Numspan_shift(DataChunk &args, ExpressionState &state, Vecto
 void SpanFunctions::Tstzspan_shift(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
     auto out_type  = result.GetType();    
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
     BinaryExecutor::Execute<string_t, interval_t, string_t>(
         span_vec, args.data[1], result, args.size(),
         [&](string_t blob, interval_t shift_interval) -> string_t {
@@ -1261,7 +1261,7 @@ void SpanFunctions::Tstzspan_shift(DataChunk &args, ExpressionState &state, Vect
 }
 
 static inline string_t Numspan_scale_common(const string_t &blob, Datum scale_datum,
-                                        meosType validate_span_type, Vector &result) {
+                                        MeosType validate_span_type, Vector &result) {
     const uint8_t *data = (const uint8_t *)blob.GetData();
     size_t size = blob.GetSize();
     
@@ -1288,7 +1288,7 @@ static inline string_t Numspan_scale_common(const string_t &blob, Datum scale_da
 void SpanFunctions::Numspan_scale(DataChunk &args, ExpressionState &state, Vector &result) {    
     auto &span_vec = args.data[0];
     auto out_type  = result.GetType();    
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
     
     switch (span_type) {
         case T_INTSPAN: { // scale(intspan, integer) -> intspan
@@ -1351,7 +1351,7 @@ static inline string_t Tstzspan_scale_common(const string_t &blob, interval_t du
 void SpanFunctions::Tstzspan_scale(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
     auto out_type  = result.GetType();    
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
     BinaryExecutor::Execute<string_t, interval_t, string_t>(
         span_vec, args.data[1], result, args.size(),
         [&](string_t blob, interval_t scale_interval) -> string_t {
@@ -1386,7 +1386,7 @@ static inline string_t Tstzspan_shift_scale_common(const string_t &blob, interva
 }
 
 static inline string_t Numspan_shift_scale_common(const string_t &blob, Datum shift_datum, Datum scale_datum,
-                                                 meosType validate_span_type, Vector &result) {
+                                                 MeosType validate_span_type, Vector &result) {
     const uint8_t *data = (const uint8_t *)blob.GetData();
     size_t size = blob.GetSize();
 
@@ -1423,7 +1423,7 @@ static inline string_t Numspan_shift_scale_common(const string_t &blob, Datum sh
 void SpanFunctions::Numspan_shift_scale(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
     auto out_type = result.GetType();
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
 
     switch (span_type) {
         case T_INTSPAN: {
@@ -1863,7 +1863,7 @@ void SpanFunctions::Span_cmp(DataChunk &args, ExpressionState &state, Vector &re
 // --- OPERATOR: span @> value ---
 void SpanFunctions::Contains_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
     
     switch (span_type){
         case T_INTSPAN: { // intspan @> integer
@@ -2009,7 +2009,7 @@ void SpanFunctions::Contains_span_span(DataChunk &args, ExpressionState &state, 
 // --- OPERATOR: value <@ span ---
 void SpanFunctions::Contained_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[1];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
     
     switch (span_type){
         case T_INTSPAN: { // integer <@ intspan
@@ -2194,7 +2194,7 @@ void SpanFunctions::Overlaps_span_span(DataChunk &args, ExpressionState &state, 
 // --- OPERATOR: value -|- span---
 void SpanFunctions::Adjacent_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[1];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
     
     switch (span_type){
         case T_INTSPAN: { // integer -|- intspan
@@ -2306,7 +2306,7 @@ void SpanFunctions::Adjacent_value_span(DataChunk &args, ExpressionState &state,
 // --- OPERATOR: span -|- value ---
 void SpanFunctions::Adjacent_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
     
     switch (span_type){
         case T_INTSPAN: { // intspan -|- integer
@@ -2454,7 +2454,7 @@ void SpanFunctions::Adjacent_span_span(DataChunk &args, ExpressionState &state, 
 // --- OPERATOR: value << span ---
 void SpanFunctions::Left_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[1];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
     
     switch (span_type){
         case T_INTSPAN: { // integer << intspan
@@ -2565,7 +2565,7 @@ void SpanFunctions::Left_value_span(DataChunk &args, ExpressionState &state, Vec
 // --- OPERATOR: span << value ---
 void SpanFunctions::Left_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
     
     switch (span_type){
         case T_INTSPAN: { // intspan << integer
@@ -2709,7 +2709,7 @@ void SpanFunctions::Left_span_span(DataChunk &args, ExpressionState &state, Vect
 // --- OPERATOR: value >> span ---
 void SpanFunctions::Right_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[1];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
     
     switch (span_type){
         case T_INTSPAN: { // integer >> intspan
@@ -2820,7 +2820,7 @@ void SpanFunctions::Right_value_span(DataChunk &args, ExpressionState &state, Ve
 // --- OPERATOR: span >> value ---
 void SpanFunctions::Right_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // intspan >> integer
             BinaryExecutor::Execute<string_t, int32_t, bool>(
@@ -2964,7 +2964,7 @@ void SpanFunctions::Right_span_span(DataChunk &args, ExpressionState &state, Vec
 // ---OPERATOR: value &< span ---
 void SpanFunctions::Overleft_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[1];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());    
     
     switch (span_type){
         case T_INTSPAN: { // integer &< intspan
@@ -3075,7 +3075,7 @@ void SpanFunctions::Overleft_value_span(DataChunk &args, ExpressionState &state,
 // ---OPERATOR: span &< value ---
 void SpanFunctions::Overleft_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // intspan &< integer
             BinaryExecutor::Execute<string_t, int32_t, bool>(
@@ -3220,7 +3220,7 @@ void SpanFunctions::Overleft_span_span(DataChunk &args, ExpressionState &state, 
 // --- OPERATOR: value &> span ---
 void SpanFunctions::Overright_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[1];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // integer &> intspan
             BinaryExecutor::Execute<int32_t, string_t, bool>(
@@ -3331,7 +3331,7 @@ void SpanFunctions::Overright_value_span(DataChunk &args, ExpressionState &state
 // --- OPERATOR: span &> value ---
 void SpanFunctions::Overright_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // intspan &> integer
             BinaryExecutor::Execute<string_t, int32_t, bool>(
@@ -3476,7 +3476,7 @@ void SpanFunctions::Overright_span_span(DataChunk &args, ExpressionState &state,
 // --- SET OPERATOR ---
 void SpanFunctions::Union_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[1];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // integer + intspan
             BinaryExecutor::Execute<int32_t, string_t, string_t>(
@@ -3621,7 +3621,7 @@ void SpanFunctions::Union_value_span(DataChunk &args, ExpressionState &state, Ve
 
 void SpanFunctions::Union_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // intspan + integer
             BinaryExecutor::Execute<string_t, int32_t, string_t>(
@@ -3802,7 +3802,7 @@ void SpanFunctions::Union_span_span(DataChunk &args, ExpressionState &state, Vec
 // --- OPERATOR: INTERSECTION ---
 void SpanFunctions::Intersection_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[1];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // integer * intspan
             BinaryExecutor::Execute<int32_t, string_t, string_t>(
@@ -3967,7 +3967,7 @@ void SpanFunctions::Intersection_value_span(DataChunk &args, ExpressionState &st
 
 void SpanFunctions::Intersection_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // intspan * integer
             BinaryExecutor::Execute<string_t, int32_t, string_t>(
@@ -4182,7 +4182,7 @@ void SpanFunctions::Intersection_span_span(DataChunk &args, ExpressionState &sta
 // --- OPERATOR: MINUS ---
 void SpanFunctions::Minus_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[1];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // integer - intspan
             BinaryExecutor::Execute<int32_t, string_t, string_t>(
@@ -4347,7 +4347,7 @@ void SpanFunctions::Minus_value_span(DataChunk &args, ExpressionState &state, Ve
 
 void SpanFunctions::Minus_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // intspan - integer
             BinaryExecutor::Execute<string_t, int32_t, string_t>(
@@ -4562,7 +4562,7 @@ void SpanFunctions::Minus_span_span(DataChunk &args, ExpressionState &state, Vec
 //--- DISTANCE FUNCTIONS ---
 void SpanFunctions::Distance_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[0];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // distance between intspan and integer
             BinaryExecutor::Execute<string_t, int32_t, double>(
@@ -4673,7 +4673,7 @@ void SpanFunctions::Distance_span_value(DataChunk &args, ExpressionState &state,
 
 void SpanFunctions::Distance_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &span_vec = args.data[1];
-    meosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
+    MeosType span_type = SpanTypeMapping::GetMeosTypeFromAlias(span_vec.GetType().GetAlias());
     switch (span_type){
         case T_INTSPAN: { // distance between integer and intspan
             BinaryExecutor::Execute<int32_t, string_t, double>(

--- a/src/temporal/spanset.cpp
+++ b/src/temporal/spanset.cpp
@@ -53,8 +53,8 @@ const std::vector<LogicalType> &SpansetTypes::AllTypes() {
     return types;
 }
 
-meosType SpansetTypeMapping::GetMeosTypeFromAlias(const std::string &alias) {
-    static const std::unordered_map<std::string, meosType> alias_to_type = {
+MeosType SpansetTypeMapping::GetMeosTypeFromAlias(const std::string &alias) {
+    static const std::unordered_map<std::string, MeosType> alias_to_type = {
         {"intspanset", T_INTSPANSET},
         {"bigintspanset", T_BIGINTSPANSET},
         {"floatspanset", T_FLOATSPANSET},        

--- a/src/temporal/spanset_functions.cpp
+++ b/src/temporal/spanset_functions.cpp
@@ -160,7 +160,7 @@ bool SpansetFunctions::Text_to_spanset(Vector &source, Vector &result, idx_t cou
     result.SetVectorType(VectorType::FLAT_VECTOR);
 
     auto target_type = result.GetType();
-    meosType spanset_type = SpansetTypeMapping::GetMeosTypeFromAlias(target_type.GetAlias());
+    MeosType spanset_type = SpansetTypeMapping::GetMeosTypeFromAlias(target_type.GetAlias());
 
     UnaryExecutor::Execute<string_t, string_t>(
         source, result, count,
@@ -226,7 +226,7 @@ static inline void Write_spanset(Vector &result, idx_t row, SpanSet *s) {
     free(s);
 }
 
-static inline void Value_to_spanset_core(Vector &source, Vector &result, idx_t count, meosType base_type) {
+static inline void Value_to_spanset_core(Vector &source, Vector &result, idx_t count, MeosType base_type) {
     source.Flatten(count);
     result.SetVectorType(VectorType::FLAT_VECTOR);
 
@@ -288,9 +288,9 @@ static inline void Value_to_spanset_core(Vector &source, Vector &result, idx_t c
 // --- CAST (conversion: base -> spanset) ----
 bool SpansetFunctions::Value_to_spanset_cast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
     auto target_type   = result.GetType();
-    meosType spanset_t = SpansetTypeMapping::GetMeosTypeFromAlias(target_type.GetAlias());
-    meosType span_t    = spansettype_spantype(spanset_t);
-    meosType base_t    = spantype_basetype(span_t);
+    MeosType spanset_t = SpansetTypeMapping::GetMeosTypeFromAlias(target_type.GetAlias());
+    MeosType span_t    = spansettype_spantype(spanset_t);
+    MeosType base_t    = spantype_basetype(span_t);
 
     Value_to_spanset_core(source, result, count, base_t);
     return true;
@@ -300,9 +300,9 @@ bool SpansetFunctions::Value_to_spanset_cast(Vector &source, Vector &result, idx
 void SpansetFunctions::Value_to_spanset(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &source      = args.data[0];
     auto out_type     = result.GetType();
-    meosType spanset_t= SpansetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
-    meosType span_t   = spansettype_spantype(spanset_t);
-    meosType base_t   = spantype_basetype(span_t);
+    MeosType spanset_t= SpansetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
+    MeosType span_t   = spansettype_spantype(spanset_t);
+    MeosType base_t   = spantype_basetype(span_t);
 
     Value_to_spanset_core(source, result, args.size(), base_t);
 }
@@ -1161,7 +1161,7 @@ void SpansetFunctions::Tstzspanset_timestamps(DataChunk &args, ExpressionState &
 }
 
 static inline string_t Numspanset_shift_common(const string_t &blob, Datum shift_datum,
-                                        meosType validate_spanset_type, Vector &result) {
+                                        MeosType validate_spanset_type, Vector &result) {
     const uint8_t *data = (const uint8_t *)blob.GetData();
     size_t size = blob.GetSize();
     
@@ -1208,7 +1208,7 @@ static inline string_t Tstzspanset_shift_common(const string_t &blob, interval_t
 void SpansetFunctions::Numspanset_shift(DataChunk &args, ExpressionState &state, Vector &result) {    
     auto &spanset_vec = args.data[0];
     auto out_type  = result.GetType();    
-    meosType spanset_type = SpansetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
+    MeosType spanset_type = SpansetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
     
     switch (spanset_type) {
         case T_INTSPANSET: { // shift(intspanset, integer) -> intspanset
@@ -1262,7 +1262,7 @@ void SpansetFunctions::Tstzspanset_shift(DataChunk &args, ExpressionState &state
 }
 
 static inline string_t Numspanset_scale_common(const string_t &blob, Datum scale_datum,
-                                        meosType validate_spanset_type, Vector &result) {
+                                        MeosType validate_spanset_type, Vector &result) {
     const uint8_t *data = (const uint8_t *)blob.GetData();
     size_t size = blob.GetSize();
     
@@ -1289,7 +1289,7 @@ static inline string_t Numspanset_scale_common(const string_t &blob, Datum scale
 void SpansetFunctions::Numspanset_scale(DataChunk &args, ExpressionState &state, Vector &result) {    
     auto &spanset_vec = args.data[0];
     auto out_type  = result.GetType();    
-    meosType spanset_type = SpansetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
+    MeosType spanset_type = SpansetTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());    
     
     switch (spanset_type) {
         case T_INTSPANSET: { // scale(intspanset, integer) -> intspanset
@@ -1386,7 +1386,7 @@ static inline string_t Tstzspanset_shift_scale_common(const string_t &blob, inte
 }
 
 static inline string_t Numspanset_shift_scale_common(const string_t &blob, Datum shift_datum, Datum scale_datum,
-                                                 meosType validate_spanset_type, Vector &result) {
+                                                 MeosType validate_spanset_type, Vector &result) {
     const uint8_t *data = (const uint8_t *)blob.GetData();
     size_t size = blob.GetSize();
 
@@ -1423,7 +1423,7 @@ static inline string_t Numspanset_shift_scale_common(const string_t &blob, Datum
 void SpansetFunctions::Numspanset_shift_scale(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &spanset_vec = args.data[0];
     auto out_type = result.GetType();
-    meosType spanset_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
+    MeosType spanset_type = SpanTypeMapping::GetMeosTypeFromAlias(out_type.GetAlias());
 
     switch (spanset_type) {
         case T_INTSPANSET: {

--- a/src/temporal/tbox_functions.cpp
+++ b/src/temporal/tbox_functions.cpp
@@ -84,7 +84,7 @@ bool TboxFunctions::Tbox_out(Vector &source, Vector &result, idx_t count, CastPa
 }
 
 template <typename TA>
-void TboxFunctions::NumberTimestamptzToTboxExecutor(Vector &value, Vector &t, meosType basetype, Vector &result, idx_t count) {
+void TboxFunctions::NumberTimestamptzToTboxExecutor(Vector &value, Vector &t, MeosType basetype, Vector &result, idx_t count) {
     BinaryExecutor::Execute<TA, timestamp_tz_t, string_t>(
         value, t, result, count,
         [&](TA value, timestamp_tz_t t) {
@@ -150,7 +150,7 @@ void TboxFunctions::Numspan_timestamptz_to_tbox(DataChunk &args, ExpressionState
 }
 
 template <typename TA>
-void TboxFunctions::NumberTstzspanToTboxExecutor(Vector &value, Vector &span_str, meosType basetype, Vector &result, idx_t count) {
+void TboxFunctions::NumberTstzspanToTboxExecutor(Vector &value, Vector &span_str, MeosType basetype, Vector &result, idx_t count) {
     BinaryExecutor::Execute<TA, string_t, string_t>(
         value, span_str, result, count,
         [&](TA value, string_t span_str) {
@@ -234,7 +234,7 @@ void TboxFunctions::Numspan_tstzspan_to_tbox(DataChunk &args, ExpressionState &s
 }
 
 template <typename TA>
-void TboxFunctions::NumberToTboxExecutor(Vector &value, meosType basetype, Vector &result, idx_t count) {
+void TboxFunctions::NumberToTboxExecutor(Vector &value, MeosType basetype, Vector &result, idx_t count) {
     UnaryExecutor::Execute<TA, string_t>(
         value, result, count,
         [&](TA value) {
@@ -1007,7 +1007,7 @@ void TboxFunctions::Tbox_shift_scale_time(DataChunk &args, ExpressionState &stat
 }
 
 template <typename TB>
-void TboxFunctions::TboxExpandValueExecutor(Vector &tbox, Vector &value, meosType basetype, Vector &result, idx_t count) {
+void TboxFunctions::TboxExpandValueExecutor(Vector &tbox, Vector &value, MeosType basetype, Vector &result, idx_t count) {
     BinaryExecutor::ExecuteWithNulls<string_t, TB, string_t>(
         tbox, value, result, count,
         [&](string_t tbox_str, TB value, ValidityMask &mask, idx_t idx) {

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -1904,10 +1904,10 @@ void TemporalTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
 
 struct TemporalUnnestBindData : public TableFunctionData {
     string_t blob;
-    meosType temptype;
+    MeosType temptype;
     LogicalType returnType;
 
-    TemporalUnnestBindData(string_t blob, meosType temptype, LogicalType returnType)
+    TemporalUnnestBindData(string_t blob, MeosType temptype, LogicalType returnType)
         : blob(std::move(blob)), temptype(temptype), returnType(std::move(returnType)) {}
 };
 

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -27,7 +27,7 @@ static const alias_type_struct DUCKDB_ALIAS_TYPE_CATALOG[] = {
     {(char*)"TGEOMETRY", T_TGEOMETRY}
 };
 
-meosType TemporalHelpers::GetTemptypeFromAlias(const char *alias) {
+MeosType TemporalHelpers::GetTemptypeFromAlias(const char *alias) {
     for (size_t i = 0; i < sizeof(DUCKDB_ALIAS_TYPE_CATALOG) / sizeof(DUCKDB_ALIAS_TYPE_CATALOG[0]); i++) {
         if (strcmp(alias, DUCKDB_ALIAS_TYPE_CATALOG[i].alias) == 0) {
             return DUCKDB_ALIAS_TYPE_CATALOG[i].temptype;
@@ -56,7 +56,7 @@ vector<Value> TemporalHelpers::TempArrToArray(Temporal **temparr, int32_t count,
 
 bool TemporalFunctions::Temporal_in(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
     auto &target_type = result.GetType();
-    meosType temptype = TemporalHelpers::GetTemptypeFromAlias(target_type.GetAlias().c_str());
+    MeosType temptype = TemporalHelpers::GetTemptypeFromAlias(target_type.GetAlias().c_str());
     bool success = true;
     UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
         source, result, count,
@@ -163,7 +163,7 @@ void TemporalFunctions::Tinstant_constructor_common(Vector &value, Vector &ts, V
     BinaryExecutor::Execute<T, timestamp_tz_t, string_t>(
         value, ts, result, count,
         [&](T value, timestamp_tz_t ts) {
-            meosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
+            MeosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
             timestamp_tz_t meos_ts = DuckDBToMeosTimestamp(ts);
 
             Datum datum;
@@ -195,7 +195,7 @@ void TemporalFunctions::Tinstant_constructor_text(Vector &value, Vector &ts, Vec
     BinaryExecutor::Execute<string_t, timestamp_tz_t, string_t>(
         value, ts, result, count,
         [&](string_t value, timestamp_tz_t ts) {
-            meosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
+            MeosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
             timestamp_tz_t meos_ts = DuckDBToMeosTimestamp(ts);
 
             std::string str = value.GetString();
@@ -243,7 +243,7 @@ void TemporalFunctions::Tsequence_constructor(DataChunk &args, ExpressionState &
     auto *list_entries = ListVector::GetData(array_vec);
     auto &child_vec = ListVector::GetEntry(array_vec);
 
-    meosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
+    MeosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
     interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
     bool lower_inc = true;
     bool upper_inc = true;
@@ -410,7 +410,7 @@ void TemporalFunctions::Tsequenceset_constructor(DataChunk &args, ExpressionStat
     }
 }
 
-static string_t Tsequence_from_base_tstzset_impl(Datum datum, string_t set_blob, meosType temptype, Vector &result) {
+static string_t Tsequence_from_base_tstzset_impl(Datum datum, string_t set_blob, MeosType temptype, Vector &result) {
     size_t data_size = set_blob.GetSize();
     if (data_size < sizeof(void*)) {
         throw InvalidInputException("[Tsequence_from_base_tstzset] Invalid tstzset data: insufficient size");
@@ -440,7 +440,7 @@ static string_t Tsequence_from_base_tstzset_impl(Datum datum, string_t set_blob,
 void TemporalFunctions::Tsequence_from_base_tstzset(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     const auto &arg_type = args.data[0].GetType();
-    meosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
+    MeosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
 
     if (arg_type.id() == LogicalTypeId::VARCHAR) {
         BinaryExecutor::Execute<string_t, string_t, string_t>(
@@ -485,7 +485,7 @@ void TemporalFunctions::Tsequence_from_base_tstzset(DataChunk &args, ExpressionS
     }
 }   
 
-static string_t Tsequence_from_base_tstzspan_impl(Datum datum, string_t span_blob, meosType temptype, interpType interp, Vector &result) {
+static string_t Tsequence_from_base_tstzspan_impl(Datum datum, string_t span_blob, MeosType temptype, interpType interp, Vector &result) {
     size_t data_size = span_blob.GetSize();
     if (data_size < sizeof(void*)) {
         throw InvalidInputException("[Tsequence_from_base_tstzspan] Invalid tstzspan data: insufficient size");
@@ -515,7 +515,7 @@ static string_t Tsequence_from_base_tstzspan_impl(Datum datum, string_t span_blo
 void TemporalFunctions::Tsequence_from_base_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     const auto &arg_type = args.data[0].GetType();
-    meosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
+    MeosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
     interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
     if (args.ColumnCount() > 2) {
         auto &interp_child = args.data[2];
@@ -568,7 +568,7 @@ void TemporalFunctions::Tsequence_from_base_tstzspan(DataChunk &args, Expression
     }
 }
 
-static string_t Tsequenceset_from_base_tstzspanset_impl(Datum datum, string_t spanset_blob, meosType temptype, interpType interp, Vector &result) {
+static string_t Tsequenceset_from_base_tstzspanset_impl(Datum datum, string_t spanset_blob, MeosType temptype, interpType interp, Vector &result) {
     size_t data_size = spanset_blob.GetSize();
     if (data_size < sizeof(void*)) {
         throw InvalidInputException("[Tsequenceset_from_base_tstzspanset] Invalid tstzspanset data: insufficient size");
@@ -598,7 +598,7 @@ static string_t Tsequenceset_from_base_tstzspanset_impl(Datum datum, string_t sp
 void TemporalFunctions::Tsequenceset_from_base_tstzspanset(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     const auto &arg_type = args.data[0].GetType();
-    meosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
+    MeosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
     interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
     if (args.ColumnCount() > 2) {
         auto &interp_child = args.data[2];
@@ -861,7 +861,7 @@ bool TemporalFunctions::Tfloat_to_tint_cast(Vector &source, Vector &result, idx_
     return true;
 }
 
-static inline string_t Tnumber_to_tbox_common(Datum datum, meosType basetype, Vector &result) {
+static inline string_t Tnumber_to_tbox_common(Datum datum, MeosType basetype, Vector &result) {
     TBox *tbox = number_tbox(datum, basetype);
     size_t tbox_size = sizeof(TBox);
     uint8_t *tbox_data = (uint8_t*)malloc(tbox_size);
@@ -910,7 +910,7 @@ void TemporalFunctions::Tnumber_to_tbox(DataChunk &args, ExpressionState &state,
                 return Tnumber_temporal_to_tbox_common(input, result);
             });
     } else if (arg_type.id() == LogicalTypeId::DOUBLE || arg_type.id() == LogicalTypeId::FLOAT) {
-        meosType basetype = TemporalHelpers::GetTemptypeFromAlias(arg_type.GetAlias().c_str());
+        MeosType basetype = TemporalHelpers::GetTemptypeFromAlias(arg_type.GetAlias().c_str());
         UnaryExecutor::Execute<double, string_t>(
             args.data[0], result, count,
             [&](double value) {
@@ -918,7 +918,7 @@ void TemporalFunctions::Tnumber_to_tbox(DataChunk &args, ExpressionState &state,
             });
     } else if (arg_type.id() == LogicalTypeId::INTEGER || arg_type.id() == LogicalTypeId::BIGINT ||
                arg_type.id() == LogicalTypeId::SMALLINT || arg_type.id() == LogicalTypeId::TINYINT) {
-        meosType basetype = TemporalHelpers::GetTemptypeFromAlias(arg_type.GetAlias().c_str());
+        MeosType basetype = TemporalHelpers::GetTemptypeFromAlias(arg_type.GetAlias().c_str());
         UnaryExecutor::Execute<int64_t, string_t>(
             args.data[0], result, count,
             [&](int64_t value) {
@@ -941,7 +941,7 @@ bool TemporalFunctions::Tnumber_to_tbox_cast(Vector &source, Vector &result, idx
             }
         );
     } else if (source.GetType().id() == LogicalTypeId::DOUBLE) {
-        meosType basetype = TemporalHelpers::GetTemptypeFromAlias(source.GetType().GetAlias().c_str());
+        MeosType basetype = TemporalHelpers::GetTemptypeFromAlias(source.GetType().GetAlias().c_str());
         UnaryExecutor::Execute<double, string_t>(
             source, result, count,
             [&](double value) {
@@ -950,7 +950,7 @@ bool TemporalFunctions::Tnumber_to_tbox_cast(Vector &source, Vector &result, idx
         );
     } else if (source.GetType().id() == LogicalTypeId::INTEGER || source.GetType().id() == LogicalTypeId::BIGINT ||
                source.GetType().id() == LogicalTypeId::SMALLINT || source.GetType().id() == LogicalTypeId::TINYINT) {
-        meosType basetype = TemporalHelpers::GetTemptypeFromAlias(source.GetType().GetAlias().c_str());
+        MeosType basetype = TemporalHelpers::GetTemptypeFromAlias(source.GetType().GetAlias().c_str());
         UnaryExecutor::Execute<int64_t, string_t>(
             source, result, count,
             [&](int64_t value) {
@@ -1121,7 +1121,7 @@ void TemporalFunctions::Temporal_valueset(DataChunk &args, ExpressionState &stat
             }
             int32_t count;
             Datum *values = temporal_values_p(temp, &count);
-            meosType basetype = temptype_basetype((meosType)temp->temptype);
+            MeosType basetype = temptype_basetype((MeosType)temp->temptype);
             if (temp->temptype == T_TBOOL) {
                 // TODO: handle tbool
             }
@@ -2416,7 +2416,7 @@ void TemporalFunctions::Temporal_set_interp(DataChunk &args, ExpressionState &st
 
 void TemporalFunctions::Temporal_append_tinstant(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
-    meosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
+    MeosType temptype = TemporalHelpers::GetTemptypeFromAlias(result.GetType().GetAlias().c_str());
     interpType interp = temptype_continuous(temptype) ? LINEAR : STEP;
     if (args.ColumnCount() > 2) {
         auto &interp_child = args.data[2];
@@ -5806,7 +5806,7 @@ DEFINE_TCMP_NUMERIC(Tge, tge)
  ****************************************************/
 
 template <typename T>
-void TemporalFunctions::Temporal_dump_common(DataChunk &args, Vector &result, meosType basetype) {
+void TemporalFunctions::Temporal_dump_common(DataChunk &args, Vector &result, MeosType basetype) {
     auto count = args.size();
     auto &temp_vec = args.data[0];
     UnifiedVectorFormat temp_format;


### PR DESCRIPTION
## Summary

Two cherry-picked commits unblocking local compilation against the current vcpkg MEOS. `make release` on `main` currently fails with `'meosType' does not name a type; did you mean 'MeosType'?` and `too many arguments to function 'Temporal* tcontains_geo_tgeo(...)'` (× 13 call sites); without these patches no parity work builds locally, and only branches that already carry the same fix get green CI.

- `fe4a0da refactor: meosType -> MeosType (sync to upstream MEOS PR #785)` — sweeps every reference of the lowercase `meosType` typedef in MobilityDuck source to the PascalCase `MeosType` that the current MEOS catalog header exposes.
- `cd1d5d2 fix(geo): adapt 12 t{contains,disjoint,intersects,touches,dwithin}_* call sites to 3-arg MEOS API` — the `tcontains_geo_tgeo`, `tdisjoint_*`, `tintersects_*`, `ttouches_*`, `tdwithin_*` exports no longer carry the `restr` / `at_value` trailing arguments (the result is the full tbool; restriction is composed at the call site via `tbool_at_value` when needed). Updates the 12 call sites in `tgeompoint_functions.cpp`.

Both commits originate from the parallel `perf/duck-stack-attempt2` work (`7a8cc22`, `c37b9e2`); cherry-picked onto `main` so they land independently and other in-flight branches stop compiling against a stale API.

## Test plan

- [ ] CI green on `linux_amd64` and `linux_arm64`.
- [ ] No behavioural change — the only places `restr=true` was used are wrapped in a `tbool_at_value(ret, at_value)` post-restriction that produces the same result the dropped MEOS args used to compute internally.
