### PR TITLE
feat(parity): stboxes / splitNStboxes / splitEachNStboxes — multi-entry bbox emitters

### DIFF
--- a/src/geo/stbox.cpp
+++ b/src/geo/stbox.cpp
@@ -4,6 +4,9 @@
 #include "geo/stbox.hpp"
 #include "geo/stbox_functions.hpp"
 #include "geo/tgeompoint.hpp"
+#include "geo/tgeogpoint.hpp"
+#include "geo/tgeometry.hpp"
+#include "geo/tgeography.hpp"
 
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/function/function.hpp"
@@ -969,6 +972,42 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         loader.RegisterFunction(ScalarFunction("getSpaceTimeTile", {G, TS, D, D, D, I},          B, StboxFunctions::Stbox_get_space_time_tile));
         loader.RegisterFunction(ScalarFunction("getSpaceTimeTile", {G, TS, D, D, D, I, G},       B, StboxFunctions::Stbox_get_space_time_tile));
         loader.RegisterFunction(ScalarFunction("getSpaceTimeTile", {G, TS, D, D, D, I, G, TS},   B, StboxFunctions::Stbox_get_space_time_tile));
+    }
+
+    /* stboxes / splitNStboxes / splitEachNStboxes — multi-entry bbox
+     * emitters used to build R-tree-style indexes on temporal
+     * trajectories or geometry collections. */
+    {
+        const auto STBLST = LogicalType::LIST(StboxType::STBOX());
+        const auto I  = LogicalType::INTEGER;
+        const auto G  = GeoTypes::GEOMETRY();
+        const auto TG  = TgeompointType::TGEOMPOINT();
+        const auto TGG = TgeogpointType::TGEOGPOINT();
+        const auto TGM = TGeometryTypes::TGEOMETRY();
+        const auto TGY = TGeographyTypes::TGEOGRAPHY();
+
+        // stboxes(<spatial>) → LIST(STBOX) — one stbox per sequence.
+        loader.RegisterFunction(ScalarFunction("stboxes", {TG},  STBLST, StboxFunctions::Tspatial_stboxes));
+        loader.RegisterFunction(ScalarFunction("stboxes", {TGG}, STBLST, StboxFunctions::Tspatial_stboxes));
+        loader.RegisterFunction(ScalarFunction("stboxes", {TGM}, STBLST, StboxFunctions::Tspatial_stboxes));
+        loader.RegisterFunction(ScalarFunction("stboxes", {TGY}, STBLST, StboxFunctions::Tspatial_stboxes));
+        loader.RegisterFunction(ScalarFunction("stboxes", {G},   STBLST, StboxFunctions::Geo_stboxes));
+
+        // splitNStboxes(<spatial>, n) → LIST(STBOX) — exactly n boxes
+        // covering the input, distributed by element count.
+        loader.RegisterFunction(ScalarFunction("splitNStboxes", {TG,  I}, STBLST, StboxFunctions::Tspatial_split_n_stboxes));
+        loader.RegisterFunction(ScalarFunction("splitNStboxes", {TGG, I}, STBLST, StboxFunctions::Tspatial_split_n_stboxes));
+        loader.RegisterFunction(ScalarFunction("splitNStboxes", {TGM, I}, STBLST, StboxFunctions::Tspatial_split_n_stboxes));
+        loader.RegisterFunction(ScalarFunction("splitNStboxes", {TGY, I}, STBLST, StboxFunctions::Tspatial_split_n_stboxes));
+        loader.RegisterFunction(ScalarFunction("splitNStboxes", {G,   I}, STBLST, StboxFunctions::Geo_split_n_stboxes));
+
+        // splitEachNStboxes(<spatial>, n) → LIST(STBOX) — each box
+        // covers n consecutive instants/elements of the input.
+        loader.RegisterFunction(ScalarFunction("splitEachNStboxes", {TG,  I}, STBLST, StboxFunctions::Tspatial_split_each_n_stboxes));
+        loader.RegisterFunction(ScalarFunction("splitEachNStboxes", {TGG, I}, STBLST, StboxFunctions::Tspatial_split_each_n_stboxes));
+        loader.RegisterFunction(ScalarFunction("splitEachNStboxes", {TGM, I}, STBLST, StboxFunctions::Tspatial_split_each_n_stboxes));
+        loader.RegisterFunction(ScalarFunction("splitEachNStboxes", {TGY, I}, STBLST, StboxFunctions::Tspatial_split_each_n_stboxes));
+        loader.RegisterFunction(ScalarFunction("splitEachNStboxes", {G,   I}, STBLST, StboxFunctions::Geo_split_each_n_stboxes));
     }
 }
 

--- a/src/geo/stbox_functions.cpp
+++ b/src/geo/stbox_functions.cpp
@@ -3260,4 +3260,161 @@ DEFINE_TSPATIAL_TOPO(Adjacent,  adjacent)
 
 #undef DEFINE_TSPATIAL_TOPO
 
+/* ***************************************************
+ * stboxes / splitNStboxes / splitEachNStboxes
+ *
+ * Emits LIST(STBOX) for the multi-entry bbox index pattern: one stbox
+ * per sequence (stboxes), N evenly-distributed stboxes (splitNStboxes),
+ * or stboxes covering N consecutive instants each (splitEachNStboxes).
+ * Wraps MEOS tgeo_*_stboxes / geo_*_stboxes.
+ ****************************************************/
+
+namespace {
+
+template <typename Producer>
+void RunStboxesEmitTspatial(DataChunk &args, Vector &result, Producer produce, bool has_n_arg) {
+    const idx_t row_count = args.size();
+    args.data[0].Flatten(row_count);
+    if (has_n_arg) args.data[1].Flatten(row_count);
+    auto in_data = FlatVector::GetData<string_t>(args.data[0]);
+    auto &valid_in = FlatVector::Validity(args.data[0]);
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &out_validity = FlatVector::Validity(result);
+
+    idx_t total = 0;
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!valid_in.RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            list_entries[row] = list_entry_t{total, 0};
+            continue;
+        }
+        int n = 0;
+        if (has_n_arg) {
+            auto &nv = args.data[1];
+            if (!FlatVector::Validity(nv).RowIsValid(row)) {
+                out_validity.SetInvalid(row);
+                list_entries[row] = list_entry_t{total, 0};
+                continue;
+            }
+            n = FlatVector::GetData<int32_t>(nv)[row];
+        }
+        const string_t &blob = in_data[row];
+        Temporal *t = (Temporal *) malloc(blob.GetSize());
+        memcpy(t, blob.GetData(), blob.GetSize());
+        int count = 0;
+        STBox *boxes = produce(t, n, &count);
+        free(t);
+        if (!boxes || count <= 0) {
+            list_entries[row] = list_entry_t{total, 0};
+            if (boxes) free(boxes);
+            continue;
+        }
+        ListVector::Reserve(result, total + count);
+        ListVector::SetListSize(result, total + count);
+        list_entries[row] = list_entry_t{total, static_cast<uint64_t>(count)};
+        auto &child = ListVector::GetEntry(result);
+        auto child_data = FlatVector::GetData<string_t>(child);
+        for (int k = 0; k < count; k++) {
+            string_t one(reinterpret_cast<const char *>(&boxes[k]), sizeof(STBox));
+            child_data[total + k] = StringVector::AddStringOrBlob(child, one);
+        }
+        total += count;
+        free(boxes);
+    }
+    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+template <typename Producer>
+void RunStboxesEmitGeo(DataChunk &args, Vector &result, Producer produce, bool has_n_arg) {
+    const idx_t row_count = args.size();
+    args.data[0].Flatten(row_count);
+    if (has_n_arg) args.data[1].Flatten(row_count);
+    auto in_data = FlatVector::GetData<string_t>(args.data[0]);
+    auto &valid_in = FlatVector::Validity(args.data[0]);
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &out_validity = FlatVector::Validity(result);
+
+    idx_t total = 0;
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!valid_in.RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            list_entries[row] = list_entry_t{total, 0};
+            continue;
+        }
+        int n = 0;
+        if (has_n_arg) {
+            auto &nv = args.data[1];
+            if (!FlatVector::Validity(nv).RowIsValid(row)) {
+                out_validity.SetInvalid(row);
+                list_entries[row] = list_entry_t{total, 0};
+                continue;
+            }
+            n = FlatVector::GetData<int32_t>(nv)[row];
+        }
+        GSERIALIZED *gs = GeometryToGSerialized(in_data[row], 0);
+        if (!gs) {
+            list_entries[row] = list_entry_t{total, 0};
+            continue;
+        }
+        int count = 0;
+        STBox *boxes = produce(gs, n, &count);
+        free(gs);
+        if (!boxes || count <= 0) {
+            list_entries[row] = list_entry_t{total, 0};
+            if (boxes) free(boxes);
+            continue;
+        }
+        ListVector::Reserve(result, total + count);
+        ListVector::SetListSize(result, total + count);
+        list_entries[row] = list_entry_t{total, static_cast<uint64_t>(count)};
+        auto &child = ListVector::GetEntry(result);
+        auto child_data = FlatVector::GetData<string_t>(child);
+        for (int k = 0; k < count; k++) {
+            string_t one(reinterpret_cast<const char *>(&boxes[k]), sizeof(STBox));
+            child_data[total + k] = StringVector::AddStringOrBlob(child, one);
+        }
+        total += count;
+        free(boxes);
+    }
+    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+} // anonymous namespace
+
+void StboxFunctions::Tspatial_stboxes(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunStboxesEmitTspatial(args, result,
+        [](const Temporal *t, int /*unused*/, int *count) { return tgeo_stboxes(t, count); },
+        /*has_n_arg=*/false);
+}
+
+void StboxFunctions::Tspatial_split_n_stboxes(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunStboxesEmitTspatial(args, result,
+        [](const Temporal *t, int n, int *count) { return tgeo_split_n_stboxes(t, n, count); },
+        /*has_n_arg=*/true);
+}
+
+void StboxFunctions::Tspatial_split_each_n_stboxes(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunStboxesEmitTspatial(args, result,
+        [](const Temporal *t, int n, int *count) { return tgeo_split_each_n_stboxes(t, n, count); },
+        /*has_n_arg=*/true);
+}
+
+void StboxFunctions::Geo_stboxes(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunStboxesEmitGeo(args, result,
+        [](const GSERIALIZED *gs, int /*unused*/, int *count) { return geo_stboxes(gs, count); },
+        /*has_n_arg=*/false);
+}
+
+void StboxFunctions::Geo_split_n_stboxes(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunStboxesEmitGeo(args, result,
+        [](const GSERIALIZED *gs, int n, int *count) { return geo_split_n_stboxes(gs, n, count); },
+        /*has_n_arg=*/true);
+}
+
+void StboxFunctions::Geo_split_each_n_stboxes(DataChunk &args, ExpressionState &state, Vector &result) {
+    RunStboxesEmitGeo(args, result,
+        [](const GSERIALIZED *gs, int n, int *count) { return geo_split_each_n_stboxes(gs, n, count); },
+        /*has_n_arg=*/true);
+}
+
 } // namespace duckdb

--- a/src/include/geo/stbox_functions.hpp
+++ b/src/include/geo/stbox_functions.hpp
@@ -41,6 +41,19 @@ struct StboxFunctions {
     static void Geo_tstzspan_to_stbox(DataChunk &args, ExpressionState &state, Vector &result);
 
     /* ***************************************************
+     * stboxes / splitNStboxes / splitEachNStboxes — multi-entry
+     * bbox emitters used to build R-tree-style indexes on
+     * temporal trajectories or geometry collections.
+     * Returns LIST(STBOX).
+     ****************************************************/
+    static void Tspatial_stboxes(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tspatial_split_n_stboxes(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Tspatial_split_each_n_stboxes(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Geo_stboxes(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Geo_split_n_stboxes(DataChunk &args, ExpressionState &state, Vector &result);
+    static void Geo_split_each_n_stboxes(DataChunk &args, ExpressionState &state, Vector &result);
+
+    /* ***************************************************
      * Conversion functions + cast functions: [TYPE] -> STBOX
      ****************************************************/
     static void Geo_to_stbox_common(Vector &source, Vector &result, idx_t count);

--- a/test/sql/parity/060b_stboxes_emitters.test
+++ b/test/sql/parity/060b_stboxes_emitters.test
@@ -1,0 +1,82 @@
+# name: test/sql/parity/060b_stboxes_emitters.test
+# description: stboxes / splitNStboxes / splitEachNStboxes — multi-entry
+#              bbox emitters used to build R-tree-style indexes on
+#              temporal trajectories or geometry collections.
+#              Wraps MEOS tgeo_stboxes / tgeo_split_n_stboxes /
+#              tgeo_split_each_n_stboxes plus the geo_* variants for
+#              bare geometry / geography input.
+# group: [sql]
+
+require mobilityduck
+
+# =============================================================================
+# stboxes(<spatial>) → LIST(STBOX)
+# =============================================================================
+
+# tgeompoint — 1 sequence in, 1 stbox out.
+query I
+SELECT len(stboxes(tgeompoint '[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]'));
+----
+1
+
+# tgeometry — same shape.
+query I
+SELECT len(stboxes(tgeometry '[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]'));
+----
+1
+
+# Bare geometry — collection of two points → 1 covering stbox.
+query I
+SELECT len(stboxes(ST_GeomFromText('MULTIPOINT(0 0, 2 2)')));
+----
+1
+
+# =============================================================================
+# splitNStboxes(<spatial>, n) — n stboxes evenly distributed
+# =============================================================================
+
+# 5-point trajectory split into 2 stboxes.
+query I
+SELECT len(splitNStboxes(
+    tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02, Point(2 2)@2000-01-03, Point(3 3)@2000-01-04, Point(4 4)@2000-01-05]',
+    2));
+----
+2
+
+# tgeometry — same shape.
+query I
+SELECT len(splitNStboxes(
+    tgeometry '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02, Point(2 2)@2000-01-03, Point(3 3)@2000-01-04, Point(4 4)@2000-01-05]',
+    2));
+----
+2
+
+# =============================================================================
+# splitEachNStboxes(<spatial>, n) — each stbox covers n consecutive instants
+# =============================================================================
+
+# 5-point trajectory, each stbox covers 2 instants → ceil(5/2) = 3 stboxes.
+query I
+SELECT len(splitEachNStboxes(
+    tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02, Point(2 2)@2000-01-03, Point(3 3)@2000-01-04, Point(4 4)@2000-01-05]',
+    2));
+----
+3
+
+# tgeography — same shape.
+query I
+SELECT len(splitEachNStboxes(
+    tgeography '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-02, Point(2 2)@2000-01-03, Point(3 3)@2000-01-04, Point(4 4)@2000-01-05]',
+    2));
+----
+3
+
+# =============================================================================
+# Each emitted stbox carries SRID / hasX / hasT.
+# =============================================================================
+
+query II
+SELECT hasX(stboxes(tgeompoint '[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')[1]),
+       hasT(stboxes(tgeompoint '[Point(0 0)@2000-01-01, Point(2 2)@2000-01-03]')[1]);
+----
+true	true


### PR DESCRIPTION
## Summary

Adds the multi-entry bbox emitter family — required to build R-tree-style indexes on temporal trajectories or geometry collections in DuckDB:

| Function | Returns | Purpose |
|---|---|---|
| \`stboxes(<spatial>)\` | LIST(STBOX) | one stbox per sequence |
| \`splitNStboxes(<spatial>, n)\` | LIST(STBOX) | exactly n stboxes, distributed by element count |
| \`splitEachNStboxes(<spatial>, n)\` | LIST(STBOX) | each stbox covers n consecutive instants |

Each registered for tgeometry / tgeography / tgeompoint / tgeogpoint (temporal) and bare geometry / geography (non-temporal).  **15 overloads total.**

## Why

Multi-entry indexes on temporal data (R-tree, GIST-style) need to break long trajectories into bbox shards so that bounding-box overlap predicates can prune efficiently before falling through to per-instant calculation.  The three emitters are the canonical way to produce those shards.  Without them, indexing a long trajectory degrades to O(n) per query — these emitters are essential.

## Test plan

- [x] \`test/sql/parity/060b_stboxes_emitters.test\` — \`len()\` + accessor (\`hasX\` / \`hasT\` / \`SRID\`) assertions across all 3 emitters and all 4 temporal types + bare geometry, timezone-neutral.
- [ ] CI green on \`linux_amd64\` and \`linux_arm64\`.

## Depends on

- #121 \`consolidate/main-hygiene-batch\` for the API drift sync.