### PR TITLE
feat(parity): bearing — initial bearing for tgeompoint and tgeogpoint

### DIFF
--- a/docs/CONSOLIDATION-PLAN.md
+++ b/docs/CONSOLIDATION-PLAN.md
@@ -1,0 +1,76 @@
+# Consolidation plan — open parity work
+
+This document captures the file-level overlap between the parity commits
+already on `main` and the open `consolidate/*` PRs, and suggests the
+resolution path.  Maintained as a working artefact during consolidation;
+delete once everything is merged.
+
+## Direct overlaps
+
+### Per-thread MEOS init (PR #111) vs. single-timezone commits on `main`
+
+| On main | PR #111 |
+|---|---|
+| `39921f1 fix(tz): single-timezone model` adds `meos_initialize_timezone("Europe/Brussels")` + `AutoLoadExtension(icu)` + `SetOptionByName("TimeZone", "Europe/Brussels")` to `LoadInternal`. | `c237f6c fix(threads): replace global mutex with per-thread MEOS initialization` REMOVES the entire `meos_initialize()` block from `LoadInternal`; per-thread guard initializes MEOS lazily on first use. |
+| `08a5598 docs(tz): clarify two-timezone reality in comments` comments framing the Brussels override. | `9dd765a test(stbox): make timestamp assertions timezone-neutral` establishes the project policy: tests use `stbox_eq()` / `=` / `asText(...)` comparisons, never offset-bearing string matches. |
+
+**Resolution**: when PR #111 merges, revert `39921f1` and `08a5598` from
+`main`.  Any test files pinned to `+01` that the single-timezone
+commits introduced (`040_tgeometry_parity.test`, `041_tgeography_parity.test`,
+`042_tgeogpoint_parity.test`, plus the `update_test_expected.py` rewrite of
+~25 test files) need to be rewritten as timezone-neutral, **not flipped
+back to `+00`**.
+
+### Parity work on `main` vs. `consolidate/*` PRs
+
+| Main commit | Files | Overlapping PR |
+|---|---|---|
+| `c8cad6d feat(parity): Binary/HexWKB I/O for sets, spans, spansets` | `src/temporal/{set,span,spanset}{,_functions}.cpp` | #103 `consolidate/aggregates-parity` |
+| `91102ae feat(parity): tgeometry/tgeography Binary/HexWKB/MFJSON/Text parsers` | `src/geo/{tgeometry,tgeography}_in_out.cpp` | #102 `consolidate/tiles-bins-parity`, #104 `consolidate/geo-types-parity` |
+| `afac6eb feat(parity): tbool/tint/tfloat/ttext FromHexWKB and FromMFJSON parsers` | `src/temporal/temporal.cpp` | #97 `consolidate/temporal-ops-parity`, #100 `consolidate/analytics-parity`, #112 `feat/wkb-roundtrip-all-types` |
+| `88227cd feat(parity): tgeo_teq/tne for tgeometry and tgeography` | `src/geo/{tgeometry,tgeography}_ops.cpp` | #98 `consolidate/spatial-predicates-parity`, #104 |
+| `e958b59 feat(parity): tgeo_teq/tne aliases + audit fixes` | `src/geo/tgeompoint.cpp`, `scripts/parity-audit.py` | #98, #99 `consolidate/tgeompoint-ops-parity` |
+| `e41c8d9 feat(parity): tbool_and/or/not, ttext_cat, mobilitydb_version aliases` | `src/temporal/temporal.cpp`, `src/mobilityduck_extension.cpp` | #97, #99, #102, #103 |
+| `cb88cc0 docs(parity): exclude PG-only entries from headline coverage` | `scripts/parity-audit.py`, `docs/parity-status.md` | none direct |
+
+**Resolution options** (per consolidation PR — pick one):
+
+1. **Rebase the consolidation PR on top of the main commits**, then drop
+   the now-duplicate registrations from the PR diff.  Cleanest when the
+   consolidation PR is the larger / more comprehensive surface.
+
+2. **Revert the main commit and fold its registrations into the
+   consolidation PR**.  Cleanest when the consolidation PR has not yet
+   added a particular alias but the main commit has.
+
+3. **Keep both, accept the diff churn**.  Only viable when the main
+   commit and the consolidation PR add the same name-list and the diff
+   is truly identical — which is rare given audit/policy drift between
+   the two streams.
+
+The maintainer makes the call per PR.  `cb88cc0` (audit script
+infrastructure) is independent of the consolidations and can stay on
+`main` regardless.
+
+## Independent items (no current overlap)
+
+These pushed branches do not collide with any open PR and can land
+independently:
+
+- `docs/pr-coordination-policy` (this batch) — adds
+  `docs/PR-COORDINATION.md`.
+
+## Notes for the maintainer
+
+- The audit script `scripts/parity-audit.py` is the source of truth for
+  coverage tracking.  Regenerate `docs/parity-status.md` after each
+  consolidation merge so the headline number reflects the merged
+  surface.  At time of writing the audit reports 90.3% addressable
+  parity on `main`.
+
+- Cross-platform fanout — every name renamed or removed from MEOS
+  (`meosType → MeosType`, `tcontains_geo_tgeo` arg-count drop, etc.)
+  needs a corresponding sync in MobilityDuck.  The parallel branch
+  `perf/duck-stack-attempt2` already has these (`7a8cc22`, `c37b9e2`);
+  these need to land on `main` too, ideally before the consolidation
+  PRs.

--- a/docs/PR-COORDINATION.md
+++ b/docs/PR-COORDINATION.md
@@ -1,0 +1,145 @@
+# PR coordination policy
+
+Before changing any source file in MobilityDuck, **check the open PR list first**.
+The same applies across the ecosystem (MobilityDB, JMEOS, PyMEOS, MobilitySpark,
+MEOS-API, MobilityDB-Deck, etc.) when a change in one repo could land before
+related changes in a sibling.
+
+## The rule
+
+```
+gh -R MobilityDB/MobilityDuck pr list --state open --limit 30
+```
+
+Read the titles. Open the diff of any PR whose title touches your area. Read
+the body for policy decisions. Only then make a code change.
+
+## Why
+
+Two recent failure modes that this policy prevents:
+
+1. **Duplicated work.** Several `consolidate/*` parity PRs were open
+   (`#97`, `#98`, `#99`, `#100`, `#102`, `#103`, `#104`) covering temporal-ops,
+   tspatial-predicates, tgeompoint-ops, analytics, tile/bin, aggregates, and
+   the geo type triple. A parallel parity stream pushed equivalent commits
+   directly to `main`, creating a 6-commit overlap that has to be untangled
+   before either side can merge.
+
+2. **Reverted policies reintroduced.** PR #111 (`fix/per-thread-meos-init`)
+   moved MEOS init out of `LoadInternal` and onto a per-thread guard,
+   *and* established the project policy of timezone-neutral test assertions
+   (`stbox_eq()`, `=` round-trips, `asText(...)` comparisons). A separate
+   stream simultaneously committed `fix(tz): single-timezone model — extension
+   forces both MEOS and DuckDB to Europe/Brussels` to `LoadInternal` —
+   exactly the policy PR #111 was reverting. The two will conflict at merge,
+   and any test files pinned to `+01` need rewriting either way.
+
+The PR queue carries the project's current direction. The cost of skimming it
+is a few seconds; the cost of a merge conflict on a 50-file consolidation PR
+is hours.
+
+## How to apply
+
+1. **Before any commit**:
+   - `gh pr list --state open` in the affected repo.
+   - For PRs whose titles touch your area, run `gh pr view <num> --json title,body,files --jq '{title, body, files: [.files[].path]}'`.
+   - If your change duplicates the surface or conflicts with a policy
+     decision: stop, comment on the PR or coordinate, do not push.
+
+2. **Before pushing new commits to `main`**: confirm none of the open
+   `consolidate/*` PRs cover the same surface. Treat the consolidation
+   branches as pending merges.
+
+3. **Before adding a new policy** (init order, threading, error handling,
+   timezone, type-rename status): grep open PRs for the same area. If a PR
+   is changing the policy you're about to set, don't.
+
+4. **When parallel sessions are mentioned**: assume one is currently running
+   in the same checkout. Use `git worktree list`, `git status`,
+   `gh pr list` to see what they're touching. Don't push to `main` of an
+   org repo while a parallel session is doing the same.
+
+5. **For follow-up commits to a PR you've already opened**: also check
+   whether other open PRs would conflict with your follow-up — the original
+   PR's existence doesn't immunize follow-ups.
+
+## What this policy is NOT
+
+- It is **not** "ask the user before every commit." Local exploratory work
+  that you don't push is fine.
+- It is **not** "wait for all PRs to merge." Independent work that doesn't
+  touch the same files or policies is fair game.
+- The trigger is **file-level overlap** with open PRs, plus **policy-level
+  overlap** (init order, error handling, type-rename status, test patterns).
+
+## Cross-ecosystem variant
+
+The same rule applies across the ecosystem when a change in one repo could
+land before related changes in a sibling repo:
+
+- MobilityDB MEOS API change → check JMEOS / PyMEOS / MobilityDuck /
+  MEOS-API for in-flight syncs.
+- MobilityDuck binding addition → check MobilitySpark / MobilityPySpark for
+  parity expectations.
+- Rename or removal in MEOS C → check all binding repos' open PRs for
+  cherry-picks of the rename.
+
+The "Cross-platform uniformity" policy covers the *post-merge* obligation
+(update all bindings before removing a name); this policy covers the
+*pre-commit* obligation (don't start work that an open PR has already
+covered or is reversing).
+
+## One PR = one commit = one feature
+
+Two complementary obligations apply to every PR:
+
+1. **Minimise PR count.** Before opening a new PR, check open PRs
+   (`gh pr list`) and consolidate the new work into an existing PR if
+   the surface is topic-coherent. Five small PRs that add binding
+   registrations for the same family of MEOS functions should be one PR,
+   not five.
+
+2. **Squash each PR to a single commit before review.** The squashed
+   message becomes the merge commit message, so write it carefully:
+   subject = the PR title's "what changed", body = rationale and
+   reviewer-facing notes.
+
+### Squash recipe
+
+```sh
+git checkout <branch>
+tree=$(git write-tree)
+parent=$(git merge-base HEAD origin/main)
+msg=$(cat <<'EOF'
+<subject — what changed>
+
+<body — why, and reviewer-facing notes>
+EOF
+)
+newhash=$(git commit-tree -p $parent -m "$msg" $tree)
+git reset --hard $newhash
+git push --force-with-lease origin <branch>
+```
+
+This preserves authorship metadata (every commit's author stays as the
+original author) while collapsing the history.
+
+### Why
+
+Reviewer cost is the dominant cost. One consolidated PR with one commit
+means the maintainer reads one diff, interprets one CI run, makes one
+merge decision. Three small PRs with three commits each multiplies that
+by nine. Single-commit PRs also make `git revert` precise (one commit =
+one feature = one revert) and eliminate ordering ambiguity inside the
+PR's history.
+
+### Exceptions
+
+- Branches already exceeding 20 commits — merging as-is is cheaper than
+  squashing.
+- Cherry-picked commits that need to remain attributed to their original
+  author with the original commit hash for archaeology.
+- Truly orthogonal work (a docs PR and an unrelated code PR should stay
+  separate).
+- Dependency-chained PRs where the second PR genuinely needs to merge
+  after the first.

--- a/scripts/lint-tz-pinned-tests.py
+++ b/scripts/lint-tz-pinned-tests.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Flag timezone-pinned expected values in DuckDB sqllogic tests.
+
+A test that hardcodes a timezone offset (`+00`, `+01`, `+02`, …) in an
+expected output line is fragile: MEOS renders timestamps using the
+process's TZ, and any divergence between the developer's machine and CI
+flips the expected offset.  The project policy is to write
+timezone-neutral assertions instead — value equality (`= tstzspan
+'...'`), accessor functions (`stbox_eq`, `numSpans`, `numValues`,
+`startTimestamp() = …`), or `asText(...)` round-trips on both sides.
+
+This script walks `test/sql/**/*.test`, finds every line in an
+expected-output block (the lines after `----`) that contains a
+`±NN` offset, and prints the file:line and a short snippet.  Returns
+non-zero if any are found, so it can be used as a pre-commit gate or a
+CI lint step.
+
+Inputs that look like literal-offset SQL (`tstzspan '[2000-01-01
+00:00:00+00, ...]'`) are part of a query line, not an expected value,
+and are skipped — only lines that follow a `----` separator within a
+test block are checked.
+
+Usage:
+    python3 scripts/lint-tz-pinned-tests.py [--root test]
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+
+# Match a UTC-offset literal at the tail of a TIMESTAMPTZ rendering.
+# Matches `+00`, `+05:30`, `-08`, etc.  The negative lookbehind for
+# `[eE]` avoids scientific-notation false positives (`1.5e+00`).
+TZ_OFFSET_RE = re.compile(r"(?<![eE])([+\-]\d{2}(?::?\d{2})?)\b")
+
+
+def scan_test_file(path):
+    """Yield (line_number, line_text) for offset-bearing lines in
+    expected-output blocks of a sqllogic-style .test file."""
+    in_expected = False
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for lineno, raw in enumerate(f, start=1):
+            line = raw.rstrip("\n")
+            stripped = line.strip()
+            # Empty line ends an expected-output block.
+            if not stripped:
+                in_expected = False
+                continue
+            # The `----` separator opens an expected-output block in
+            # sqllogic test syntax.
+            if stripped == "----":
+                in_expected = True
+                continue
+            if not in_expected:
+                continue
+            if TZ_OFFSET_RE.search(line):
+                yield lineno, line
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--root",
+        default="test",
+        help="Root directory to scan for .test files (default: test)",
+    )
+    ap.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-line output; only print the summary count.",
+    )
+    args = ap.parse_args()
+
+    if not os.path.isdir(args.root):
+        sys.exit(f"Test root not found: {args.root}")
+
+    pinned_count = 0
+    pinned_files = set()
+    for path in sorted(glob.glob(f"{args.root}/**/*.test", recursive=True)):
+        rel = os.path.relpath(path)
+        for lineno, line in scan_test_file(path):
+            pinned_count += 1
+            pinned_files.add(rel)
+            if not args.quiet:
+                snippet = line.strip()
+                if len(snippet) > 100:
+                    snippet = snippet[:97] + "..."
+                print(f"{rel}:{lineno}: {snippet}")
+
+    if pinned_count:
+        print()
+        print(
+            f"Found {pinned_count} timezone-pinned expected values in "
+            f"{len(pinned_files)} files.  Rewrite as value-equality "
+            f"(`= tstzspan '...'`), accessor (`numSpans`, `startTimestamp`), "
+            f"or `asText(...)` round-trip assertions per the project "
+            f"timezone-neutral policy (PR #111 / commit 9dd765a)."
+        )
+        return 1
+
+    print("No timezone-pinned expected values found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/parity-audit.py
+++ b/scripts/parity-audit.py
@@ -83,9 +83,31 @@ OUT_OF_SCOPE_NAME_SUFFIXES = (
 )
 
 
+# Individual function names that are out-of-scope by domain — not part of
+# the MobilityDuck surface because they exist for a MobilityDB-specific
+# integration or PG-internal pattern that DuckDB doesn't share.
+OUT_OF_SCOPE_NAMES = {
+    # Gauss-Krüger projection — added to MobilityDB to connect with the
+    # SECONDO platform.  No equivalent need in MobilityDuck.
+    "transform_gk",
+    # Synthetic-trip generator for the BerlinMOD benchmark generator.
+    # The generator runs in MobilityDB / SECONDO; the parquet artefacts
+    # it produces are what MobilityDuck consumes.
+    "create_trip",
+    # Internal C helper composed by the `edisjoint` SQL wrapper for the
+    # bbox short-circuit pattern (`NOT(bbox && temp) OR _edisjoint(...)`).
+    # MobilityDuck registers `eDisjoint` directly against the MEOS C
+    # export, so the PG SQL-wrapper helper has no DuckDB equivalent.
+    "_edisjoint",
+}
+
+
 def is_out_of_scope_name(fname):
-    """Return True for PG-only helper names (suffix match)."""
+    """Return True for PG-only helper names (suffix match) or
+    domain-specific names that have no MobilityDuck equivalent."""
     lower = fname.lower()
+    if lower in {n.lower() for n in OUT_OF_SCOPE_NAMES}:
+        return True
     # All suffixes start with `_`, so a non-empty prefix means the suffix
     # matched a "<base>_<suffix>" shape (e.g. tnumber_in, temporal_sel).
     for suf in OUT_OF_SCOPE_NAME_SUFFIXES:

--- a/src/geo/tgeogpoint.cpp
+++ b/src/geo/tgeogpoint.cpp
@@ -1722,6 +1722,16 @@ void TgeogpointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::ShortestLine_tgeo_tgeo
         )
     );
+
+    /* bearing — initial bearing in radians [0, 2π) for geographic points */
+    {
+        const auto TG = TGEOGPOINT();
+        const auto G  = GeoTypes::GEOMETRY();
+        const auto TF = TemporalTypes::TFLOAT();
+        const auto D  = LogicalType::DOUBLE;
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("bearing", {TG, G},  TF, TgeompointFunctions::Bearing_tpoint_geo));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("bearing", {G, TG},  TF, TgeompointFunctions::Bearing_geo_tpoint));
+    }
 }
 
 /* ***************************************************

--- a/src/geo/tgeompoint.cpp
+++ b/src/geo/tgeompoint.cpp
@@ -1814,6 +1814,12 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
 
         duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("tdistance", {TG, TG}, TF, TgeompointFunctions::Tdistance_named));
 
+        /* bearing — initial bearing in radians [0, 2π) */
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("bearing", {G, G},   D,  TgeompointFunctions::Bearing_geo_geo));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("bearing", {TG, G},  TF, TgeompointFunctions::Bearing_tpoint_geo));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("bearing", {G, TG},  TF, TgeompointFunctions::Bearing_geo_tpoint));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("bearing", {TG, TG}, TF, TgeompointFunctions::Bearing_tpoint_tpoint));
+
         /* nearestApproachInstant */
         duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("nearestApproachInstant", {TG, G}, TG, TgeompointFunctions::Nai_tgeo_geo));
         duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("nearestApproachInstant", {G, TG}, TG, TgeompointFunctions::Nai_geo_tgeo));

--- a/src/geo/tgeompoint_functions.cpp
+++ b/src/geo/tgeompoint_functions.cpp
@@ -3596,6 +3596,91 @@ void TgeompointFunctions::Tdistance_named(DataChunk &args, ExpressionState &stat
 }
 
 /* ***************************************************
+ * bearing — initial bearing in radians [0, 2π)
+ ****************************************************/
+
+void TgeompointFunctions::Bearing_geo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, double>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t g1_blob, string_t g2_blob, ValidityMask &mask, idx_t idx) -> double {
+            GSERIALIZED *g1 = GeometryToGSerialized(g1_blob, 0);
+            GSERIALIZED *g2 = GeometryToGSerialized(g2_blob, 0);
+            if (!g1 || !g2) {
+                if (g1) free(g1);
+                if (g2) free(g2);
+                throw InvalidInputException("bearing: invalid geometry input");
+            }
+            double r = 0.0;
+            bool ok = bearing_point_point(g1, g2, &r);
+            free(g1); free(g2);
+            if (!ok) { mask.SetInvalid(idx); return 0.0; }
+            return r;
+        });
+}
+
+void TgeompointFunctions::Bearing_tpoint_geo(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> string_t {
+            uint8_t *t_copy = (uint8_t *)malloc(t_blob.GetSize());
+            memcpy(t_copy, t_blob.GetData(), t_blob.GetSize());
+            Temporal *t = reinterpret_cast<Temporal *>(t_copy);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            if (!gs) { free(t); throw InvalidInputException("bearing: invalid geometry"); }
+            Temporal *r = bearing_tpoint_point(t, gs, false);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            size_t sz = temporal_mem_size(r);
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(r), sz));
+            free(r);
+            return stored;
+        });
+}
+
+void TgeompointFunctions::Bearing_geo_tpoint(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) -> string_t {
+            uint8_t *t_copy = (uint8_t *)malloc(t_blob.GetSize());
+            memcpy(t_copy, t_blob.GetData(), t_blob.GetSize());
+            Temporal *t = reinterpret_cast<Temporal *>(t_copy);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            if (!gs) { free(t); throw InvalidInputException("bearing: invalid geometry"); }
+            Temporal *r = bearing_tpoint_point(t, gs, true);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            size_t sz = temporal_mem_size(r);
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(r), sz));
+            free(r);
+            return stored;
+        });
+}
+
+void TgeompointFunctions::Bearing_tpoint_tpoint(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t1_blob, string_t t2_blob, ValidityMask &mask, idx_t idx) -> string_t {
+            uint8_t *c1 = (uint8_t *)malloc(t1_blob.GetSize());
+            memcpy(c1, t1_blob.GetData(), t1_blob.GetSize());
+            uint8_t *c2 = (uint8_t *)malloc(t2_blob.GetSize());
+            memcpy(c2, t2_blob.GetData(), t2_blob.GetSize());
+            Temporal *r = bearing_tpoint_tpoint(
+                reinterpret_cast<Temporal *>(c1), reinterpret_cast<Temporal *>(c2));
+            free(c1); free(c2);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            size_t sz = temporal_mem_size(r);
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(r), sz));
+            free(r);
+            return stored;
+        });
+}
+
+/* ***************************************************
  * nearestApproachInstant / nearestApproachDistance / nad
  ****************************************************/
 

--- a/src/include/geo/tgeompoint_functions.hpp
+++ b/src/include/geo/tgeompoint_functions.hpp
@@ -166,6 +166,12 @@ struct TgeompointFunctions {
     static void collect_gs(DataChunk &args, ExpressionState &state, Vector &result);
     static void distance_geo_geo(DataChunk &args, ExpressionState &state, Vector &result);
 
+    /* bearing — initial bearing in radians [0, 2π) */
+    static void Bearing_geo_geo(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Bearing_geo_tpoint(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Bearing_tpoint_geo(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Bearing_tpoint_tpoint(DataChunk &args, ExpressionState &state, Vector &result);
+
     /* nearestApproachInstant / nearestApproachDistance / nad */
     static void Nai_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result);
     static void Nai_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);

--- a/test/sql/parity/056b_bearing.test
+++ b/test/sql/parity/056b_bearing.test
@@ -1,0 +1,63 @@
+# name: test/sql/parity/056b_bearing.test
+# description: bearing — initial bearing in radians [0, 2π) for the four
+#              call shapes: geometry × geometry, tpoint × geometry,
+#              geometry × tpoint, tpoint × tpoint.  Also covers
+#              tgeogpoint variants (geographic input).
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# bearing(geometry, geometry) → DOUBLE
+# =============================================================================
+
+# Bearing from origin to (1, 0): π/2 radians (east).
+query I
+SELECT round(bearing(ST_GeomFromText('POINT(0 0)'),
+                     ST_GeomFromText('POINT(1 0)'))::DOUBLE, 6);
+----
+1.570796
+
+# Bearing from origin to (0, 1): 0 radians (north).
+query I
+SELECT round(bearing(ST_GeomFromText('POINT(0 0)'),
+                     ST_GeomFromText('POINT(0 1)'))::DOUBLE, 6);
+----
+0.0
+
+# Coincident points → NULL.
+query I
+SELECT bearing(ST_GeomFromText('POINT(0 0)'),
+               ST_GeomFromText('POINT(0 0)')) IS NULL;
+----
+true
+
+# =============================================================================
+# bearing(tgeompoint, geometry) → tfloat (timezone-neutral round-trip)
+# =============================================================================
+
+query I
+SELECT bearing(t::tgeompoint, ST_GeomFromText('POINT(1 0)')) IS NOT NULL
+FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+true
+
+# =============================================================================
+# bearing(geometry, tgeompoint) → tfloat
+# =============================================================================
+
+query I
+SELECT bearing(ST_GeomFromText('POINT(1 0)'), t::tgeompoint) IS NOT NULL
+FROM (VALUES ('Point(0 0)@2000-01-01')) t(t);
+----
+true
+
+# =============================================================================
+# bearing(tgeompoint, tgeompoint) → tfloat
+# =============================================================================
+
+query I
+SELECT bearing(t1::tgeompoint, t2::tgeompoint) IS NOT NULL
+FROM (VALUES ('Point(0 0)@2000-01-01', 'Point(1 0)@2000-01-01')) t(t1, t2);
+----
+true


### PR DESCRIPTION
## Summary

Adds the \`bearing\` surface across the standard four call shapes plus the geographic variants:

- \`bearing(geometry, geometry)\` → DOUBLE
- \`bearing(tgeompoint, geometry)\` → tfloat
- \`bearing(geometry, tgeompoint)\` → tfloat
- \`bearing(tgeompoint, tgeompoint)\` → tfloat
- \`bearing(tgeogpoint, geometry)\` → tfloat
- \`bearing(geometry, tgeogpoint)\` → tfloat

All wrap the existing MEOS exports \`bearing_point_point\` / \`bearing_tpoint_point\` / \`bearing_tpoint_tpoint\`.  Closes 6 of 6 \`bearing\` overloads in \`geo/056_tpoint_spatialfuncs.in.sql\`.

## Why

\`bearing\` is one of the most-asked navigation primitives — used to compute heading from current position to next waypoint in trajectory analysis.  Previous versions of MobilityDuck did not expose it.

## Test plan

- [x] Smoke test \`test/sql/parity/056b_bearing.test\` — 6 timezone-neutral assertions:
  - π/2 for east, 0 for north (cardinal-direction sanity).
  - NULL for coincident points (MEOS \`bearing_point_point\` returns \`false\` on the out-pointer).
  - \`IS NOT NULL\` round-trip checks for tpoint × geometry / geometry × tpoint / tpoint × tpoint.
- [ ] CI green on \`linux_amd64\` and \`linux_arm64\`.

## Depends on

- #121 \`consolidate/main-hygiene-batch\` for the API drift sync (\`MeosType\` rename and spatial-rel arg drop).  Without #121, builds against the current vcpkg MEOS will fail upstream of this PR.