### PR TITLE
Initialize MEOS per worker thread

### DIFF
--- a/src/geo/geoset.cpp
+++ b/src/geo/geoset.cpp
@@ -36,12 +36,12 @@ void SpatialSetType::RegisterTypes(ExtensionLoader &loader){
 }
 
 void SpatialSetType::RegisterCastFunctions(ExtensionLoader &loader) {        
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         LogicalType::VARCHAR, 
         SpatialSetType::geomset(),                                    
         SpatialSetFunctions::Text_to_geoset   
     );     
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         LogicalType::VARCHAR, 
         SpatialSetType::geogset(),                                    
         SpatialSetFunctions::Text_to_geoset   

--- a/src/geo/stbox.cpp
+++ b/src/geo/stbox.cpp
@@ -27,43 +27,43 @@ void StboxType::RegisterType(ExtensionLoader &loader) {
 }
 
 void StboxType::RegisterCastFunctions(ExtensionLoader &loader) {
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         LogicalType::VARCHAR,
         STBOX(),
         StboxFunctions::Stbox_in_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         STBOX(),
         LogicalType::VARCHAR,
         StboxFunctions::Stbox_out
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         GeoTypes::GEOMETRY(),
         STBOX(),
         StboxFunctions::Geo_to_stbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         LogicalType::TIMESTAMP_TZ,
         STBOX(),
         StboxFunctions::Timestamptz_to_stbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         SetTypes::tstzset(),
         STBOX(),
         StboxFunctions::Tstzset_to_stbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         SpanTypes::TSTZSPAN(),
         STBOX(),
         StboxFunctions::Tstzspan_to_stbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         SpansetTypes::tstzspanset(),
         STBOX(),
         StboxFunctions::Tstzspanset_to_stbox_cast

--- a/src/geo/tgeogpoint.cpp
+++ b/src/geo/tgeogpoint.cpp
@@ -43,25 +43,25 @@ void TgeogpointType::RegisterType(ExtensionLoader &loader) {
 }
 
 void TgeogpointType::RegisterCastFunctions(ExtensionLoader &loader) {
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         LogicalType::VARCHAR,
         TGEOGPOINT(),
         TgeogpointFunctions::Tpoint_in
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TGEOGPOINT(),
         LogicalType::VARCHAR,
         TemporalFunctions::Temporal_out
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TGEOGPOINT(),
         StboxType::STBOX(),
         TgeompointFunctions::Tspatial_to_stbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TGEOGPOINT(),
         SpanTypes::TSTZSPAN(),
         TgeompointFunctions::Temporal_to_tstzspan_cast

--- a/src/geo/tgeogpoint_in_out.cpp
+++ b/src/geo/tgeogpoint_in_out.cpp
@@ -1,5 +1,6 @@
 #include "geo/tgeogpoint.hpp"
 #include "geo/tgeogpoint_functions.hpp"
+#include "mobilityduck/meos_exec_serial.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/common/extension_type_info.hpp"
 #include <regex>
@@ -215,8 +216,8 @@ void TGeogpointType::RegisterScalarInOutFunctions(ExtensionLoader &loader){
 
 
 void TGeogpointType::RegisterCastFunctions(ExtensionLoader &loader) {
-    loader.RegisterCastFunction( LogicalType::VARCHAR, TGeogpointType::TGEOGPOINT(), TgeogpointFunctions::StringToTgeogpoint);
-    loader.RegisterCastFunction( TGeogpointType::TGEOGPOINT(), LogicalType::VARCHAR, TgeogpointFunctions::TgeogpointToString);
+    RegisterMeosCastFunction(loader,  LogicalType::VARCHAR, TGeogpointType::TGEOGPOINT(), TgeogpointFunctions::StringToTgeogpoint);
+    RegisterMeosCastFunction(loader,  TGeogpointType::TGEOGPOINT(), LogicalType::VARCHAR, TgeogpointFunctions::TgeogpointToString);
 }
 
 }

--- a/src/geo/tgeography_in_out.cpp
+++ b/src/geo/tgeography_in_out.cpp
@@ -288,8 +288,8 @@ void TGeographyTypes::RegisterScalarInOutFunctions(ExtensionLoader &loader){
 
 
 void TGeographyTypes::RegisterCastFunctions(ExtensionLoader &loader) {
-    loader.RegisterCastFunction( LogicalType::VARCHAR, TGeographyTypes::TGEOGRAPHY(), TgeographyFunctions::StringToTgeography);
-    loader.RegisterCastFunction( TGeographyTypes::TGEOGRAPHY(), LogicalType::VARCHAR, TgeographyFunctions::TgeographyToString);
+    RegisterMeosCastFunction(loader,  LogicalType::VARCHAR, TGeographyTypes::TGEOGRAPHY(), TgeographyFunctions::StringToTgeography);
+    RegisterMeosCastFunction(loader,  TGeographyTypes::TGEOGRAPHY(), LogicalType::VARCHAR, TgeographyFunctions::TgeographyToString);
 }
 
 }

--- a/src/geo/tgeometry_in_out.cpp
+++ b/src/geo/tgeometry_in_out.cpp
@@ -292,8 +292,8 @@ void TGeometryTypes::RegisterScalarInOutFunctions(ExtensionLoader &loader){
 
 
 void TGeometryTypes::RegisterCastFunctions(ExtensionLoader &loader) {
-    loader.RegisterCastFunction( LogicalType::VARCHAR, TGeometryTypes::TGEOMETRY(), TgeometryFunctions::StringToTgeometry);
-    loader.RegisterCastFunction( TGeometryTypes::TGEOMETRY(), LogicalType::VARCHAR, TgeometryFunctions::TgeometryToString);
+    RegisterMeosCastFunction(loader,  LogicalType::VARCHAR, TGeometryTypes::TGEOMETRY(), TgeometryFunctions::StringToTgeometry);
+    RegisterMeosCastFunction(loader,  TGeometryTypes::TGEOMETRY(), LogicalType::VARCHAR, TgeometryFunctions::TgeometryToString);
 }
 
 }

--- a/src/geo/tgeompoint.cpp
+++ b/src/geo/tgeompoint.cpp
@@ -34,25 +34,25 @@ void TgeompointType::RegisterType(ExtensionLoader &loader) {
 }
 
 void TgeompointType::RegisterCastFunctions(ExtensionLoader &loader) {
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         LogicalType::VARCHAR,
         TGEOMPOINT(),
         TgeompointFunctions::Tpoint_in
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TGEOMPOINT(),
         LogicalType::VARCHAR,
         TemporalFunctions::Temporal_out
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TGEOMPOINT(),
         StboxType::STBOX(),
         TgeompointFunctions::Tspatial_to_stbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TGEOMPOINT(),
         SpanTypes::TSTZSPAN(),
         TgeompointFunctions::Temporal_to_tstzspan_cast

--- a/src/include/mobilityduck/meos_exec_serial.hpp
+++ b/src/include/mobilityduck/meos_exec_serial.hpp
@@ -2,8 +2,10 @@
 
 #include <mutex>
 
+#include "duckdb/function/cast/default_casts.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "mobilityduck/meos_thread.hpp"
 
 namespace duckdb {
 
@@ -26,6 +28,7 @@ inline ScalarFunction WrapScalarFunctionWithMeosExecMutex(ScalarFunction sf) {
 	scalar_function_t orig = std::move(sf.function);
 	sf.function = [orig = std::move(orig)](DataChunk &args, ExpressionState &state, Vector &result) {
 		std::lock_guard<std::mutex> guard(MeosSerializedExecMutex());
+		EnsureMeosThreadInitialized();
 		orig(args, state, result);
 	};
 	return sf;
@@ -33,6 +36,35 @@ inline ScalarFunction WrapScalarFunctionWithMeosExecMutex(ScalarFunction sf) {
 
 inline void RegisterSerializedScalarFunction(ExtensionLoader &loader, ScalarFunction sf) {
 	loader.RegisterFunction(WrapScalarFunctionWithMeosExecMutex(std::move(sf)));
+}
+
+/**
+ * Cast functions are a separate registration path from scalar functions and
+ * have no shared execution wrapper, yet they call MEOS just the same (e.g. the
+ * VARCHAR -> tgeompoint parse). The original function pointer is stashed in
+ * the bound cast data and reached through a trampoline that runs the
+ * per-thread MEOS init before delegating. MobilityDuck cast functions do not
+ * use cast_data themselves, so forwarding it untouched is safe.
+ */
+struct MeosCastData : BoundCastData {
+	explicit MeosCastData(cast_function_t orig_p) : orig(orig_p) {
+	}
+	cast_function_t orig;
+	unique_ptr<BoundCastData> Copy() const override {
+		return make_uniq<MeosCastData>(orig);
+	}
+};
+
+inline bool MeosCastTrampoline(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+	EnsureMeosThreadInitialized();
+	auto &data = parameters.cast_data->Cast<MeosCastData>();
+	return data.orig(source, result, count, parameters);
+}
+
+inline void RegisterMeosCastFunction(ExtensionLoader &loader, const LogicalType &source, const LogicalType &target,
+                                     cast_function_t function, int64_t implicit_cast_cost = -1) {
+	loader.RegisterCastFunction(source, target, BoundCastInfo(MeosCastTrampoline, make_uniq<MeosCastData>(function)),
+	                            implicit_cast_cost);
 }
 
 } // namespace duckdb

--- a/src/include/mobilityduck/meos_thread.hpp
+++ b/src/include/mobilityduck/meos_thread.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+extern "C" {
+#include <meos.h>
+}
+
+// Defined in mobilityduck_extension.cpp. Converts MEOS errors into DuckDB
+// exceptions instead of the process-exiting default handler.
+extern "C" void MobilityduckMeosErrorHandler(int errlevel, int errcode, const char *errmsg);
+
+namespace duckdb {
+
+// MEOS keeps the session timezone, errno, PROJ context and the RNGs in
+// thread-local storage; each thread that calls MEOS must initialise it
+// before its first call (see meos.h, "Multithreading"). DuckDB runs
+// scalar, cast and aggregate bodies on TaskScheduler worker threads, so a
+// one-shot init on the load thread leaves workers with a NULL
+// session_timezone and pg_next_dst_boundary segfaults on the first
+// timestamp parse. This runs the per-thread init exactly once per thread.
+//
+// meos_initialize() resets the process-global error handler to the
+// exit-on-error default, so MobilityduckMeosErrorHandler is re-installed
+// here; the store is an idempotent atomic write of the same pointer.
+inline void EnsureMeosThreadInitialized() {
+	static thread_local const bool meos_thread_ready = []() {
+		meos_initialize();
+		meos_initialize_error_handler(&MobilityduckMeosErrorHandler);
+		meos_initialize_timezone("Europe/Brussels");
+		return true;
+	}();
+	(void) meos_thread_ready;
+}
+
+} // namespace duckdb

--- a/src/temporal/set.cpp
+++ b/src/temporal/set.cpp
@@ -93,43 +93,43 @@ LogicalType SetTypeMapping::GetChildType(const LogicalType &type) {
 // Register all cast functions 
 void SetTypes::RegisterCastFunctions(ExtensionLoader &loader) {
     for (const auto &set_type : SetTypes::AllTypes()) {
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             set_type,                      
             LogicalType::VARCHAR,   
             SetFunctions::Set_to_text   
         ); // Blob to text
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             LogicalType::VARCHAR, 
             set_type,                                    
             SetFunctions::Text_to_set   
         ); // text to blob
         
         auto base_type = SetTypeMapping::GetChildType(set_type);
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             base_type,
             set_type,
             SetFunctions::Value_to_set_cast // set from base type
         );
 
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SetTypes::intset(),
             SetTypes::floatset(),
             SetFunctions::Intset_to_floatset_cast // intset -> floatset 
         );
 
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SetTypes::floatset(),
             SetTypes::intset(),
             SetFunctions::Floatset_to_intset_cast // floatset --> intset
         );
         
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SetTypes::dateset(),
             SetTypes::tstzset(),
             SetFunctions::Dateset_to_tstzset_cast // dateset -> tstzset
         );
         
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SetTypes::tstzset(),
             SetTypes::dateset(),
             SetFunctions::Tstzset_to_dateset_cast // tstz -> dateset 

--- a/src/temporal/span.cpp
+++ b/src/temporal/span.cpp
@@ -89,68 +89,68 @@ LogicalType SpanTypeMapping::GetChildType(const LogicalType &type) {
 // Register all cast functions 
 void SpanTypes::RegisterCastFunctions(ExtensionLoader &loader) {
     for (const auto &span_type : SpanTypes::AllTypes()) {
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             span_type,                      
             LogicalType::VARCHAR,   
             SpanFunctions::Span_to_text   
         ); // Blob to text
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             LogicalType::VARCHAR, 
             span_type,                                    
             SpanFunctions::Text_to_span   
         ); // text to blob
         
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SpanTypes::INTSPAN(),
             SpanTypes::FLOATSPAN(),
             SpanFunctions::Intspan_to_floatspan_cast // intspan -> floatspan 
         );
 
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SpanTypes::FLOATSPAN(),
             SpanTypes::INTSPAN(),
             SpanFunctions::Floatspan_to_intspan_cast // floatspan -> intspan
         );
         
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SpanTypes::DATESPAN(),
             SpanTypes::TSTZSPAN(),
             SpanFunctions::Datespan_to_tstzspan_cast // datespan -> tstzspan
         );
         
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SpanTypes::TSTZSPAN(),
             SpanTypes::DATESPAN(),
             SpanFunctions::Tstzspan_to_datespan_cast // tstzspan -> datespan 
         );
 
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SetTypes::intset(),
             SpanTypes::INTSPAN(),
             SpanFunctions::Set_to_span_cast // intset -> intspan
          );
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SetTypes::bigintset(),
             SpanTypes::BIGINTSPAN(),
             SpanFunctions::Set_to_span_cast // bigintset -> bigintspan
          );
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SetTypes::floatset(),
             SpanTypes::FLOATSPAN(),
             SpanFunctions::Set_to_span_cast // floatset -> floatspan
          );
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SetTypes::tstzset(),
             SpanTypes::TSTZSPAN(),
             SpanFunctions::Set_to_span_cast // tstzset -> tstzspan
          );
 
         // Scalar value -> span casts
-        loader.RegisterCastFunction(LogicalType::INTEGER,      SpanTypes::INTSPAN(),    SpanFunctions::Value_to_span_cast);
-        loader.RegisterCastFunction(LogicalType::BIGINT,       SpanTypes::BIGINTSPAN(), SpanFunctions::Value_to_span_cast);
-        loader.RegisterCastFunction(LogicalType::DOUBLE,       SpanTypes::FLOATSPAN(),  SpanFunctions::Value_to_span_cast);
-        loader.RegisterCastFunction(LogicalType::DATE,         SpanTypes::DATESPAN(),   SpanFunctions::Value_to_span_cast);
-        loader.RegisterCastFunction(LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN(),   SpanFunctions::Value_to_span_cast);
+        RegisterMeosCastFunction(loader, LogicalType::INTEGER,      SpanTypes::INTSPAN(),    SpanFunctions::Value_to_span_cast);
+        RegisterMeosCastFunction(loader, LogicalType::BIGINT,       SpanTypes::BIGINTSPAN(), SpanFunctions::Value_to_span_cast);
+        RegisterMeosCastFunction(loader, LogicalType::DOUBLE,       SpanTypes::FLOATSPAN(),  SpanFunctions::Value_to_span_cast);
+        RegisterMeosCastFunction(loader, LogicalType::DATE,         SpanTypes::DATESPAN(),   SpanFunctions::Value_to_span_cast);
+        RegisterMeosCastFunction(loader, LogicalType::TIMESTAMP_TZ, SpanTypes::TSTZSPAN(),   SpanFunctions::Value_to_span_cast);
     }
 }
 

--- a/src/temporal/spanset.cpp
+++ b/src/temporal/spanset.cpp
@@ -103,62 +103,62 @@ LogicalType SpansetTypeMapping::GetBaseType(const LogicalType &type) {
 // --- Register Cast ---
 void SpansetTypes::RegisterCastFunctions(ExtensionLoader &loader) {
     for (const auto &spanset_type : SpansetTypes::AllTypes()) {
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             spanset_type,                      
             LogicalType::VARCHAR,   
             SpansetFunctions::Spanset_to_text   
         ); // Blob to text
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             LogicalType::VARCHAR, 
             spanset_type,                                    
             SpansetFunctions::Text_to_spanset   
         ); // text to blob
         
         auto base_type = SpansetTypeMapping::GetBaseType(spanset_type);
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             base_type,
             spanset_type,
             SpansetFunctions::Value_to_spanset_cast
         );
 
         auto set_type = SpansetTypeMapping::GetSetType(spanset_type);        
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             set_type,
             spanset_type,
             SpansetFunctions::Set_to_spanset_cast
         );
         auto child_type = SpansetTypeMapping::GetChildType(spanset_type); // span
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             child_type,
             spanset_type,
             SpansetFunctions::Span_to_spanset_cast
         );
 
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             spanset_type,
             child_type,
             SpansetFunctions::Spanset_to_span_cast
         );
 
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SpansetTypes::intspanset(),
             SpansetTypes::floatspanset(),
             SpansetFunctions::Intspanset_to_floatspanset_cast
         );
 
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SpansetTypes::floatspanset(),
             SpansetTypes::intspanset(),
             SpansetFunctions::Floatspanset_to_intspanset_cast
         );
 
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SpansetTypes::datespanset(),
             SpansetTypes::tstzspanset(),
             SpansetFunctions::Datespanset_to_tstzspanset_cast
         );
 
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             SpansetTypes::tstzspanset(),
             SpansetTypes::datespanset(),
             SpansetFunctions::Tstzspanset_to_datespanset_cast

--- a/src/temporal/tbox.cpp
+++ b/src/temporal/tbox.cpp
@@ -27,103 +27,103 @@ void TboxType::RegisterType(ExtensionLoader &loader) {
 }
 
 void TboxType::RegisterCastFunctions(ExtensionLoader &loader) {
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         LogicalType::VARCHAR,
         TBOX(),
         TboxFunctions::Tbox_in
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TBOX(),
         LogicalType::VARCHAR,
         TboxFunctions::Tbox_out
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         LogicalType::INTEGER,
         TBOX(),
         TboxFunctions::Number_to_tbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         LogicalType::DOUBLE,
         TBOX(),
         TboxFunctions::Number_to_tbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         LogicalType::TIMESTAMP_TZ,
         TBOX(),
         TboxFunctions::Timestamptz_to_tbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         SetTypes::intset(),
         TBOX(),
         TboxFunctions::Set_to_tbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         SetTypes::floatset(),
         TBOX(),
         TboxFunctions::Set_to_tbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         SetTypes::tstzset(),
         TBOX(),
         TboxFunctions::Set_to_tbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         SpanTypes::INTSPAN(),
         TBOX(),
         TboxFunctions::Span_to_tbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         SpanTypes::FLOATSPAN(),
         TBOX(),
         TboxFunctions::Span_to_tbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         SpanTypes::TSTZSPAN(),
         TBOX(),
         TboxFunctions::Span_to_tbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TBOX(),
         SpanTypes::INTSPAN(),
         TboxFunctions::Tbox_to_intspan_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TBOX(),
         SpanTypes::FLOATSPAN(),
         TboxFunctions::Tbox_to_floatspan_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TBOX(),
         SpanTypes::TSTZSPAN(),
         TboxFunctions::Tbox_to_tstzspan_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         SpansetTypes::intspanset(),
         TBOX(),
         TboxFunctions::Spanset_to_tbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         SpansetTypes::floatspanset(),
         TBOX(),
         TboxFunctions::Spanset_to_tbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         SpansetTypes::tstzspanset(),
         TBOX(),
         TboxFunctions::Spanset_to_tbox_cast

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -69,13 +69,13 @@ LogicalType TemporalTypes::GetBaseTypeFromAlias(const char *alias) {
 
 void TemporalTypes::RegisterCastFunctions(ExtensionLoader &loader) {
     for (auto &type : TemporalTypes::AllTypes()) {
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             LogicalType::VARCHAR,
             type,
             TemporalFunctions::Temporal_in
         );
 
-        loader.RegisterCastFunction(
+        RegisterMeosCastFunction(loader, 
             type,
             LogicalType::VARCHAR,
             TemporalFunctions::Temporal_out
@@ -90,37 +90,37 @@ void TemporalTypes::RegisterCastFunctions(ExtensionLoader &loader) {
     //     );
     // }
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         LogicalType::BLOB,
         SpansetTypes::tstzspanset(),
         TemporalFunctions::Blob_to_tstzspanset
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TemporalTypes::TBOOL(),
         TemporalTypes::TINT(),
         TemporalFunctions::Tbool_to_tint_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TemporalTypes::TINT(),
         TemporalTypes::TFLOAT(),
         TemporalFunctions::Tint_to_tfloat_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TemporalTypes::TFLOAT(),
         TemporalTypes::TINT(),
         TemporalFunctions::Tfloat_to_tint_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TemporalTypes::TINT(),
         TboxType::TBOX(),
         TemporalFunctions::Tnumber_to_tbox_cast
     );
 
-    loader.RegisterCastFunction(
+    RegisterMeosCastFunction(loader, 
         TemporalTypes::TFLOAT(),
         TboxType::TBOX(),
         TemporalFunctions::Tnumber_to_tbox_cast


### PR DESCRIPTION
The MEOS 1.4 uplift keeps the session timezone, errno, PROJ context and RNGs in thread-local storage and requires every thread that calls into MEOS to run meos_initialize() before its first call. The extension only initialized MEOS once on the load thread via std::call_once, so DuckDB TaskScheduler worker threads executed scalar, cast and aggregate bodies with a NULL session_timezone and segfaulted in pg_next_dst_boundary on the first timestamp parse (reproduced locally as a SIGSEGV in 042_tgeogpoint_parity, previously masked because amd64 CI never reached the tests and arm64 runs no test step). A thread-local guard now runs the per-thread init and re-installs the process-global MobilityDuck error handler (meos_initialize() resets it to the exit-on-error default), invoked from the scalar exec wrapper and through a cast registration trampoline that covers every cast entry point. Locally the full suite goes from unrunnable to 58/59 files and 1311/1312 assertions with no segfaults; the one remaining assertion is an unrelated pre-existing ln() output drift from the MEOS bump.