### PR TITLE
Wrap bigint_to_set in an int64_t forwarder for SetUnionAgg

### DIFF
--- a/src/temporal/set.cpp
+++ b/src/temporal/set.cpp
@@ -945,6 +945,13 @@ static inline Set *date_to_set_duckdb(DateADT d) {
     return date_to_set(ToMeosDate(duckdb::date_t(d)));
 }
 
+// macOS LP64: int64 (long) and int64_t (long long) are distinct types, so
+// clang rejects passing bigint_to_set where a Set *(*)(int64_t) is expected as
+// a non-type template arg. The cast is a no-op on Linux.
+static inline Set *bigint_to_set_duckdb(int64_t i) {
+    return bigint_to_set(static_cast<int64>(i));
+}
+
 struct SetPtrState {
     Set *accumulated;
 };
@@ -1069,7 +1076,7 @@ void SetTypes::RegisterSetUnionAgg(ExtensionLoader &loader) {
             LogicalType::INTEGER, SetTypes::intset()));
     set_union_set.AddFunction(
         AggregateFunction::UnaryAggregateDestructor<SetPtrState, int64_t, string_t,
-            SetUnionScalarFunction<int64_t, bigint_to_set>>(
+            SetUnionScalarFunction<int64_t, bigint_to_set_duckdb>>(
             LogicalType::BIGINT, SetTypes::bigintset()));
     set_union_set.AddFunction(
         AggregateFunction::UnaryAggregateDestructor<SetPtrState, double, string_t,


### PR DESCRIPTION
On macOS LP64 int64 (long) and int64_t (long long) are the same width but distinct types, so clang rejects bigint_to_set as the non-type template argument of SetUnionScalarFunction<int64_t, ...>, failing the osx_amd64 and osx_arm64 builds in the icu-fix stack leaf #138. This adds a bigint_to_set_duckdb forwarder taking int64_t and casting to int64 before calling MEOS, mirroring the existing date_to_set_duckdb idiom; the cast is a no-op on Linux. Stacked on #138 (fix/tnumber-math-turnpt-expected); its commits show in this diff until it merges.