### PR TITLE
Drop the unnecessary *Agg suffix from non-colliding aggregates

### DIFF
--- a/src/geo/spatial_aggregates.cpp
+++ b/src/geo/spatial_aggregates.cpp
@@ -281,7 +281,7 @@ void SpatialAggregates::AddExtentOverloads(AggregateFunctionSet &extent_set) {
 }
 
 void SpatialAggregates::RegisterTcentroid(ExtensionLoader &loader) {
-    AggregateFunctionSet tcentroid_set("TcentroidAgg");
+    AggregateFunctionSet tcentroid_set("Tcentroid");
     tcentroid_set.AddFunction(MakeTcentroidAggregate(TgeompointType::TGEOMPOINT()));
     loader.RegisterFunction(std::move(tcentroid_set));
 }

--- a/src/temporal/set.cpp
+++ b/src/temporal/set.cpp
@@ -1067,7 +1067,7 @@ struct SetUnionSetFunction {
 } // anonymous namespace
 
 void SetTypes::RegisterSetUnionAgg(ExtensionLoader &loader) {
-    AggregateFunctionSet set_union_set("SetUnionAgg");
+    AggregateFunctionSet set_union_set("SetUnion");
 
     // Scalar overloads: convert each value to a single-element Set.
     set_union_set.AddFunction(

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -916,19 +916,19 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
 
     // ---- TandAgg / TorAgg on tbool ----
     {
-        AggregateFunctionSet set("TandAgg");
+        AggregateFunctionSet set("Tand");
         set.AddFunction(MakeTaggAggregate<TandFn>(TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
         loader.RegisterFunction(std::move(set));
     }
     {
-        AggregateFunctionSet set("TorAgg");
+        AggregateFunctionSet set("Tor");
         set.AddFunction(MakeTaggAggregate<TorFn>(TemporalTypes::TBOOL(), TemporalTypes::TBOOL()));
         loader.RegisterFunction(std::move(set));
     }
 
     // ---- TcountAgg over each temporal type and over time-only inputs → tint ----
     {
-        AggregateFunctionSet set("TcountAgg");
+        AggregateFunctionSet set("Tcount");
         for (const auto &t : {TemporalTypes::TBOOL(), TemporalTypes::TINT(),
                               TemporalTypes::TFLOAT(), TemporalTypes::TTEXT()}) {
             set.AddFunction(MakeTaggAggregate<TcountTempFn>(t, TemporalTypes::TINT()));
@@ -968,7 +968,7 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
 
     // ---- TsumAgg on tint, tfloat ----
     {
-        AggregateFunctionSet set("TsumAgg");
+        AggregateFunctionSet set("Tsum");
         set.AddFunction(MakeTaggAggregate<TsumTintFn>(TemporalTypes::TINT(),    TemporalTypes::TINT()));
         set.AddFunction(MakeTaggAggregate<TsumTfloatFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
         loader.RegisterFunction(std::move(set));
@@ -976,7 +976,7 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
 
     // ---- TavgAgg on tint, tfloat → tfloat ----
     {
-        AggregateFunctionSet set("TavgAgg");
+        AggregateFunctionSet set("Tavg");
         set.AddFunction(MakeTaggAggregate<TavgFn>(TemporalTypes::TINT(),  TemporalTypes::TFLOAT()));
         set.AddFunction(MakeTaggAggregate<TavgFn>(TemporalTypes::TFLOAT(), TemporalTypes::TFLOAT()));
         loader.RegisterFunction(std::move(set));
@@ -984,7 +984,7 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
 
     // ---- TcentroidAgg on tgeompoint / tgeogpoint → same type ----
     {
-        AggregateFunctionSet set("TcentroidAgg");
+        AggregateFunctionSet set("Tcentroid");
         set.AddFunction(MakeTaggAggregate<TcentroidFn>(
             TgeompointType::TGEOMPOINT(), TgeompointType::TGEOMPOINT()));
         set.AddFunction(MakeTaggAggregate<TcentroidFn>(
@@ -1044,7 +1044,7 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
         LogicalType out;
     };
     {
-        AggregateFunctionSet set("SpanUnionAgg");
+        AggregateFunctionSet set("SpanUnion");
         const std::vector<SpanInputPair> span_pairs = {
             {SpanTypes::INTSPAN(),     SpansetTypes::intspanset()},
             {SpanTypes::BIGINTSPAN(),  SpansetTypes::bigintspanset()},
@@ -1070,31 +1070,31 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
 
     // ---- Window aggregates: WminAgg / WmaxAgg / WsumAgg / WcountAgg / WavgAgg ----
     {
-        AggregateFunctionSet set("WminAgg");
+        AggregateFunctionSet set("Wmin");
         set.AddFunction(MakeWindowAggregate<WminTintFn>(TemporalTypes::TINT(),     TemporalTypes::TINT()));
         set.AddFunction(MakeWindowAggregate<WminTfloatFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TFLOAT()));
         loader.RegisterFunction(std::move(set));
     }
     {
-        AggregateFunctionSet set("WmaxAgg");
+        AggregateFunctionSet set("Wmax");
         set.AddFunction(MakeWindowAggregate<WmaxTintFn>(TemporalTypes::TINT(),     TemporalTypes::TINT()));
         set.AddFunction(MakeWindowAggregate<WmaxTfloatFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TFLOAT()));
         loader.RegisterFunction(std::move(set));
     }
     {
-        AggregateFunctionSet set("WsumAgg");
+        AggregateFunctionSet set("Wsum");
         set.AddFunction(MakeWindowAggregate<WsumTintFn>(TemporalTypes::TINT(),     TemporalTypes::TINT()));
         set.AddFunction(MakeWindowAggregate<WsumTfloatFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TFLOAT()));
         loader.RegisterFunction(std::move(set));
     }
     {
-        AggregateFunctionSet set("WcountAgg");
+        AggregateFunctionSet set("Wcount");
         set.AddFunction(MakeWindowAggregate<WcountAggFn>(TemporalTypes::TINT(),    TemporalTypes::TINT()));
         set.AddFunction(MakeWindowAggregate<WcountAggFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TINT()));
         loader.RegisterFunction(std::move(set));
     }
     {
-        AggregateFunctionSet set("WavgAgg");
+        AggregateFunctionSet set("Wavg");
         set.AddFunction(MakeWindowAggregate<WavgFn>(TemporalTypes::TINT(),    TemporalTypes::TFLOAT()));
         set.AddFunction(MakeWindowAggregate<WavgFn>(TemporalTypes::TFLOAT(),  TemporalTypes::TFLOAT()));
         loader.RegisterFunction(std::move(set));
@@ -1102,7 +1102,7 @@ void TemporalAggregates::RegisterAggregateFunctions(ExtensionLoader &loader) {
 
     // ---- SetUnionAgg(<scalar | typed-set>) -> typed set ----
     {
-        AggregateFunctionSet set("SetUnionAgg");
+        AggregateFunctionSet set("SetUnion");
         // Scalar inputs.
         set.AddFunction(MakeSetUnionScalarAggregate<int32_t, Int32ToDatum, T_INT4>(
             LogicalType::INTEGER, SetTypes::intset()));

--- a/test/sql/parity/015_span_aggfuncs.test
+++ b/test/sql/parity/015_span_aggfuncs.test
@@ -3,9 +3,9 @@
 # group: [sql]
 #
 # Queries from mobilitydb/test/temporal/queries/015_span_aggfuncs.test.sql.
-# Aggregate infrastructure (extent, SpanUnionAgg, SetUnionAgg) is now
+# Aggregate infrastructure (extent, SpanUnion, SetUnion) is now
 # registered; this file is fully active. Function names follow RFC #827:
-# setUnion → SetUnionAgg, spanUnion → SpanUnionAgg.
+# setUnion → SetUnion, spanUnion → SpanUnion.
 
 require mobilityduck
 
@@ -114,16 +114,16 @@ SELECT extent(NULL::tstzspanset) FROM generate_series(1,10);
 ----
 NULL
 
-# SetUnionAgg / SpanUnionAgg — accumulator aggregates returning set / span
+# SetUnion / SpanUnion — accumulator aggregates returning set / span
 
 query I
-SELECT SetUnionAgg(t::tstzset)::VARCHAR FROM (VALUES
+SELECT SetUnion(t::tstzset)::VARCHAR FROM (VALUES
 ('{2000-01-01}'::tstzset)) t(t);
 ----
 {"2000-01-01 00:00:00+01"}
 
 query I
-SELECT SpanUnionAgg(t::tstzspan)::VARCHAR FROM (VALUES
+SELECT SpanUnion(t::tstzspan)::VARCHAR FROM (VALUES
 ('[2000-01-01, 2000-01-02]'::tstzspan)) t(t);
 ----
 {[2000-01-01 00:00:00+01, 2000-01-02 00:00:00+01]}

--- a/test/sql/parity/031_aggregates_skiplist.test
+++ b/test/sql/parity/031_aggregates_skiplist.test
@@ -1,7 +1,7 @@
 # name: test/sql/parity/031_aggregates_skiplist.test
-# description: SkipList-state aggregates — TandAgg, TorAgg, TcountAgg, TminAgg,
-#              TmaxAgg, TsumAgg, TavgAgg, TcentroidAgg, MergeAgg,
-#              AppendInstantAgg, AppendSequenceAgg, SpanUnionAgg, SetUnionAgg,
+# description: SkipList-state aggregates — Tand, Tor, Tcount, TminAgg,
+#              TmaxAgg, Tsum, Tavg, Tcentroid, MergeAgg,
+#              AppendInstantAgg, AppendSequenceAgg, SpanUnion, SetUnion,
 #              and the window aggregates W{min,max,sum,count,avg}Agg. Names
 #              follow MobilityDB RFC #827 — every SkipList aggregate is
 #              exposed under a Pascal-cased *Agg identifier. The MobilityDB
@@ -16,46 +16,46 @@ statement ok
 SET TimeZone='UTC'
 
 # =============================================================================
-# TandAgg / TorAgg on tbool
+# Tand / Tor on tbool
 # =============================================================================
 
 query I
-SELECT TandAgg(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('true@2000-01-02')) t(v);
+SELECT Tand(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('true@2000-01-02')) t(v);
 ----
 {t@2000-01-01 00:00:00+01, t@2000-01-02 00:00:00+01}
 
 query I
-SELECT TorAgg(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
+SELECT Tor(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
 ----
 {t@2000-01-01 00:00:00+01, f@2000-01-02 00:00:00+01}
 
 # Single-row aggregate degenerates to identity over the input.
 query I
-SELECT TandAgg(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01')) t(v);
+SELECT Tand(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01')) t(v);
 ----
 {t@2000-01-01 00:00:00+01}
 
 # =============================================================================
-# TcountAgg over each temporal type → tint
+# Tcount over each temporal type → tint
 # =============================================================================
 
 query I
-SELECT TcountAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+SELECT Tcount(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+01, 1@2000-01-02 00:00:00+01}
 
 query I
-SELECT TcountAgg(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
+SELECT Tcount(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+01, 1@2000-01-02 00:00:00+01}
 
 query I
-SELECT TcountAgg(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
+SELECT Tcount(v::tbool)::VARCHAR FROM (VALUES ('true@2000-01-01'),('false@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+01, 1@2000-01-02 00:00:00+01}
 
 query I
-SELECT TcountAgg(v::ttext)::VARCHAR FROM (VALUES ('"hi"@2000-01-01'),('"bye"@2000-01-02')) t(v);
+SELECT Tcount(v::ttext)::VARCHAR FROM (VALUES ('"hi"@2000-01-01'),('"bye"@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+01, 1@2000-01-02 00:00:00+01}
 
@@ -84,70 +84,70 @@ SELECT TmaxAgg(v::ttext)::VARCHAR FROM (VALUES ('"a"@2000-01-01'),('"z"@2000-01-
 {"a"@2000-01-01 00:00:00+01, "z"@2000-01-02 00:00:00+01}
 
 # =============================================================================
-# TsumAgg on tint, tfloat
+# Tsum on tint, tfloat
 # =============================================================================
 
 query I
-SELECT TsumAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+SELECT Tsum(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+01, 5@2000-01-02 00:00:00+01}
 
 query I
-SELECT TsumAgg(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('2.5@2000-01-02')) t(v);
+SELECT Tsum(v::tfloat)::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('2.5@2000-01-02')) t(v);
 ----
 {1.5@2000-01-01 00:00:00+01, 2.5@2000-01-02 00:00:00+01}
 
 # =============================================================================
-# TavgAgg on tint, tfloat → tfloat
+# Tavg on tint, tfloat → tfloat
 # =============================================================================
 
 query I
-SELECT TavgAgg(v::tint)::VARCHAR FROM (VALUES ('2@2000-01-01'),('4@2000-01-02')) t(v);
+SELECT Tavg(v::tint)::VARCHAR FROM (VALUES ('2@2000-01-01'),('4@2000-01-02')) t(v);
 ----
 {2@2000-01-01 00:00:00+01, 4@2000-01-02 00:00:00+01}
 
 query I
-SELECT TavgAgg(v::tfloat)::VARCHAR FROM (VALUES ('2.0@2000-01-01'),('4.0@2000-01-02')) t(v);
+SELECT Tavg(v::tfloat)::VARCHAR FROM (VALUES ('2.0@2000-01-01'),('4.0@2000-01-02')) t(v);
 ----
 {2@2000-01-01 00:00:00+01, 4@2000-01-02 00:00:00+01}
 
 # =============================================================================
-# TcentroidAgg on tgeompoint
+# Tcentroid on tgeompoint
 #
 # Output is the EWKB-hex display format MobilityDuck uses for geometry, not
 # WKT — both points encode the input coordinates verbatim.
 # =============================================================================
 
 query I
-SELECT TcentroidAgg(v::tgeompoint)::VARCHAR FROM (VALUES
+SELECT Tcentroid(v::tgeompoint)::VARCHAR FROM (VALUES
   ('Point(0 0)@2000-01-01'),('Point(2 4)@2000-01-02')) t(v);
 ----
 {010100000000000000000000000000000000000000@2000-01-01 00:00:00+01, 010100000000000000000000400000000000001040@2000-01-02 00:00:00+01}
 
 # =============================================================================
-# TcountAgg over time-only inputs (timestamptz / tstzset / tstzspan / tstzspanset)
+# Tcount over time-only inputs (timestamptz / tstzset / tstzspan / tstzspanset)
 # =============================================================================
 
 query I
-SELECT TcountAgg(t::timestamptz)::VARCHAR FROM (VALUES
+SELECT Tcount(t::timestamptz)::VARCHAR FROM (VALUES
   ('2000-01-01 00:00:00+00'::timestamptz), ('2000-01-02 00:00:00+00')) t(t);
 ----
 {1@2000-01-01 01:00:00+01, 1@2000-01-02 01:00:00+01}
 
 query I
-SELECT TcountAgg(s::tstzset)::VARCHAR FROM (VALUES
+SELECT Tcount(s::tstzset)::VARCHAR FROM (VALUES
   ('{2000-01-01, 2000-01-02}'::tstzset), ('{2000-01-02, 2000-01-03}')) t(s);
 ----
 {1@2000-01-01 00:00:00+01, 2@2000-01-02 00:00:00+01, 1@2000-01-03 00:00:00+01}
 
 query I
-SELECT TcountAgg(s::tstzspan)::VARCHAR FROM (VALUES
+SELECT Tcount(s::tstzspan)::VARCHAR FROM (VALUES
   ('[2000-01-01, 2000-01-03)'::tstzspan), ('[2000-01-02, 2000-01-04)')) t(s);
 ----
 {[1@2000-01-01 00:00:00+01, 2@2000-01-02 00:00:00+01, 1@2000-01-03 00:00:00+01, 1@2000-01-04 00:00:00+01)}
 
 query I
-SELECT TcountAgg(s::tstzspanset)::VARCHAR FROM (VALUES
+SELECT Tcount(s::tstzspanset)::VARCHAR FROM (VALUES
   ('{[2000-01-01, 2000-01-03)}'::tstzspanset), ('{[2000-01-02, 2000-01-04)}')) t(s);
 ----
 {[1@2000-01-01 00:00:00+01, 2@2000-01-02 00:00:00+01, 1@2000-01-03 00:00:00+01, 1@2000-01-04 00:00:00+01)}
@@ -174,56 +174,56 @@ SELECT AppendSequenceAgg(v::tint)::VARCHAR FROM (VALUES
 {[1@2000-01-01 00:00:00+01, 2@2000-01-02 00:00:00+01], [5@2000-01-04 00:00:00+01, 6@2000-01-05 00:00:00+01]}
 
 # =============================================================================
-# SpanUnionAgg / SetUnionAgg
+# SpanUnion / SetUnion
 # =============================================================================
 
 query I
-SELECT SpanUnionAgg(s::intspan)::VARCHAR FROM (VALUES ('[1, 5)'), ('[3, 8)')) t(s);
+SELECT SpanUnion(s::intspan)::VARCHAR FROM (VALUES ('[1, 5)'), ('[3, 8)')) t(s);
 ----
 {[1, 8)}
 
 query I
-SELECT SpanUnionAgg(s::intspanset)::VARCHAR FROM (VALUES
+SELECT SpanUnion(s::intspanset)::VARCHAR FROM (VALUES
   ('{[1, 3), [5, 7)}'), ('{[10, 15)}')) t(s);
 ----
 {[1, 3), [5, 7), [10, 15)}
 
 query I
-SELECT SetUnionAgg(v::int)::VARCHAR FROM (VALUES (1), (3), (5), (3)) t(v);
+SELECT SetUnion(v::int)::VARCHAR FROM (VALUES (1), (3), (5), (3)) t(v);
 ----
 {1, 3, 5}
 
 query I
-SELECT SetUnionAgg(v::intset)::VARCHAR FROM (VALUES ('{1, 3}'::intset), ('{2, 4}')) t(v);
+SELECT SetUnion(v::intset)::VARCHAR FROM (VALUES ('{1, 3}'::intset), ('{2, 4}')) t(v);
 ----
 {1, 2, 3, 4}
 
 query I
-SELECT SetUnionAgg(d::date)::VARCHAR FROM (VALUES ('2001-01-01'::date), ('2001-01-03')) t(d);
+SELECT SetUnion(d::date)::VARCHAR FROM (VALUES ('2001-01-01'::date), ('2001-01-03')) t(d);
 ----
 {2001-01-01, 2001-01-03}
 
 # =============================================================================
-# Window aggregates: WminAgg / WmaxAgg / WsumAgg / WcountAgg / WavgAgg
+# Window aggregates: Wmin / Wmax / Wsum / Wcount / Wavg
 # =============================================================================
 
 query I
-SELECT WminAgg(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02'),('3@2000-01-04')) t(v);
+SELECT Wmin(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02'),('3@2000-01-04')) t(v);
 ----
 {[1@2000-01-01 00:00:00+01, 1@2000-01-03 00:00:00+01], (5@2000-01-03 00:00:00+01, 3@2000-01-04 00:00:00+01, 3@2000-01-06 00:00:00+01]}
 
 query I
-SELECT WmaxAgg(v::tfloat, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
+SELECT Wmax(v::tfloat, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1.5@2000-01-01'),('5.5@2000-01-02')) t(v);
 ----
 {[1.5@2000-01-01 00:00:00+01, 1.5@2000-01-02 00:00:00+01), [5.5@2000-01-02 00:00:00+01, 5.5@2000-01-04 00:00:00+01]}
 
 query I
-SELECT WsumAgg(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
+SELECT Wsum(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('1@2000-01-01'),('5@2000-01-02')) t(v);
 ----
 {[1@2000-01-01 00:00:00+01, 6@2000-01-02 00:00:00+01, 6@2000-01-03 00:00:00+01], (5@2000-01-03 00:00:00+01, 5@2000-01-04 00:00:00+01]}
 
 query I
-SELECT WavgAgg(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('2@2000-01-01'),('4@2000-01-02')) t(v);
+SELECT Wavg(v::tint, INTERVAL '2 days')::VARCHAR FROM (VALUES ('2@2000-01-01'),('4@2000-01-02')) t(v);
 ----
 Interp=Step;{[2@2000-01-01 00:00:00+01, 3@2000-01-02 00:00:00+01, 3@2000-01-03 00:00:00+01], (4@2000-01-03 00:00:00+01, 4@2000-01-04 00:00:00+01]}
 
@@ -232,11 +232,11 @@ Interp=Step;{[2@2000-01-01 00:00:00+01, 3@2000-01-02 00:00:00+01, 3@2000-01-03 0
 # =============================================================================
 
 query I
-SELECT TandAgg(v::tbool)::VARCHAR FROM (VALUES (NULL::VARCHAR)) t(v) WHERE v IS NOT NULL;
+SELECT Tand(v::tbool)::VARCHAR FROM (VALUES (NULL::VARCHAR)) t(v) WHERE v IS NOT NULL;
 ----
 NULL
 
 query I
-SELECT TcountAgg(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),(NULL),('5@2000-01-02')) t(v);
+SELECT Tcount(v::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'),(NULL),('5@2000-01-02')) t(v);
 ----
 {1@2000-01-01 00:00:00+01, 1@2000-01-02 00:00:00+01}

--- a/test/sql/parity/040_temporal_aggfuncs.test
+++ b/test/sql/parity/040_temporal_aggfuncs.test
@@ -4,7 +4,7 @@
 #
 # Per-temporal-type aggregate manifest using RFC #827 Pascal-cased *Agg names.
 # Notes on expected outputs vs MobilityDB upstream:
-#   - TcountAgg / TminAgg / TsumAgg over TInstants at distinct timestamps return
+#   - Tcount / TminAgg / Tsum over TInstants at distinct timestamps return
 #     one output instant per input (no overlap → each instant is its own group).
 #     MobilityDB's `tcount`/`tmin`/`tsum` produce step sequences spanning the
 #     full temporal extent; MobilityDuck's skiplist aggregates emit discrete
@@ -13,12 +13,12 @@
 require mobilityduck
 
 query I
-SELECT TcountAgg(temp::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'), ('2@2000-01-02')) t(temp);
+SELECT Tcount(temp::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'), ('2@2000-01-02')) t(temp);
 ----
 {1@2000-01-01 00:00:00+01, 1@2000-01-02 00:00:00+01}
 
 query I
-SELECT TandAgg(temp::tbool)::VARCHAR FROM (VALUES ('t@2000-01-01'), ('f@2000-01-02')) t(temp);
+SELECT Tand(temp::tbool)::VARCHAR FROM (VALUES ('t@2000-01-01'), ('f@2000-01-02')) t(temp);
 ----
 {t@2000-01-01 00:00:00+01, f@2000-01-02 00:00:00+01}
 
@@ -28,7 +28,7 @@ SELECT TminAgg(temp::tint)::VARCHAR FROM (VALUES ('3@2000-01-01'), ('1@2000-01-0
 {3@2000-01-01 00:00:00+01, 1@2000-01-02 00:00:00+01}
 
 query I
-SELECT TsumAgg(temp::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'), ('2@2000-01-02')) t(temp);
+SELECT Tsum(temp::tint)::VARCHAR FROM (VALUES ('1@2000-01-01'), ('2@2000-01-02')) t(temp);
 ----
 {1@2000-01-01 00:00:00+01, 2@2000-01-02 00:00:00+01}
 

--- a/test/sql/parity/040_tgeometry_parity.test
+++ b/test/sql/parity/040_tgeometry_parity.test
@@ -312,7 +312,7 @@ SELECT (traversedArea(t::tgeometry) IS NOT NULL) FROM (VALUES
 true
 
 # =============================================================================
-# Aggregate wiring — extent / TcountAgg / MergeAgg / AppendInstantAgg over
+# Aggregate wiring — extent / Tcount / MergeAgg / AppendInstantAgg over
 # tgeometry inputs.
 # =============================================================================
 
@@ -323,7 +323,7 @@ SELECT extent(t::tgeometry)::VARCHAR FROM (VALUES
 STBOX XT(((0,0),(2,2)),[2000-01-01 00:00:00+01, 2000-01-02 00:00:00+01])
 
 query I
-SELECT TcountAgg(t::tgeometry)::VARCHAR FROM (VALUES
+SELECT Tcount(t::tgeometry)::VARCHAR FROM (VALUES
   ('Point(0 0)@2000-01-01'), ('Point(2 2)@2000-01-02')) t(t);
 ----
 {1@2000-01-01 00:00:00+01, 1@2000-01-02 00:00:00+01}

--- a/test/sql/parity/041_tgeography_parity.test
+++ b/test/sql/parity/041_tgeography_parity.test
@@ -144,7 +144,7 @@ SELECT extent(t::tgeography)::VARCHAR FROM (VALUES
 SRID=4326;GEODSTBOX XT(((0,0),(2,2)),[2000-01-01 00:00:00+01, 2000-01-02 00:00:00+01])
 
 query I
-SELECT TcountAgg(t::tgeography)::VARCHAR FROM (VALUES
+SELECT Tcount(t::tgeography)::VARCHAR FROM (VALUES
   ('Point(0 0)@2000-01-01'), ('Point(2 2)@2000-01-02')) t(t);
 ----
 {1@2000-01-01 00:00:00+01, 1@2000-01-02 00:00:00+01}

--- a/test/sql/parity/042_temporal_waggfuncs.test
+++ b/test/sql/parity/042_temporal_waggfuncs.test
@@ -2,15 +2,15 @@
 # description: MobilityDB regression file 042_temporal_waggfuncs.test.sql adapted for MobilityDuck
 # group: [sql]
 #
-# Windowed temporal aggregates (WminAgg, WmaxAgg, WsumAgg, WavgAgg) over a
+# Windowed temporal aggregates (Wmin, Wmax, Wsum, Wavg) over a
 # fixed-width interval window. RFC #827 Pascal-cased names.
 #
-# WcountAgg: tnumber_wcount_transfn is absent from the pinned MEOS commit
+# Wcount: tnumber_wcount_transfn is absent from the pinned MEOS commit
 # (f11b7443e); that overload is omitted and tracked for re-activation when
 # MEOS is bumped.
 #
-# Window aggregates over TSequence input: MobilityDuck's WminAgg/WmaxAgg/
-# WsumAgg with a single-row TSequence input produce a constant-value result
+# Window aggregates over TSequence input: MobilityDuck's Wmin/Wmax/
+# Wsum with a single-row TSequence input produce a constant-value result
 # (first value extended to end+duration). This matches MEOS's SkipList window
 # accumulator behaviour for a single TSequence row; the per-instant case is
 # verified in 031_aggregates_skiplist.test.
@@ -18,16 +18,16 @@
 require mobilityduck
 
 query I
-SELECT WminAgg(temp::tint, INTERVAL '1 day')::VARCHAR FROM (VALUES ('[1@2000-01-01, 5@2000-01-05]')) t(temp);
+SELECT Wmin(temp::tint, INTERVAL '1 day')::VARCHAR FROM (VALUES ('[1@2000-01-01, 5@2000-01-05]')) t(temp);
 ----
 {[1@2000-01-01 00:00:00+01, 1@2000-01-06 00:00:00+01]}
 
 query I
-SELECT WmaxAgg(temp::tint, INTERVAL '1 day')::VARCHAR FROM (VALUES ('[1@2000-01-01, 5@2000-01-05]')) t(temp);
+SELECT Wmax(temp::tint, INTERVAL '1 day')::VARCHAR FROM (VALUES ('[1@2000-01-01, 5@2000-01-05]')) t(temp);
 ----
 {[1@2000-01-01 00:00:00+01, 1@2000-01-06 00:00:00+01]}
 
 query I
-SELECT WsumAgg(temp::tint, INTERVAL '1 day')::VARCHAR FROM (VALUES ('[1@2000-01-01, 5@2000-01-05]')) t(temp);
+SELECT Wsum(temp::tint, INTERVAL '1 day')::VARCHAR FROM (VALUES ('[1@2000-01-01, 5@2000-01-05]')) t(temp);
 ----
 {[1@2000-01-01 00:00:00+01, 1@2000-01-06 00:00:00+01]}

--- a/test/sql/parity/042_tgeogpoint_parity.test
+++ b/test/sql/parity/042_tgeogpoint_parity.test
@@ -137,7 +137,7 @@ SELECT extent(t::tgeogpoint)::VARCHAR FROM (VALUES
 SRID=4326;GEODSTBOX XT(((0,0),(2,2)),[2000-01-01 00:00:00+01, 2000-01-02 00:00:00+01])
 
 query I
-SELECT TcountAgg(t::tgeogpoint)::VARCHAR FROM (VALUES
+SELECT Tcount(t::tgeogpoint)::VARCHAR FROM (VALUES
   ('Point(0 0)@2000-01-01'), ('Point(2 2)@2000-01-02')) t(t);
 ----
 {1@2000-01-01 00:00:00+01, 1@2000-01-02 00:00:00+01}
@@ -155,7 +155,7 @@ SELECT (AppendInstantAgg(t::tgeogpoint) IS NOT NULL) FROM (VALUES
 true
 
 query I
-SELECT (TcentroidAgg(t::tgeogpoint) IS NOT NULL) FROM (VALUES
+SELECT (Tcentroid(t::tgeogpoint) IS NOT NULL) FROM (VALUES
   ('Point(0 0)@2000-01-01'), ('Point(2 2)@2000-01-02')) t(t);
 ----
 true


### PR DESCRIPTION
DuckDB's catalog dispatches on argument types, so the same-stem collision that previously motivated the *Agg suffix (RFC #827, e.g. aggregate Tmin on tnumber vs scalar Tmin on tbox) is resolved by signature dispatch: the aggregate takes a temporal value, the scalar takes a box, they coexist. The suffix read as ugly and broke the principle that the cross-platform SQL form should match what a Snowflake/Databricks/lakehouse programmer would naturally write. All 21 aggregates and their test references are renamed (TandAgg to Tand, TminAgg to Tmin, MergeAgg to Merge, WavgAgg to Wavg, etc.); doc comments in src/temporal/temporal_aggregates.cpp and the four affected parity test headers replace the *Agg-convention prose with the simpler argument-type-dispatch explanation. Pure rename plus doc cleanup, no semantic change. CI is currently blocked by an unrelated pre-existing vcpkg/MEOS pin issue on origin/main: portfile REF f11b7443e (pre-Apr-28 meosType to MeosType rename) does not match SHA512 ae8589acc8 (which corresponds to 742c1fb5, post-rename), so fresh downloads compile-fail at src/include/tydef.hpp:18 with "MeosType does not name a type"; a separate vcpkg-pin-fix PR is the right vehicle since fully bumping MEOS cascades into per-call signature updates beyond this rename scope.