### PR TITLE
Refresh tnumber ln/exp/log expected output for MEOS turning points

### DIFF
--- a/test/sql/parity/026b_tnumber_mathfuncs_followups.test
+++ b/test/sql/parity/026b_tnumber_mathfuncs_followups.test
@@ -6,22 +6,24 @@
 
 require mobilityduck
 
-# Unary tfloat math: ln(e) ≈ 1, log10(100) = 2, exp(0) = 1
+# Unary tfloat math: ln(e) ≈ 1, log10(100) = 2, exp(0) = 1.
+# Each lift inserts one chord-error-minimising turning point on the linear
+# input segment, so the result has three instants where the input had two.
 
 query I
 SELECT round(ln(tfloat '[1@2000-01-01, 2.71828182845905@2000-01-02]'), 6);
 ----
-[0@2000-01-01 00:00:00+01, 1@2000-01-02 00:00:00+01]
+[0@2000-01-01 00:00:00+01, 0.541325@2000-01-01 10:01:57.212526+01, 1@2000-01-02 00:00:00+01]
 
 query I
 SELECT log10(tfloat '[1@2000-01-01, 100@2000-01-02]');
 ----
-[0@2000-01-01 00:00:00+01, 2@2000-01-02 00:00:00+01]
+[0@2000-01-01 00:00:00+01, 1.332389510222689@2000-01-01 04:58:08.794345+01, 2@2000-01-02 00:00:00+01]
 
 query I
 SELECT round(exp(tfloat '[0@2000-01-01, 1@2000-01-02]'), 6);
 ----
-[1@2000-01-01 00:00:00+01, 2.718282@2000-01-02 00:00:00+01]
+[1@2000-01-01 00:00:00+01, 1.718282@2000-01-01 12:59:30.467438+01, 2.718282@2000-01-02 00:00:00+01]
 
 # deltaValue — successive differences
 

--- a/vcpkg_ports/meos/portfile.cmake
+++ b/vcpkg_ports/meos/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO MobilityDB/MobilityDB
-    REF 2c4243a265
-    SHA512 36d88c3a925d8c38a540c651fa74d127565985bcad79191344f2e93cb0de54e8f8efb84ef308595f8c4c122f1047e6b9d9696cff47bbc56ae9d0b4b807c7ab02
+    REPO estebanzimanyi/MobilityDB
+    REF a8178dc9d56d841d0eb5025a7e8717c8d25a1d0f
+    SHA512 030a144bb3247695702dd2de11f4c389ed28c6eb0186e6988a489e2b00e9801179ba8f27bcbcd81ae89e398a7277ed7f9ff7058dbf15f5db322ae4644365c560
 )
 
 vcpkg_replace_string(


### PR DESCRIPTION
The MEOS uplift adds tfloat_ln_turnpt / tfloat_exp_turnpt (MobilityDB #1003), which insert one chord-error-minimising turning point on a linear input segment for the transcendental unary lifts, so ln/log10/exp over a two-instant tfloat now return three instants. This refreshes the 026b expectations to the new values (captured from the built extension); deltaValue, trend and the arithmetic-alias cases are linear and unchanged. With this on top of the per-thread MEOS init fix the amd64 suite is fully green (59/59 files locally and the previously failing assertion now passes).