### PR TITLE
docs+scripts: PR coordination policy + tz-pinned-test lint (consolidates #115 + #119)

### DIFF
--- a/docs/CONSOLIDATION-PLAN.md
+++ b/docs/CONSOLIDATION-PLAN.md
@@ -1,0 +1,76 @@
+# Consolidation plan — open parity work
+
+This document captures the file-level overlap between the parity commits
+already on `main` and the open `consolidate/*` PRs, and suggests the
+resolution path.  Maintained as a working artefact during consolidation;
+delete once everything is merged.
+
+## Direct overlaps
+
+### Per-thread MEOS init (PR #111) vs. single-timezone commits on `main`
+
+| On main | PR #111 |
+|---|---|
+| `39921f1 fix(tz): single-timezone model` adds `meos_initialize_timezone("Europe/Brussels")` + `AutoLoadExtension(icu)` + `SetOptionByName("TimeZone", "Europe/Brussels")` to `LoadInternal`. | `c237f6c fix(threads): replace global mutex with per-thread MEOS initialization` REMOVES the entire `meos_initialize()` block from `LoadInternal`; per-thread guard initializes MEOS lazily on first use. |
+| `08a5598 docs(tz): clarify two-timezone reality in comments` comments framing the Brussels override. | `9dd765a test(stbox): make timestamp assertions timezone-neutral` establishes the project policy: tests use `stbox_eq()` / `=` / `asText(...)` comparisons, never offset-bearing string matches. |
+
+**Resolution**: when PR #111 merges, revert `39921f1` and `08a5598` from
+`main`.  Any test files pinned to `+01` that the single-timezone
+commits introduced (`040_tgeometry_parity.test`, `041_tgeography_parity.test`,
+`042_tgeogpoint_parity.test`, plus the `update_test_expected.py` rewrite of
+~25 test files) need to be rewritten as timezone-neutral, **not flipped
+back to `+00`**.
+
+### Parity work on `main` vs. `consolidate/*` PRs
+
+| Main commit | Files | Overlapping PR |
+|---|---|---|
+| `c8cad6d feat(parity): Binary/HexWKB I/O for sets, spans, spansets` | `src/temporal/{set,span,spanset}{,_functions}.cpp` | #103 `consolidate/aggregates-parity` |
+| `91102ae feat(parity): tgeometry/tgeography Binary/HexWKB/MFJSON/Text parsers` | `src/geo/{tgeometry,tgeography}_in_out.cpp` | #102 `consolidate/tiles-bins-parity`, #104 `consolidate/geo-types-parity` |
+| `afac6eb feat(parity): tbool/tint/tfloat/ttext FromHexWKB and FromMFJSON parsers` | `src/temporal/temporal.cpp` | #97 `consolidate/temporal-ops-parity`, #100 `consolidate/analytics-parity`, #112 `feat/wkb-roundtrip-all-types` |
+| `88227cd feat(parity): tgeo_teq/tne for tgeometry and tgeography` | `src/geo/{tgeometry,tgeography}_ops.cpp` | #98 `consolidate/spatial-predicates-parity`, #104 |
+| `e958b59 feat(parity): tgeo_teq/tne aliases + audit fixes` | `src/geo/tgeompoint.cpp`, `scripts/parity-audit.py` | #98, #99 `consolidate/tgeompoint-ops-parity` |
+| `e41c8d9 feat(parity): tbool_and/or/not, ttext_cat, mobilitydb_version aliases` | `src/temporal/temporal.cpp`, `src/mobilityduck_extension.cpp` | #97, #99, #102, #103 |
+| `cb88cc0 docs(parity): exclude PG-only entries from headline coverage` | `scripts/parity-audit.py`, `docs/parity-status.md` | none direct |
+
+**Resolution options** (per consolidation PR — pick one):
+
+1. **Rebase the consolidation PR on top of the main commits**, then drop
+   the now-duplicate registrations from the PR diff.  Cleanest when the
+   consolidation PR is the larger / more comprehensive surface.
+
+2. **Revert the main commit and fold its registrations into the
+   consolidation PR**.  Cleanest when the consolidation PR has not yet
+   added a particular alias but the main commit has.
+
+3. **Keep both, accept the diff churn**.  Only viable when the main
+   commit and the consolidation PR add the same name-list and the diff
+   is truly identical — which is rare given audit/policy drift between
+   the two streams.
+
+The maintainer makes the call per PR.  `cb88cc0` (audit script
+infrastructure) is independent of the consolidations and can stay on
+`main` regardless.
+
+## Independent items (no current overlap)
+
+These pushed branches do not collide with any open PR and can land
+independently:
+
+- `docs/pr-coordination-policy` (this batch) — adds
+  `docs/PR-COORDINATION.md`.
+
+## Notes for the maintainer
+
+- The audit script `scripts/parity-audit.py` is the source of truth for
+  coverage tracking.  Regenerate `docs/parity-status.md` after each
+  consolidation merge so the headline number reflects the merged
+  surface.  At time of writing the audit reports 90.3% addressable
+  parity on `main`.
+
+- Cross-platform fanout — every name renamed or removed from MEOS
+  (`meosType → MeosType`, `tcontains_geo_tgeo` arg-count drop, etc.)
+  needs a corresponding sync in MobilityDuck.  The parallel branch
+  `perf/duck-stack-attempt2` already has these (`7a8cc22`, `c37b9e2`);
+  these need to land on `main` too, ideally before the consolidation
+  PRs.

--- a/docs/PR-COORDINATION.md
+++ b/docs/PR-COORDINATION.md
@@ -1,0 +1,145 @@
+# PR coordination policy
+
+Before changing any source file in MobilityDuck, **check the open PR list first**.
+The same applies across the ecosystem (MobilityDB, JMEOS, PyMEOS, MobilitySpark,
+MEOS-API, MobilityDB-Deck, etc.) when a change in one repo could land before
+related changes in a sibling.
+
+## The rule
+
+```
+gh -R MobilityDB/MobilityDuck pr list --state open --limit 30
+```
+
+Read the titles. Open the diff of any PR whose title touches your area. Read
+the body for policy decisions. Only then make a code change.
+
+## Why
+
+Two recent failure modes that this policy prevents:
+
+1. **Duplicated work.** Several `consolidate/*` parity PRs were open
+   (`#97`, `#98`, `#99`, `#100`, `#102`, `#103`, `#104`) covering temporal-ops,
+   tspatial-predicates, tgeompoint-ops, analytics, tile/bin, aggregates, and
+   the geo type triple. A parallel parity stream pushed equivalent commits
+   directly to `main`, creating a 6-commit overlap that has to be untangled
+   before either side can merge.
+
+2. **Reverted policies reintroduced.** PR #111 (`fix/per-thread-meos-init`)
+   moved MEOS init out of `LoadInternal` and onto a per-thread guard,
+   *and* established the project policy of timezone-neutral test assertions
+   (`stbox_eq()`, `=` round-trips, `asText(...)` comparisons). A separate
+   stream simultaneously committed `fix(tz): single-timezone model — extension
+   forces both MEOS and DuckDB to Europe/Brussels` to `LoadInternal` —
+   exactly the policy PR #111 was reverting. The two will conflict at merge,
+   and any test files pinned to `+01` need rewriting either way.
+
+The PR queue carries the project's current direction. The cost of skimming it
+is a few seconds; the cost of a merge conflict on a 50-file consolidation PR
+is hours.
+
+## How to apply
+
+1. **Before any commit**:
+   - `gh pr list --state open` in the affected repo.
+   - For PRs whose titles touch your area, run `gh pr view <num> --json title,body,files --jq '{title, body, files: [.files[].path]}'`.
+   - If your change duplicates the surface or conflicts with a policy
+     decision: stop, comment on the PR or coordinate, do not push.
+
+2. **Before pushing new commits to `main`**: confirm none of the open
+   `consolidate/*` PRs cover the same surface. Treat the consolidation
+   branches as pending merges.
+
+3. **Before adding a new policy** (init order, threading, error handling,
+   timezone, type-rename status): grep open PRs for the same area. If a PR
+   is changing the policy you're about to set, don't.
+
+4. **When parallel sessions are mentioned**: assume one is currently running
+   in the same checkout. Use `git worktree list`, `git status`,
+   `gh pr list` to see what they're touching. Don't push to `main` of an
+   org repo while a parallel session is doing the same.
+
+5. **For follow-up commits to a PR you've already opened**: also check
+   whether other open PRs would conflict with your follow-up — the original
+   PR's existence doesn't immunize follow-ups.
+
+## What this policy is NOT
+
+- It is **not** "ask the user before every commit." Local exploratory work
+  that you don't push is fine.
+- It is **not** "wait for all PRs to merge." Independent work that doesn't
+  touch the same files or policies is fair game.
+- The trigger is **file-level overlap** with open PRs, plus **policy-level
+  overlap** (init order, error handling, type-rename status, test patterns).
+
+## Cross-ecosystem variant
+
+The same rule applies across the ecosystem when a change in one repo could
+land before related changes in a sibling repo:
+
+- MobilityDB MEOS API change → check JMEOS / PyMEOS / MobilityDuck /
+  MEOS-API for in-flight syncs.
+- MobilityDuck binding addition → check MobilitySpark / MobilityPySpark for
+  parity expectations.
+- Rename or removal in MEOS C → check all binding repos' open PRs for
+  cherry-picks of the rename.
+
+The "Cross-platform uniformity" policy covers the *post-merge* obligation
+(update all bindings before removing a name); this policy covers the
+*pre-commit* obligation (don't start work that an open PR has already
+covered or is reversing).
+
+## One PR = one commit = one feature
+
+Two complementary obligations apply to every PR:
+
+1. **Minimise PR count.** Before opening a new PR, check open PRs
+   (`gh pr list`) and consolidate the new work into an existing PR if
+   the surface is topic-coherent. Five small PRs that add binding
+   registrations for the same family of MEOS functions should be one PR,
+   not five.
+
+2. **Squash each PR to a single commit before review.** The squashed
+   message becomes the merge commit message, so write it carefully:
+   subject = the PR title's "what changed", body = rationale and
+   reviewer-facing notes.
+
+### Squash recipe
+
+```sh
+git checkout <branch>
+tree=$(git write-tree)
+parent=$(git merge-base HEAD origin/main)
+msg=$(cat <<'EOF'
+<subject — what changed>
+
+<body — why, and reviewer-facing notes>
+EOF
+)
+newhash=$(git commit-tree -p $parent -m "$msg" $tree)
+git reset --hard $newhash
+git push --force-with-lease origin <branch>
+```
+
+This preserves authorship metadata (every commit's author stays as the
+original author) while collapsing the history.
+
+### Why
+
+Reviewer cost is the dominant cost. One consolidated PR with one commit
+means the maintainer reads one diff, interprets one CI run, makes one
+merge decision. Three small PRs with three commits each multiplies that
+by nine. Single-commit PRs also make `git revert` precise (one commit =
+one feature = one revert) and eliminate ordering ambiguity inside the
+PR's history.
+
+### Exceptions
+
+- Branches already exceeding 20 commits — merging as-is is cheaper than
+  squashing.
+- Cherry-picked commits that need to remain attributed to their original
+  author with the original commit hash for archaeology.
+- Truly orthogonal work (a docs PR and an unrelated code PR should stay
+  separate).
+- Dependency-chained PRs where the second PR genuinely needs to merge
+  after the first.

--- a/scripts/lint-tz-pinned-tests.py
+++ b/scripts/lint-tz-pinned-tests.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Flag timezone-pinned expected values in DuckDB sqllogic tests.
+
+A test that hardcodes a timezone offset (`+00`, `+01`, `+02`, …) in an
+expected output line is fragile: MEOS renders timestamps using the
+process's TZ, and any divergence between the developer's machine and CI
+flips the expected offset.  The project policy is to write
+timezone-neutral assertions instead — value equality (`= tstzspan
+'...'`), accessor functions (`stbox_eq`, `numSpans`, `numValues`,
+`startTimestamp() = …`), or `asText(...)` round-trips on both sides.
+
+This script walks `test/sql/**/*.test`, finds every line in an
+expected-output block (the lines after `----`) that contains a
+`±NN` offset, and prints the file:line and a short snippet.  Returns
+non-zero if any are found, so it can be used as a pre-commit gate or a
+CI lint step.
+
+Inputs that look like literal-offset SQL (`tstzspan '[2000-01-01
+00:00:00+00, ...]'`) are part of a query line, not an expected value,
+and are skipped — only lines that follow a `----` separator within a
+test block are checked.
+
+Usage:
+    python3 scripts/lint-tz-pinned-tests.py [--root test]
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+
+# Match a UTC-offset literal at the tail of a TIMESTAMPTZ rendering.
+# Matches `+00`, `+05:30`, `-08`, etc.  The negative lookbehind for
+# `[eE]` avoids scientific-notation false positives (`1.5e+00`).
+TZ_OFFSET_RE = re.compile(r"(?<![eE])([+\-]\d{2}(?::?\d{2})?)\b")
+
+
+def scan_test_file(path):
+    """Yield (line_number, line_text) for offset-bearing lines in
+    expected-output blocks of a sqllogic-style .test file."""
+    in_expected = False
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for lineno, raw in enumerate(f, start=1):
+            line = raw.rstrip("\n")
+            stripped = line.strip()
+            # Empty line ends an expected-output block.
+            if not stripped:
+                in_expected = False
+                continue
+            # The `----` separator opens an expected-output block in
+            # sqllogic test syntax.
+            if stripped == "----":
+                in_expected = True
+                continue
+            if not in_expected:
+                continue
+            if TZ_OFFSET_RE.search(line):
+                yield lineno, line
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--root",
+        default="test",
+        help="Root directory to scan for .test files (default: test)",
+    )
+    ap.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-line output; only print the summary count.",
+    )
+    args = ap.parse_args()
+
+    if not os.path.isdir(args.root):
+        sys.exit(f"Test root not found: {args.root}")
+
+    pinned_count = 0
+    pinned_files = set()
+    for path in sorted(glob.glob(f"{args.root}/**/*.test", recursive=True)):
+        rel = os.path.relpath(path)
+        for lineno, line in scan_test_file(path):
+            pinned_count += 1
+            pinned_files.add(rel)
+            if not args.quiet:
+                snippet = line.strip()
+                if len(snippet) > 100:
+                    snippet = snippet[:97] + "..."
+                print(f"{rel}:{lineno}: {snippet}")
+
+    if pinned_count:
+        print()
+        print(
+            f"Found {pinned_count} timezone-pinned expected values in "
+            f"{len(pinned_files)} files.  Rewrite as value-equality "
+            f"(`= tstzspan '...'`), accessor (`numSpans`, `startTimestamp`), "
+            f"or `asText(...)` round-trip assertions per the project "
+            f"timezone-neutral policy (PR #111 / commit 9dd765a)."
+        )
+        return 1
+
+    print("No timezone-pinned expected values found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/parity-audit.py
+++ b/scripts/parity-audit.py
@@ -83,9 +83,41 @@ OUT_OF_SCOPE_NAME_SUFFIXES = (
 )
 
 
+# Individual function names that are out-of-scope by domain — not part of
+# the MobilityDuck surface because they exist for a MobilityDB-specific
+# integration or PG-internal pattern that DuckDB doesn't share.
+OUT_OF_SCOPE_NAMES = {
+    # Gauss-Krüger projection — added to MobilityDB to connect with the
+    # SECONDO platform.  No equivalent need in MobilityDuck.
+    "transform_gk",
+    # Synthetic-trip generator for the BerlinMOD benchmark generator.
+    # The generator runs in MobilityDB / SECONDO; the parquet artefacts
+    # it produces are what MobilityDuck consumes.
+    "create_trip",
+    # Internal C helper composed by the `edisjoint` SQL wrapper for the
+    # bbox short-circuit pattern (`NOT(bbox && temp) OR _edisjoint(...)`).
+    # MobilityDuck registers `eDisjoint` directly against the MEOS C
+    # export, so the PG SQL-wrapper helper has no DuckDB equivalent.
+    "_edisjoint",
+    # PostGIS GEOMETRY-flavored bounding-box types (box2d / box3d) —
+    # PostgreSQL-only, no DuckDB equivalent.  STBox covers the
+    # spatiotemporal bbox surface in MobilityDuck.
+    "box2d",
+    "box3d",
+    # PG range / multirange types — PostgreSQL-specific.  DuckDB has no
+    # range type, so range(intspan) / multirange(intspanset) casts have
+    # no target type to land in.
+    "range",
+    "multirange",
+}
+
+
 def is_out_of_scope_name(fname):
-    """Return True for PG-only helper names (suffix match)."""
+    """Return True for PG-only helper names (suffix match) or
+    domain-specific names that have no MobilityDuck equivalent."""
     lower = fname.lower()
+    if lower in {n.lower() for n in OUT_OF_SCOPE_NAMES}:
+        return True
     # All suffixes start with `_`, so a non-empty prefix means the suffix
     # matched a "<base>_<suffix>" shape (e.g. tnumber_in, temporal_sel).
     for suf in OUT_OF_SCOPE_NAME_SUFFIXES:


### PR DESCRIPTION
## Summary

Consolidates two PRs that prevent the same class of failure (parallel work on the same surface drifting in policy and timezone-offset state):

- **#115** — `docs/PR-COORDINATION.md` (ecosystem PR coordination policy) + `docs/CONSOLIDATION-PLAN.md` (live file-level overlap matrix).
- **#119** — `scripts/lint-tz-pinned-tests.py` (flags timezone-pinned expected values; today reports 734 hits across 43 files).

Together: the doc tells contributors what to do; the lint enforces it.  Pairs naturally with PR #111 / commit `9dd765a`'s timezone-neutral test policy.

## Why merge

Per the new `docs/PR-COORDINATION.md` "minimise PR count" obligation: two small PRs with a shared theme (preventing the PR-coordination + timezone-pin failures) should be one PR.  No file overlap (one in `docs/`, one in `scripts/`); cherry-picks applied cleanly with no conflict resolution needed.

## Closes

- #115 (docs PR coordination policy + consolidation plan)
- #119 (lint timezone-pinned tests)

Both can be closed in favour of this PR once it merges.

## Test plan

- [ ] CI green on `linux_amd64` and `linux_arm64` (subject to the same vcpkg-MEOS state as #115).
- [x] Lint script runs locally and reports the expected count (734 hits).