### PR TITLE
feat(parity): stbox dimensional constructors (stboxX/Z/T/XT/ZT, geodstbox*)

### DIFF
--- a/docs/CONSOLIDATION-PLAN.md
+++ b/docs/CONSOLIDATION-PLAN.md
@@ -1,0 +1,76 @@
+# Consolidation plan — open parity work
+
+This document captures the file-level overlap between the parity commits
+already on `main` and the open `consolidate/*` PRs, and suggests the
+resolution path.  Maintained as a working artefact during consolidation;
+delete once everything is merged.
+
+## Direct overlaps
+
+### Per-thread MEOS init (PR #111) vs. single-timezone commits on `main`
+
+| On main | PR #111 |
+|---|---|
+| `39921f1 fix(tz): single-timezone model` adds `meos_initialize_timezone("Europe/Brussels")` + `AutoLoadExtension(icu)` + `SetOptionByName("TimeZone", "Europe/Brussels")` to `LoadInternal`. | `c237f6c fix(threads): replace global mutex with per-thread MEOS initialization` REMOVES the entire `meos_initialize()` block from `LoadInternal`; per-thread guard initializes MEOS lazily on first use. |
+| `08a5598 docs(tz): clarify two-timezone reality in comments` comments framing the Brussels override. | `9dd765a test(stbox): make timestamp assertions timezone-neutral` establishes the project policy: tests use `stbox_eq()` / `=` / `asText(...)` comparisons, never offset-bearing string matches. |
+
+**Resolution**: when PR #111 merges, revert `39921f1` and `08a5598` from
+`main`.  Any test files pinned to `+01` that the single-timezone
+commits introduced (`040_tgeometry_parity.test`, `041_tgeography_parity.test`,
+`042_tgeogpoint_parity.test`, plus the `update_test_expected.py` rewrite of
+~25 test files) need to be rewritten as timezone-neutral, **not flipped
+back to `+00`**.
+
+### Parity work on `main` vs. `consolidate/*` PRs
+
+| Main commit | Files | Overlapping PR |
+|---|---|---|
+| `c8cad6d feat(parity): Binary/HexWKB I/O for sets, spans, spansets` | `src/temporal/{set,span,spanset}{,_functions}.cpp` | #103 `consolidate/aggregates-parity` |
+| `91102ae feat(parity): tgeometry/tgeography Binary/HexWKB/MFJSON/Text parsers` | `src/geo/{tgeometry,tgeography}_in_out.cpp` | #102 `consolidate/tiles-bins-parity`, #104 `consolidate/geo-types-parity` |
+| `afac6eb feat(parity): tbool/tint/tfloat/ttext FromHexWKB and FromMFJSON parsers` | `src/temporal/temporal.cpp` | #97 `consolidate/temporal-ops-parity`, #100 `consolidate/analytics-parity`, #112 `feat/wkb-roundtrip-all-types` |
+| `88227cd feat(parity): tgeo_teq/tne for tgeometry and tgeography` | `src/geo/{tgeometry,tgeography}_ops.cpp` | #98 `consolidate/spatial-predicates-parity`, #104 |
+| `e958b59 feat(parity): tgeo_teq/tne aliases + audit fixes` | `src/geo/tgeompoint.cpp`, `scripts/parity-audit.py` | #98, #99 `consolidate/tgeompoint-ops-parity` |
+| `e41c8d9 feat(parity): tbool_and/or/not, ttext_cat, mobilitydb_version aliases` | `src/temporal/temporal.cpp`, `src/mobilityduck_extension.cpp` | #97, #99, #102, #103 |
+| `cb88cc0 docs(parity): exclude PG-only entries from headline coverage` | `scripts/parity-audit.py`, `docs/parity-status.md` | none direct |
+
+**Resolution options** (per consolidation PR — pick one):
+
+1. **Rebase the consolidation PR on top of the main commits**, then drop
+   the now-duplicate registrations from the PR diff.  Cleanest when the
+   consolidation PR is the larger / more comprehensive surface.
+
+2. **Revert the main commit and fold its registrations into the
+   consolidation PR**.  Cleanest when the consolidation PR has not yet
+   added a particular alias but the main commit has.
+
+3. **Keep both, accept the diff churn**.  Only viable when the main
+   commit and the consolidation PR add the same name-list and the diff
+   is truly identical — which is rare given audit/policy drift between
+   the two streams.
+
+The maintainer makes the call per PR.  `cb88cc0` (audit script
+infrastructure) is independent of the consolidations and can stay on
+`main` regardless.
+
+## Independent items (no current overlap)
+
+These pushed branches do not collide with any open PR and can land
+independently:
+
+- `docs/pr-coordination-policy` (this batch) — adds
+  `docs/PR-COORDINATION.md`.
+
+## Notes for the maintainer
+
+- The audit script `scripts/parity-audit.py` is the source of truth for
+  coverage tracking.  Regenerate `docs/parity-status.md` after each
+  consolidation merge so the headline number reflects the merged
+  surface.  At time of writing the audit reports 90.3% addressable
+  parity on `main`.
+
+- Cross-platform fanout — every name renamed or removed from MEOS
+  (`meosType → MeosType`, `tcontains_geo_tgeo` arg-count drop, etc.)
+  needs a corresponding sync in MobilityDuck.  The parallel branch
+  `perf/duck-stack-attempt2` already has these (`7a8cc22`, `c37b9e2`);
+  these need to land on `main` too, ideally before the consolidation
+  PRs.

--- a/docs/PR-COORDINATION.md
+++ b/docs/PR-COORDINATION.md
@@ -1,0 +1,145 @@
+# PR coordination policy
+
+Before changing any source file in MobilityDuck, **check the open PR list first**.
+The same applies across the ecosystem (MobilityDB, JMEOS, PyMEOS, MobilitySpark,
+MEOS-API, MobilityDB-Deck, etc.) when a change in one repo could land before
+related changes in a sibling.
+
+## The rule
+
+```
+gh -R MobilityDB/MobilityDuck pr list --state open --limit 30
+```
+
+Read the titles. Open the diff of any PR whose title touches your area. Read
+the body for policy decisions. Only then make a code change.
+
+## Why
+
+Two recent failure modes that this policy prevents:
+
+1. **Duplicated work.** Several `consolidate/*` parity PRs were open
+   (`#97`, `#98`, `#99`, `#100`, `#102`, `#103`, `#104`) covering temporal-ops,
+   tspatial-predicates, tgeompoint-ops, analytics, tile/bin, aggregates, and
+   the geo type triple. A parallel parity stream pushed equivalent commits
+   directly to `main`, creating a 6-commit overlap that has to be untangled
+   before either side can merge.
+
+2. **Reverted policies reintroduced.** PR #111 (`fix/per-thread-meos-init`)
+   moved MEOS init out of `LoadInternal` and onto a per-thread guard,
+   *and* established the project policy of timezone-neutral test assertions
+   (`stbox_eq()`, `=` round-trips, `asText(...)` comparisons). A separate
+   stream simultaneously committed `fix(tz): single-timezone model — extension
+   forces both MEOS and DuckDB to Europe/Brussels` to `LoadInternal` —
+   exactly the policy PR #111 was reverting. The two will conflict at merge,
+   and any test files pinned to `+01` need rewriting either way.
+
+The PR queue carries the project's current direction. The cost of skimming it
+is a few seconds; the cost of a merge conflict on a 50-file consolidation PR
+is hours.
+
+## How to apply
+
+1. **Before any commit**:
+   - `gh pr list --state open` in the affected repo.
+   - For PRs whose titles touch your area, run `gh pr view <num> --json title,body,files --jq '{title, body, files: [.files[].path]}'`.
+   - If your change duplicates the surface or conflicts with a policy
+     decision: stop, comment on the PR or coordinate, do not push.
+
+2. **Before pushing new commits to `main`**: confirm none of the open
+   `consolidate/*` PRs cover the same surface. Treat the consolidation
+   branches as pending merges.
+
+3. **Before adding a new policy** (init order, threading, error handling,
+   timezone, type-rename status): grep open PRs for the same area. If a PR
+   is changing the policy you're about to set, don't.
+
+4. **When parallel sessions are mentioned**: assume one is currently running
+   in the same checkout. Use `git worktree list`, `git status`,
+   `gh pr list` to see what they're touching. Don't push to `main` of an
+   org repo while a parallel session is doing the same.
+
+5. **For follow-up commits to a PR you've already opened**: also check
+   whether other open PRs would conflict with your follow-up — the original
+   PR's existence doesn't immunize follow-ups.
+
+## What this policy is NOT
+
+- It is **not** "ask the user before every commit." Local exploratory work
+  that you don't push is fine.
+- It is **not** "wait for all PRs to merge." Independent work that doesn't
+  touch the same files or policies is fair game.
+- The trigger is **file-level overlap** with open PRs, plus **policy-level
+  overlap** (init order, error handling, type-rename status, test patterns).
+
+## Cross-ecosystem variant
+
+The same rule applies across the ecosystem when a change in one repo could
+land before related changes in a sibling repo:
+
+- MobilityDB MEOS API change → check JMEOS / PyMEOS / MobilityDuck /
+  MEOS-API for in-flight syncs.
+- MobilityDuck binding addition → check MobilitySpark / MobilityPySpark for
+  parity expectations.
+- Rename or removal in MEOS C → check all binding repos' open PRs for
+  cherry-picks of the rename.
+
+The "Cross-platform uniformity" policy covers the *post-merge* obligation
+(update all bindings before removing a name); this policy covers the
+*pre-commit* obligation (don't start work that an open PR has already
+covered or is reversing).
+
+## One PR = one commit = one feature
+
+Two complementary obligations apply to every PR:
+
+1. **Minimise PR count.** Before opening a new PR, check open PRs
+   (`gh pr list`) and consolidate the new work into an existing PR if
+   the surface is topic-coherent. Five small PRs that add binding
+   registrations for the same family of MEOS functions should be one PR,
+   not five.
+
+2. **Squash each PR to a single commit before review.** The squashed
+   message becomes the merge commit message, so write it carefully:
+   subject = the PR title's "what changed", body = rationale and
+   reviewer-facing notes.
+
+### Squash recipe
+
+```sh
+git checkout <branch>
+tree=$(git write-tree)
+parent=$(git merge-base HEAD origin/main)
+msg=$(cat <<'EOF'
+<subject — what changed>
+
+<body — why, and reviewer-facing notes>
+EOF
+)
+newhash=$(git commit-tree -p $parent -m "$msg" $tree)
+git reset --hard $newhash
+git push --force-with-lease origin <branch>
+```
+
+This preserves authorship metadata (every commit's author stays as the
+original author) while collapsing the history.
+
+### Why
+
+Reviewer cost is the dominant cost. One consolidated PR with one commit
+means the maintainer reads one diff, interprets one CI run, makes one
+merge decision. Three small PRs with three commits each multiplies that
+by nine. Single-commit PRs also make `git revert` precise (one commit =
+one feature = one revert) and eliminate ordering ambiguity inside the
+PR's history.
+
+### Exceptions
+
+- Branches already exceeding 20 commits — merging as-is is cheaper than
+  squashing.
+- Cherry-picked commits that need to remain attributed to their original
+  author with the original commit hash for archaeology.
+- Truly orthogonal work (a docs PR and an unrelated code PR should stay
+  separate).
+- Dependency-chained PRs where the second PR genuinely needs to merge
+  after the first.

--- a/scripts/lint-tz-pinned-tests.py
+++ b/scripts/lint-tz-pinned-tests.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Flag timezone-pinned expected values in DuckDB sqllogic tests.
+
+A test that hardcodes a timezone offset (`+00`, `+01`, `+02`, …) in an
+expected output line is fragile: MEOS renders timestamps using the
+process's TZ, and any divergence between the developer's machine and CI
+flips the expected offset.  The project policy is to write
+timezone-neutral assertions instead — value equality (`= tstzspan
+'...'`), accessor functions (`stbox_eq`, `numSpans`, `numValues`,
+`startTimestamp() = …`), or `asText(...)` round-trips on both sides.
+
+This script walks `test/sql/**/*.test`, finds every line in an
+expected-output block (the lines after `----`) that contains a
+`±NN` offset, and prints the file:line and a short snippet.  Returns
+non-zero if any are found, so it can be used as a pre-commit gate or a
+CI lint step.
+
+Inputs that look like literal-offset SQL (`tstzspan '[2000-01-01
+00:00:00+00, ...]'`) are part of a query line, not an expected value,
+and are skipped — only lines that follow a `----` separator within a
+test block are checked.
+
+Usage:
+    python3 scripts/lint-tz-pinned-tests.py [--root test]
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+
+# Match a UTC-offset literal at the tail of a TIMESTAMPTZ rendering.
+# Matches `+00`, `+05:30`, `-08`, etc.  The negative lookbehind for
+# `[eE]` avoids scientific-notation false positives (`1.5e+00`).
+TZ_OFFSET_RE = re.compile(r"(?<![eE])([+\-]\d{2}(?::?\d{2})?)\b")
+
+
+def scan_test_file(path):
+    """Yield (line_number, line_text) for offset-bearing lines in
+    expected-output blocks of a sqllogic-style .test file."""
+    in_expected = False
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for lineno, raw in enumerate(f, start=1):
+            line = raw.rstrip("\n")
+            stripped = line.strip()
+            # Empty line ends an expected-output block.
+            if not stripped:
+                in_expected = False
+                continue
+            # The `----` separator opens an expected-output block in
+            # sqllogic test syntax.
+            if stripped == "----":
+                in_expected = True
+                continue
+            if not in_expected:
+                continue
+            if TZ_OFFSET_RE.search(line):
+                yield lineno, line
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--root",
+        default="test",
+        help="Root directory to scan for .test files (default: test)",
+    )
+    ap.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-line output; only print the summary count.",
+    )
+    args = ap.parse_args()
+
+    if not os.path.isdir(args.root):
+        sys.exit(f"Test root not found: {args.root}")
+
+    pinned_count = 0
+    pinned_files = set()
+    for path in sorted(glob.glob(f"{args.root}/**/*.test", recursive=True)):
+        rel = os.path.relpath(path)
+        for lineno, line in scan_test_file(path):
+            pinned_count += 1
+            pinned_files.add(rel)
+            if not args.quiet:
+                snippet = line.strip()
+                if len(snippet) > 100:
+                    snippet = snippet[:97] + "..."
+                print(f"{rel}:{lineno}: {snippet}")
+
+    if pinned_count:
+        print()
+        print(
+            f"Found {pinned_count} timezone-pinned expected values in "
+            f"{len(pinned_files)} files.  Rewrite as value-equality "
+            f"(`= tstzspan '...'`), accessor (`numSpans`, `startTimestamp`), "
+            f"or `asText(...)` round-trip assertions per the project "
+            f"timezone-neutral policy (PR #111 / commit 9dd765a)."
+        )
+        return 1
+
+    print("No timezone-pinned expected values found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/parity-audit.py
+++ b/scripts/parity-audit.py
@@ -83,9 +83,31 @@ OUT_OF_SCOPE_NAME_SUFFIXES = (
 )
 
 
+# Individual function names that are out-of-scope by domain — not part of
+# the MobilityDuck surface because they exist for a MobilityDB-specific
+# integration or PG-internal pattern that DuckDB doesn't share.
+OUT_OF_SCOPE_NAMES = {
+    # Gauss-Krüger projection — added to MobilityDB to connect with the
+    # SECONDO platform.  No equivalent need in MobilityDuck.
+    "transform_gk",
+    # Synthetic-trip generator for the BerlinMOD benchmark generator.
+    # The generator runs in MobilityDB / SECONDO; the parquet artefacts
+    # it produces are what MobilityDuck consumes.
+    "create_trip",
+    # Internal C helper composed by the `edisjoint` SQL wrapper for the
+    # bbox short-circuit pattern (`NOT(bbox && temp) OR _edisjoint(...)`).
+    # MobilityDuck registers `eDisjoint` directly against the MEOS C
+    # export, so the PG SQL-wrapper helper has no DuckDB equivalent.
+    "_edisjoint",
+}
+
+
 def is_out_of_scope_name(fname):
-    """Return True for PG-only helper names (suffix match)."""
+    """Return True for PG-only helper names (suffix match) or
+    domain-specific names that have no MobilityDuck equivalent."""
     lower = fname.lower()
+    if lower in {n.lower() for n in OUT_OF_SCOPE_NAMES}:
+        return True
     # All suffixes start with `_`, so a non-empty prefix means the suffix
     # matched a "<base>_<suffix>" shape (e.g. tnumber_in, temporal_sel).
     for suf in OUT_OF_SCOPE_NAME_SUFFIXES:

--- a/src/geo/stbox.cpp
+++ b/src/geo/stbox.cpp
@@ -94,7 +94,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
     //     )
     // );
 
-    duckdb::RegisterSerializedScalarFunction(loader, 
+    duckdb::RegisterSerializedScalarFunction(loader,
         ScalarFunction(
             "asText",
             {STBOX()},
@@ -102,6 +102,52 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
             StboxFunctions::Stbox_as_text
         )
     );
+
+    /* Dimensional constructors — stboxX/Z/T/XT/ZT and the geodstbox*
+     * variants.  All wrap MEOS stbox_make with the appropriate
+     * has-x/has-z/geodetic flags filled in. */
+    {
+        const auto STB = STBOX();
+        const auto D   = LogicalType::DOUBLE;
+        const auto I   = LogicalType::INTEGER;
+        const auto T   = LogicalType::TIMESTAMP_TZ;
+        const auto SP  = SpanTypes::TSTZSPAN();
+
+        // stboxX(xmin, xmax, ymin, ymax, srid)
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "stboxX", {D, D, D, D, I}, STB, StboxFunctions::Stbox_constructor_x));
+        // stboxZ(xmin, xmax, ymin, ymax, zmin, zmax, srid)
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "stboxZ", {D, D, D, D, D, D, I}, STB, StboxFunctions::Stbox_constructor_z));
+        // stboxT(timestamptz) and stboxT(tstzspan)
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "stboxT", {T},  STB, StboxFunctions::Stbox_constructor_t_ts));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "stboxT", {SP}, STB, StboxFunctions::Stbox_constructor_t_span));
+        // stboxXT(xmin, xmax, ymin, ymax, ts|span, srid)
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "stboxXT", {D, D, D, D, T,  I}, STB, StboxFunctions::Stbox_constructor_xt_ts));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "stboxXT", {D, D, D, D, SP, I}, STB, StboxFunctions::Stbox_constructor_xt_span));
+        // stboxZT(xmin, xmax, ymin, ymax, zmin, zmax, ts|span, srid)
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "stboxZT", {D, D, D, D, D, D, T,  I}, STB, StboxFunctions::Stbox_constructor_zt_ts));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "stboxZT", {D, D, D, D, D, D, SP, I}, STB, StboxFunctions::Stbox_constructor_zt_span));
+
+        // Geographic variants — geodetic flag set; SRID defaults to
+        // 4326 in the time-only forms (MobilityDB convention).
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "geodstboxZ", {D, D, D, D, D, D, I}, STB, StboxFunctions::Geodstbox_constructor_z));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "geodstboxT", {T},  STB, StboxFunctions::Geodstbox_constructor_t_ts));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "geodstboxT", {SP}, STB, StboxFunctions::Geodstbox_constructor_t_span));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "geodstboxZT", {D, D, D, D, D, D, T,  I}, STB, StboxFunctions::Geodstbox_constructor_zt_ts));
+        duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
+            "geodstboxZT", {D, D, D, D, D, D, SP, I}, STB, StboxFunctions::Geodstbox_constructor_zt_span));
+    }
 
     duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(

--- a/src/geo/stbox_functions.cpp
+++ b/src/geo/stbox_functions.cpp
@@ -326,6 +326,284 @@ void StboxFunctions::Stbox_as_hexwkb(DataChunk &args, ExpressionState &state, Ve
  * Constructor functions
  ****************************************************/
 
+namespace {
+
+// Pack a freshly-built STBox into a DuckDB blob and free the source.
+inline string_t StboxToBlob(Vector &result, STBox *box) {
+    size_t sz = sizeof(STBox);
+    string_t stored = StringVector::AddStringOrBlob(
+        result, string_t(reinterpret_cast<const char *>(box), sz));
+    free(box);
+    return stored;
+}
+
+// Build a Span (TimestampTz, single-instant or range) for the time
+// component of stboxT / stboxXT / stboxZT.  Caller frees.
+inline Span *MakeTstzSpanInstant(timestamp_tz_t ts_duckdb) {
+    timestamp_tz_t ts_meos = DuckDBToMeosTimestamp(ts_duckdb);
+    return tstzspan_make((TimestampTz) ts_meos.value,
+                         (TimestampTz) ts_meos.value, true, true);
+}
+
+// Cast the input span blob into a heap-owned Span* the caller can pass
+// directly to stbox_make.
+inline Span *CopyTstzSpanFromBlob(string_t span_blob) {
+    if (span_blob.GetSize() < sizeof(Span))
+        throw InvalidInputException("invalid TSTZSPAN blob");
+    Span *s = (Span *)malloc(sizeof(Span));
+    memcpy(s, span_blob.GetData(), sizeof(Span));
+    return s;
+}
+
+} // anonymous namespace
+
+void StboxFunctions::Stbox_constructor_x(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t count = args.size();
+    args.data[0].Flatten(count); args.data[1].Flatten(count);
+    args.data[2].Flatten(count); args.data[3].Flatten(count);
+    args.data[4].Flatten(count);
+    auto xmin = FlatVector::GetData<double>(args.data[0]);
+    auto xmax = FlatVector::GetData<double>(args.data[1]);
+    auto ymin = FlatVector::GetData<double>(args.data[2]);
+    auto ymax = FlatVector::GetData<double>(args.data[3]);
+    auto srid = FlatVector::GetData<int32_t>(args.data[4]);
+    auto out  = FlatVector::GetData<string_t>(result);
+    for (idx_t i = 0; i < count; i++) {
+        STBox *b = stbox_make(true, false, false, srid[i],
+                              xmin[i], xmax[i], ymin[i], ymax[i], 0, 0, NULL);
+        if (!b) throw InvalidInputException("stboxX: stbox_make failed");
+        out[i] = StboxToBlob(result, b);
+    }
+}
+
+void StboxFunctions::Stbox_constructor_z(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(count);
+    auto xmin = FlatVector::GetData<double>(args.data[0]);
+    auto xmax = FlatVector::GetData<double>(args.data[1]);
+    auto ymin = FlatVector::GetData<double>(args.data[2]);
+    auto ymax = FlatVector::GetData<double>(args.data[3]);
+    auto zmin = FlatVector::GetData<double>(args.data[4]);
+    auto zmax = FlatVector::GetData<double>(args.data[5]);
+    auto srid = FlatVector::GetData<int32_t>(args.data[6]);
+    auto out  = FlatVector::GetData<string_t>(result);
+    for (idx_t i = 0; i < count; i++) {
+        STBox *b = stbox_make(true, true, false, srid[i],
+                              xmin[i], xmax[i], ymin[i], ymax[i],
+                              zmin[i], zmax[i], NULL);
+        if (!b) throw InvalidInputException("stboxZ: stbox_make failed");
+        out[i] = StboxToBlob(result, b);
+    }
+}
+
+void StboxFunctions::Stbox_constructor_t_ts(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<timestamp_tz_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](timestamp_tz_t ts) -> string_t {
+            Span *p = MakeTstzSpanInstant(ts);
+            STBox *b = stbox_make(false, false, false, 0,
+                                  0, 0, 0, 0, 0, 0, p);
+            free(p);
+            if (!b) throw InvalidInputException("stboxT: stbox_make failed");
+            return StboxToBlob(result, b);
+        });
+}
+
+void StboxFunctions::Stbox_constructor_t_span(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t span_blob) -> string_t {
+            Span *p = CopyTstzSpanFromBlob(span_blob);
+            STBox *b = stbox_make(false, false, false, 0,
+                                  0, 0, 0, 0, 0, 0, p);
+            free(p);
+            if (!b) throw InvalidInputException("stboxT: stbox_make failed");
+            return StboxToBlob(result, b);
+        });
+}
+
+void StboxFunctions::Stbox_constructor_xt_ts(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(count);
+    auto xmin = FlatVector::GetData<double>(args.data[0]);
+    auto xmax = FlatVector::GetData<double>(args.data[1]);
+    auto ymin = FlatVector::GetData<double>(args.data[2]);
+    auto ymax = FlatVector::GetData<double>(args.data[3]);
+    auto ts   = FlatVector::GetData<timestamp_tz_t>(args.data[4]);
+    auto srid = FlatVector::GetData<int32_t>(args.data[5]);
+    auto out  = FlatVector::GetData<string_t>(result);
+    for (idx_t i = 0; i < count; i++) {
+        Span *p = MakeTstzSpanInstant(ts[i]);
+        STBox *b = stbox_make(true, false, false, srid[i],
+                              xmin[i], xmax[i], ymin[i], ymax[i], 0, 0, p);
+        free(p);
+        if (!b) throw InvalidInputException("stboxXT: stbox_make failed");
+        out[i] = StboxToBlob(result, b);
+    }
+}
+
+void StboxFunctions::Stbox_constructor_xt_span(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(count);
+    auto xmin = FlatVector::GetData<double>(args.data[0]);
+    auto xmax = FlatVector::GetData<double>(args.data[1]);
+    auto ymin = FlatVector::GetData<double>(args.data[2]);
+    auto ymax = FlatVector::GetData<double>(args.data[3]);
+    auto sp   = FlatVector::GetData<string_t>(args.data[4]);
+    auto srid = FlatVector::GetData<int32_t>(args.data[5]);
+    auto out  = FlatVector::GetData<string_t>(result);
+    for (idx_t i = 0; i < count; i++) {
+        Span *p = CopyTstzSpanFromBlob(sp[i]);
+        STBox *b = stbox_make(true, false, false, srid[i],
+                              xmin[i], xmax[i], ymin[i], ymax[i], 0, 0, p);
+        free(p);
+        if (!b) throw InvalidInputException("stboxXT: stbox_make failed");
+        out[i] = StboxToBlob(result, b);
+    }
+}
+
+void StboxFunctions::Stbox_constructor_zt_ts(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(count);
+    auto xmin = FlatVector::GetData<double>(args.data[0]);
+    auto xmax = FlatVector::GetData<double>(args.data[1]);
+    auto ymin = FlatVector::GetData<double>(args.data[2]);
+    auto ymax = FlatVector::GetData<double>(args.data[3]);
+    auto zmin = FlatVector::GetData<double>(args.data[4]);
+    auto zmax = FlatVector::GetData<double>(args.data[5]);
+    auto ts   = FlatVector::GetData<timestamp_tz_t>(args.data[6]);
+    auto srid = FlatVector::GetData<int32_t>(args.data[7]);
+    auto out  = FlatVector::GetData<string_t>(result);
+    for (idx_t i = 0; i < count; i++) {
+        Span *p = MakeTstzSpanInstant(ts[i]);
+        STBox *b = stbox_make(true, true, false, srid[i],
+                              xmin[i], xmax[i], ymin[i], ymax[i],
+                              zmin[i], zmax[i], p);
+        free(p);
+        if (!b) throw InvalidInputException("stboxZT: stbox_make failed");
+        out[i] = StboxToBlob(result, b);
+    }
+}
+
+void StboxFunctions::Stbox_constructor_zt_span(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(count);
+    auto xmin = FlatVector::GetData<double>(args.data[0]);
+    auto xmax = FlatVector::GetData<double>(args.data[1]);
+    auto ymin = FlatVector::GetData<double>(args.data[2]);
+    auto ymax = FlatVector::GetData<double>(args.data[3]);
+    auto zmin = FlatVector::GetData<double>(args.data[4]);
+    auto zmax = FlatVector::GetData<double>(args.data[5]);
+    auto sp   = FlatVector::GetData<string_t>(args.data[6]);
+    auto srid = FlatVector::GetData<int32_t>(args.data[7]);
+    auto out  = FlatVector::GetData<string_t>(result);
+    for (idx_t i = 0; i < count; i++) {
+        Span *p = CopyTstzSpanFromBlob(sp[i]);
+        STBox *b = stbox_make(true, true, false, srid[i],
+                              xmin[i], xmax[i], ymin[i], ymax[i],
+                              zmin[i], zmax[i], p);
+        free(p);
+        if (!b) throw InvalidInputException("stboxZT: stbox_make failed");
+        out[i] = StboxToBlob(result, b);
+    }
+}
+
+/* Geographic variants — geodetic=true.  No geodstboxX (the 2D-only
+ * geodetic stbox is degenerate on a sphere; MobilityDB exposes
+ * geodstboxZ / geodstboxT / geodstboxZT only). */
+
+void StboxFunctions::Geodstbox_constructor_z(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(count);
+    auto xmin = FlatVector::GetData<double>(args.data[0]);
+    auto xmax = FlatVector::GetData<double>(args.data[1]);
+    auto ymin = FlatVector::GetData<double>(args.data[2]);
+    auto ymax = FlatVector::GetData<double>(args.data[3]);
+    auto zmin = FlatVector::GetData<double>(args.data[4]);
+    auto zmax = FlatVector::GetData<double>(args.data[5]);
+    auto srid = FlatVector::GetData<int32_t>(args.data[6]);
+    auto out  = FlatVector::GetData<string_t>(result);
+    for (idx_t i = 0; i < count; i++) {
+        STBox *b = stbox_make(true, true, true, srid[i],
+                              xmin[i], xmax[i], ymin[i], ymax[i],
+                              zmin[i], zmax[i], NULL);
+        if (!b) throw InvalidInputException("geodstboxZ: stbox_make failed");
+        out[i] = StboxToBlob(result, b);
+    }
+}
+
+void StboxFunctions::Geodstbox_constructor_t_ts(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<timestamp_tz_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](timestamp_tz_t ts) -> string_t {
+            Span *p = MakeTstzSpanInstant(ts);
+            STBox *b = stbox_make(false, false, true, 4326,
+                                  0, 0, 0, 0, 0, 0, p);
+            free(p);
+            if (!b) throw InvalidInputException("geodstboxT: stbox_make failed");
+            return StboxToBlob(result, b);
+        });
+}
+
+void StboxFunctions::Geodstbox_constructor_t_span(DataChunk &args, ExpressionState &state, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t span_blob) -> string_t {
+            Span *p = CopyTstzSpanFromBlob(span_blob);
+            STBox *b = stbox_make(false, false, true, 4326,
+                                  0, 0, 0, 0, 0, 0, p);
+            free(p);
+            if (!b) throw InvalidInputException("geodstboxT: stbox_make failed");
+            return StboxToBlob(result, b);
+        });
+}
+
+void StboxFunctions::Geodstbox_constructor_zt_ts(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(count);
+    auto xmin = FlatVector::GetData<double>(args.data[0]);
+    auto xmax = FlatVector::GetData<double>(args.data[1]);
+    auto ymin = FlatVector::GetData<double>(args.data[2]);
+    auto ymax = FlatVector::GetData<double>(args.data[3]);
+    auto zmin = FlatVector::GetData<double>(args.data[4]);
+    auto zmax = FlatVector::GetData<double>(args.data[5]);
+    auto ts   = FlatVector::GetData<timestamp_tz_t>(args.data[6]);
+    auto srid = FlatVector::GetData<int32_t>(args.data[7]);
+    auto out  = FlatVector::GetData<string_t>(result);
+    for (idx_t i = 0; i < count; i++) {
+        Span *p = MakeTstzSpanInstant(ts[i]);
+        STBox *b = stbox_make(true, true, true, srid[i],
+                              xmin[i], xmax[i], ymin[i], ymax[i],
+                              zmin[i], zmax[i], p);
+        free(p);
+        if (!b) throw InvalidInputException("geodstboxZT: stbox_make failed");
+        out[i] = StboxToBlob(result, b);
+    }
+}
+
+void StboxFunctions::Geodstbox_constructor_zt_span(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(count);
+    auto xmin = FlatVector::GetData<double>(args.data[0]);
+    auto xmax = FlatVector::GetData<double>(args.data[1]);
+    auto ymin = FlatVector::GetData<double>(args.data[2]);
+    auto ymax = FlatVector::GetData<double>(args.data[3]);
+    auto zmin = FlatVector::GetData<double>(args.data[4]);
+    auto zmax = FlatVector::GetData<double>(args.data[5]);
+    auto sp   = FlatVector::GetData<string_t>(args.data[6]);
+    auto srid = FlatVector::GetData<int32_t>(args.data[7]);
+    auto out  = FlatVector::GetData<string_t>(result);
+    for (idx_t i = 0; i < count; i++) {
+        Span *p = CopyTstzSpanFromBlob(sp[i]);
+        STBox *b = stbox_make(true, true, true, srid[i],
+                              xmin[i], xmax[i], ymin[i], ymax[i],
+                              zmin[i], zmax[i], p);
+        free(p);
+        if (!b) throw InvalidInputException("geodstboxZT: stbox_make failed");
+        out[i] = StboxToBlob(result, b);
+    }
+}
+
 void StboxFunctions::Geo_timestamptz_to_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, timestamp_tz_t, string_t>(
         args.data[0], args.data[1], result, args.size(),

--- a/src/geo/tgeography_ops.cpp
+++ b/src/geo/tgeography_ops.cpp
@@ -989,6 +989,16 @@ void TGeographyOps::RegisterScalarFunctions(ExtensionLoader &loader) {
     REG_TCMP("temporal_teq", Teq)
     REG_TCMP("temporal_tne", Tne)
 #undef REG_TCMP
+
+    // eCovers (BOOLEAN) and tCovers (tbool) — covering relationships
+    // for tgeography.  acovers_*_tgeo is not exposed by the MEOS public
+    // API at present so the aCovers wrapper isn't registered here.
+    loader.RegisterFunction(ScalarFunction("eCovers", {GEOM, TGEOM},  LogicalType::BOOLEAN, TgeompointFunctions::Ecovers_geo_tgeo));
+    loader.RegisterFunction(ScalarFunction("eCovers", {TGEOM, GEOM},  LogicalType::BOOLEAN, TgeompointFunctions::Ecovers_tgeo_geo));
+    loader.RegisterFunction(ScalarFunction("eCovers", {TGEOM, TGEOM}, LogicalType::BOOLEAN, TgeompointFunctions::Ecovers_tgeo_tgeo));
+    loader.RegisterFunction(ScalarFunction("tCovers", {GEOM, TGEOM},  TemporalTypes::TBOOL(), TgeompointFunctions::Tcovers_geo_tgeo));
+    loader.RegisterFunction(ScalarFunction("tCovers", {TGEOM, GEOM},  TemporalTypes::TBOOL(), TgeompointFunctions::Tcovers_tgeo_geo));
+    loader.RegisterFunction(ScalarFunction("tCovers", {TGEOM, TGEOM}, TemporalTypes::TBOOL(), TgeompointFunctions::Tcovers_tgeo_tgeo));
 }
 
 } // namespace duckdb

--- a/src/geo/tgeometry_ops.cpp
+++ b/src/geo/tgeometry_ops.cpp
@@ -986,6 +986,16 @@ void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
     REG_TCMP("temporal_teq", Teq)
     REG_TCMP("temporal_tne", Tne)
 #undef REG_TCMP
+
+    // eCovers (BOOLEAN) and tCovers (tbool) — covering relationships
+    // for tgeometry.  acovers_*_tgeo is not exposed by the MEOS public
+    // API at present so the aCovers wrapper isn't registered here.
+    loader.RegisterFunction(ScalarFunction("eCovers", {GEOM, TGEOM},  LogicalType::BOOLEAN, TgeompointFunctions::Ecovers_geo_tgeo));
+    loader.RegisterFunction(ScalarFunction("eCovers", {TGEOM, GEOM},  LogicalType::BOOLEAN, TgeompointFunctions::Ecovers_tgeo_geo));
+    loader.RegisterFunction(ScalarFunction("eCovers", {TGEOM, TGEOM}, LogicalType::BOOLEAN, TgeompointFunctions::Ecovers_tgeo_tgeo));
+    loader.RegisterFunction(ScalarFunction("tCovers", {GEOM, TGEOM},  TemporalTypes::TBOOL(), TgeompointFunctions::Tcovers_geo_tgeo));
+    loader.RegisterFunction(ScalarFunction("tCovers", {TGEOM, GEOM},  TemporalTypes::TBOOL(), TgeompointFunctions::Tcovers_tgeo_geo));
+    loader.RegisterFunction(ScalarFunction("tCovers", {TGEOM, TGEOM}, TemporalTypes::TBOOL(), TgeompointFunctions::Tcovers_tgeo_tgeo));
 }
 
 } // namespace duckdb

--- a/src/geo/tgeompoint.cpp
+++ b/src/geo/tgeompoint.cpp
@@ -1263,7 +1263,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
     /* ***************************************************
      * Spatial relationships
      ****************************************************/
-    duckdb::RegisterSerializedScalarFunction(loader, 
+    duckdb::RegisterSerializedScalarFunction(loader,
         ScalarFunction(
             "eContains",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1271,7 +1271,7 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Econtains_geo_tgeo
         )
     );
-    duckdb::RegisterSerializedScalarFunction(loader, 
+    duckdb::RegisterSerializedScalarFunction(loader,
         ScalarFunction(
             "aContains",
             {GeoTypes::GEOMETRY(), TGEOMPOINT()},
@@ -1279,6 +1279,26 @@ void TgeompointType::RegisterScalarFunctions(ExtensionLoader &loader) {
             TgeompointFunctions::Acontains_geo_tgeo
         )
     );
+    /* eCovers — covering relationships (returns BOOLEAN). */
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers",
+        {GeoTypes::GEOMETRY(), TGEOMPOINT()}, LogicalType::BOOLEAN,
+        TgeompointFunctions::Ecovers_geo_tgeo));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers",
+        {TGEOMPOINT(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN,
+        TgeompointFunctions::Ecovers_tgeo_geo));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers",
+        {TGEOMPOINT(), TGEOMPOINT()}, LogicalType::BOOLEAN,
+        TgeompointFunctions::Ecovers_tgeo_tgeo));
+    /* tCovers — temporal covering relationships (returns tbool). */
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers",
+        {GeoTypes::GEOMETRY(), TGEOMPOINT()}, TemporalTypes::TBOOL(),
+        TgeompointFunctions::Tcovers_geo_tgeo));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers",
+        {TGEOMPOINT(), GeoTypes::GEOMETRY()}, TemporalTypes::TBOOL(),
+        TgeompointFunctions::Tcovers_tgeo_geo));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers",
+        {TGEOMPOINT(), TGEOMPOINT()}, TemporalTypes::TBOOL(),
+        TgeompointFunctions::Tcovers_tgeo_tgeo));
     
      duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(

--- a/src/geo/tgeompoint_functions.cpp
+++ b/src/geo/tgeompoint_functions.cpp
@@ -2473,6 +2473,127 @@ void TgeompointFunctions::Tcontains_geo_tgeo(DataChunk &args, ExpressionState &s
     }
 }
 
+/* ***************************************************
+ * eCovers / tCovers — covering relationships
+ *
+ * acovers_*_tgeo is not exported by the MEOS public API at present;
+ * tracked as upstream MEOS gap.  When MEOS exposes the symbol, the
+ * matching aCovers_* wrappers can be added by mirroring the pattern
+ * below.
+ ****************************************************/
+
+void TgeompointFunctions::Ecovers_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) -> bool {
+            uint8_t *t_copy = (uint8_t *)malloc(t_blob.GetSize());
+            memcpy(t_copy, t_blob.GetData(), t_blob.GetSize());
+            Temporal *t = reinterpret_cast<Temporal *>(t_copy);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            if (!gs) { free(t); throw InvalidInputException("eCovers: invalid geometry"); }
+            int r = ecovers_geo_tgeo(gs, t);
+            free(t); free(gs);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+void TgeompointFunctions::Ecovers_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> bool {
+            uint8_t *t_copy = (uint8_t *)malloc(t_blob.GetSize());
+            memcpy(t_copy, t_blob.GetData(), t_blob.GetSize());
+            Temporal *t = reinterpret_cast<Temporal *>(t_copy);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            if (!gs) { free(t); throw InvalidInputException("eCovers: invalid geometry"); }
+            int r = ecovers_tgeo_geo(t, gs);
+            free(t); free(gs);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+void TgeompointFunctions::Ecovers_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t1_blob, string_t t2_blob, ValidityMask &mask, idx_t idx) -> bool {
+            uint8_t *c1 = (uint8_t *)malloc(t1_blob.GetSize());
+            memcpy(c1, t1_blob.GetData(), t1_blob.GetSize());
+            uint8_t *c2 = (uint8_t *)malloc(t2_blob.GetSize());
+            memcpy(c2, t2_blob.GetData(), t2_blob.GetSize());
+            int r = ecovers_tgeo_tgeo(
+                reinterpret_cast<Temporal *>(c1), reinterpret_cast<Temporal *>(c2));
+            free(c1); free(c2);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+void TgeompointFunctions::Tcovers_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) -> string_t {
+            uint8_t *t_copy = (uint8_t *)malloc(t_blob.GetSize());
+            memcpy(t_copy, t_blob.GetData(), t_blob.GetSize());
+            Temporal *t = reinterpret_cast<Temporal *>(t_copy);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            if (!gs) { free(t); throw InvalidInputException("tCovers: invalid geometry"); }
+            Temporal *r = tcovers_geo_tgeo(gs, t);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            size_t sz = temporal_mem_size(r);
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(r), sz));
+            free(r);
+            return stored;
+        });
+}
+
+void TgeompointFunctions::Tcovers_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> string_t {
+            uint8_t *t_copy = (uint8_t *)malloc(t_blob.GetSize());
+            memcpy(t_copy, t_blob.GetData(), t_blob.GetSize());
+            Temporal *t = reinterpret_cast<Temporal *>(t_copy);
+            int32 srid = tspatial_srid(t);
+            GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
+            if (!gs) { free(t); throw InvalidInputException("tCovers: invalid geometry"); }
+            Temporal *r = tcovers_tgeo_geo(t, gs);
+            free(t); free(gs);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            size_t sz = temporal_mem_size(r);
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(r), sz));
+            free(r);
+            return stored;
+        });
+}
+
+void TgeompointFunctions::Tcovers_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
+    BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+        args.data[0], args.data[1], result, args.size(),
+        [&](string_t t1_blob, string_t t2_blob, ValidityMask &mask, idx_t idx) -> string_t {
+            uint8_t *c1 = (uint8_t *)malloc(t1_blob.GetSize());
+            memcpy(c1, t1_blob.GetData(), t1_blob.GetSize());
+            uint8_t *c2 = (uint8_t *)malloc(t2_blob.GetSize());
+            memcpy(c2, t2_blob.GetData(), t2_blob.GetSize());
+            Temporal *r = tcovers_tgeo_tgeo(
+                reinterpret_cast<Temporal *>(c1), reinterpret_cast<Temporal *>(c2));
+            free(c1); free(c2);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            size_t sz = temporal_mem_size(r);
+            string_t stored = StringVector::AddStringOrBlob(
+                result, string_t(reinterpret_cast<const char *>(r), sz));
+            free(r);
+            return stored;
+        });
+}
+
 void TgeompointFunctions::Tdisjoint_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
     bool at_value = false;
     bool restr = false;

--- a/src/include/geo/stbox_functions.hpp
+++ b/src/include/geo/stbox_functions.hpp
@@ -31,11 +31,27 @@ struct StboxFunctions {
     static void Stbox_as_hexwkb(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
-     * Constructor functions
+     * Dimensional constructor functions
+     * stboxX  — 2D (xmin/xmax/ymin/ymax)
+     * stboxZ  — 3D (xmin/xmax/ymin/ymax/zmin/zmax)
+     * stboxT  — time-only
+     * stboxXT — 2D + time
+     * stboxZT — 3D + time
+     * geodstboxZ / geodstboxT / geodstboxZT — geodetic variants
      ****************************************************/
-    // static void Stbox_constructor_x(DataChunk &args, ExpressionState &state, Vector &result);
-    // static void Stbox_constructor_z(DataChunk &args, ExpressionState &state, Vector &result);
-    // static void Stbox_constructor_t(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Stbox_constructor_x(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Stbox_constructor_z(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Stbox_constructor_t_ts(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Stbox_constructor_t_span(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Stbox_constructor_xt_ts(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Stbox_constructor_xt_span(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Stbox_constructor_zt_ts(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Stbox_constructor_zt_span(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Geodstbox_constructor_z(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Geodstbox_constructor_t_ts(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Geodstbox_constructor_t_span(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Geodstbox_constructor_zt_ts(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Geodstbox_constructor_zt_span(DataChunk &args, ExpressionState &state, Vector &result);
 
     static void Geo_timestamptz_to_stbox(DataChunk &args, ExpressionState &state, Vector &result);
     static void Geo_tstzspan_to_stbox(DataChunk &args, ExpressionState &state, Vector &result);

--- a/src/include/geo/tgeompoint_functions.hpp
+++ b/src/include/geo/tgeompoint_functions.hpp
@@ -134,10 +134,16 @@ struct TgeompointFunctions {
     static void Adwithin_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adwithin_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result);
     static void Adwithin_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ecovers_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ecovers_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Ecovers_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);
     /* ***************************************************
      * Temporal-spatial relationships
      ****************************************************/
     static void Tcontains_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tcovers_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tcovers_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tcovers_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);
     static void Tdisjoint_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);
     static void Tdisjoint_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result);
     static void Tdisjoint_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result);

--- a/test/sql/parity/051b_stbox_dimensional_constructors.test
+++ b/test/sql/parity/051b_stbox_dimensional_constructors.test
@@ -1,0 +1,134 @@
+# name: test/sql/parity/051b_stbox_dimensional_constructors.test
+# description: Dimensional stbox constructors —
+#              stboxX (2D), stboxZ (3D), stboxT (time-only),
+#              stboxXT (2D + time), stboxZT (3D + time),
+#              and the geodstbox* geographic variants.  All wrap
+#              MEOS stbox_make with the appropriate has-x / has-z /
+#              geodetic flags.
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# stboxX — 2D
+# =============================================================================
+
+query I
+SELECT hasX(stboxX(1, 3, 2, 4, 0));
+----
+true
+
+query I
+SELECT NOT hasZ(stboxX(1, 3, 2, 4, 0))
+   AND NOT hasT(stboxX(1, 3, 2, 4, 0));
+----
+true
+
+query I
+SELECT Xmin(stboxX(1, 3, 2, 4, 0)),
+       Xmax(stboxX(1, 3, 2, 4, 0)),
+       Ymin(stboxX(1, 3, 2, 4, 0)),
+       Ymax(stboxX(1, 3, 2, 4, 0));
+----
+1.0	3.0	2.0	4.0
+
+query I
+SELECT SRID(stboxX(1, 3, 2, 4, 4326));
+----
+4326
+
+# =============================================================================
+# stboxZ — 3D
+# =============================================================================
+
+query I
+SELECT hasX(stboxZ(1, 3, 2, 4, 5, 6, 0))
+   AND hasZ(stboxZ(1, 3, 2, 4, 5, 6, 0));
+----
+true
+
+query I
+SELECT Zmin(stboxZ(1, 3, 2, 4, 5, 6, 0)),
+       Zmax(stboxZ(1, 3, 2, 4, 5, 6, 0));
+----
+5.0	6.0
+
+# =============================================================================
+# stboxT — time-only
+# =============================================================================
+
+query I
+SELECT NOT hasX(stboxT(TIMESTAMPTZ '2000-01-01 00:00:00+00'))
+   AND     hasT(stboxT(TIMESTAMPTZ '2000-01-01 00:00:00+00'));
+----
+true
+
+# tstzspan overload — same predicates.
+query I
+SELECT NOT hasX(stboxT(tstzspan '[2000-01-01, 2000-01-02]'))
+   AND     hasT(stboxT(tstzspan '[2000-01-01, 2000-01-02]'));
+----
+true
+
+# =============================================================================
+# stboxXT — 2D + time
+# =============================================================================
+
+query I
+SELECT hasX(stboxXT(1, 3, 2, 4, TIMESTAMPTZ '2000-01-01 00:00:00+00', 0))
+   AND hasT(stboxXT(1, 3, 2, 4, TIMESTAMPTZ '2000-01-01 00:00:00+00', 0));
+----
+true
+
+query I
+SELECT hasX(stboxXT(1, 3, 2, 4, tstzspan '[2000-01-01, 2000-01-02]', 0))
+   AND hasT(stboxXT(1, 3, 2, 4, tstzspan '[2000-01-01, 2000-01-02]', 0));
+----
+true
+
+# =============================================================================
+# stboxZT — 3D + time
+# =============================================================================
+
+query I
+SELECT hasX(stboxZT(1, 3, 2, 4, 5, 6, TIMESTAMPTZ '2000-01-01 00:00:00+00', 0))
+   AND hasZ(stboxZT(1, 3, 2, 4, 5, 6, TIMESTAMPTZ '2000-01-01 00:00:00+00', 0))
+   AND hasT(stboxZT(1, 3, 2, 4, 5, 6, TIMESTAMPTZ '2000-01-01 00:00:00+00', 0));
+----
+true
+
+query I
+SELECT hasX(stboxZT(1, 3, 2, 4, 5, 6, tstzspan '[2000-01-01, 2000-01-02]', 0))
+   AND hasZ(stboxZT(1, 3, 2, 4, 5, 6, tstzspan '[2000-01-01, 2000-01-02]', 0))
+   AND hasT(stboxZT(1, 3, 2, 4, 5, 6, tstzspan '[2000-01-01, 2000-01-02]', 0));
+----
+true
+
+# =============================================================================
+# geodstbox* — geographic variants (geodetic = true)
+# =============================================================================
+
+query I
+SELECT isGeodetic(geodstboxZ(1, 3, 2, 4, 5, 6, 4326));
+----
+true
+
+query I
+SELECT isGeodetic(geodstboxT(TIMESTAMPTZ '2000-01-01 00:00:00+00'));
+----
+true
+
+query I
+SELECT isGeodetic(geodstboxT(tstzspan '[2000-01-01, 2000-01-02]'));
+----
+true
+
+query I
+SELECT isGeodetic(geodstboxZT(1, 3, 2, 4, 5, 6, TIMESTAMPTZ '2000-01-01 00:00:00+00', 4326));
+----
+true
+
+query I
+SELECT isGeodetic(geodstboxZT(1, 3, 2, 4, 5, 6, tstzspan '[2000-01-01, 2000-01-02]', 4326));
+----
+true

--- a/test/sql/parity/070b_covers.test
+++ b/test/sql/parity/070b_covers.test
@@ -1,0 +1,75 @@
+# name: test/sql/parity/070b_covers.test
+# description: eCovers (BOOLEAN) and tCovers (tbool) — covering
+#              relationships for tgeometry / tgeography / tgeompoint
+#              across the standard three call shapes (geometry × tgeo,
+#              tgeo × geometry, tgeo × tgeo).  aCovers (always covers)
+#              is not exposed by MEOS at present and therefore not
+#              registered.
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# eCovers — geometry × tgeompoint
+# =============================================================================
+
+# A 5×5 polygon at the origin covers a tgeompoint at (2, 2).
+query I
+SELECT eCovers(
+  ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))'),
+  t::tgeompoint)
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+# eCovers — tgeompoint × geometry — a single point covers itself.
+query I
+SELECT eCovers(t::tgeompoint, ST_GeomFromText('POINT(2 2)'))
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+# eCovers — tgeompoint × tgeompoint — identity.
+query I
+SELECT eCovers(t::tgeompoint, t::tgeompoint)
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+# =============================================================================
+# tCovers — temporal coverage (returns tbool, IS NOT NULL is timezone-neutral)
+# =============================================================================
+
+query I
+SELECT tCovers(
+  ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))'),
+  t::tgeompoint) IS NOT NULL
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+query I
+SELECT tCovers(t::tgeompoint, t::tgeompoint) IS NOT NULL
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+# =============================================================================
+# eCovers / tCovers — tgeometry surface
+# =============================================================================
+
+query I
+SELECT eCovers(
+  ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))'),
+  t::tgeometry)
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true
+
+query I
+SELECT tCovers(
+  ST_GeomFromText('POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))'),
+  t::tgeometry) IS NOT NULL
+FROM (VALUES ('Point(2 2)@2000-01-01')) t(t);
+----
+true


### PR DESCRIPTION
## Summary

Adds 13 dimensional-shortcut constructors for STBox, wrapping MEOS \`stbox_make\` with the appropriate \`has-x / has-z / geodetic\` flag combinations:

| Name | Args | Flags |
|---|---|---|
| \`stboxX\` | xmin, xmax, ymin, ymax, srid | hasx, !hasz, !geodetic |
| \`stboxZ\` | xmin, xmax, ymin, ymax, zmin, zmax, srid | hasx, hasz, !geodetic |
| \`stboxT\` | timestamptz \| tstzspan | !hasx, hasT |
| \`stboxXT\` | xmin, xmax, ymin, ymax, ts\|span, srid | hasx, hasT |
| \`stboxZT\` | xmin, xmax, ymin, ymax, zmin, zmax, ts\|span, srid | hasx, hasz, hasT |
| \`geodstboxZ\` | xmin, xmax, ymin, ymax, zmin, zmax, srid | + geodetic |
| \`geodstboxT\` | timestamptz \| tstzspan | + geodetic |
| \`geodstboxZT\` | xmin, xmax, ymin, ymax, zmin, zmax, ts\|span, srid | + geodetic |

Closes the dimensional-constructor block in \`geo/051_stbox.in.sql\` (13 of the 16 missing names there).

The 2D-only geographic variant (\`geodstboxX\`) is intentionally not registered: a 2D stbox without a time dimension on a sphere is degenerate, and MobilityDB doesn't expose it either.

## Test plan

- [x] \`test/sql/parity/051b_stbox_dimensional_constructors.test\` — accessor-based assertions (\`hasX\`/\`hasZ\`/\`hasT\`/\`Xmin\`/.../\`SRID\`/\`isGeodetic\`), no timestamp-string matching → timezone-neutral.
- [ ] CI green on \`linux_amd64\` and \`linux_arm64\`.

## Depends on

- #121 \`consolidate/main-hygiene-batch\` for the API drift sync.