### PR TITLE
Build the pinned MEOS with the CBUFFER, NPOINT, POSE and RGEO modules

### DIFF
--- a/vcpkg_ports/meos/portfile.cmake
+++ b/vcpkg_ports/meos/portfile.cmake
@@ -25,6 +25,12 @@ vcpkg_cmake_configure(
         # Build only the MEOS library, not the MEOS C test binaries: those link
         # the GEOS C++ API, which the arm64-linux vcpkg triplet does not carry.
         -DBUILD_TESTING=OFF
+        # Build the optional spatial type families that MobilityDuck ports
+        # (tcbuffer, tnpoint, tpose, trgeometry). RGEO depends on POSE.
+        -DCBUFFER=ON
+        -DNPOINT=ON
+        -DPOSE=ON
+        -DRGEO=ON
         -DCMAKE_C_FLAGS="-Dsession_timezone=meos_session_timezone"
         -DCMAKE_CXX_FLAGS="-Dsession_timezone=meos_session_timezone"
 


### PR DESCRIPTION
The MobilityDuck extended temporal type ports (tcbuffer, tnpoint, tpose, trgeometry) cannot link until the vcpkg-built MEOS exposes those modules. MEOS builds them opt-in and RGEO is a dependent option that requires POSE, so all four are enabled together in the vcpkg portfile OPTIONS, leaving each subsequent type port as pure extension code. Stacked on #134 because main's pinned MEOS predates the symbols these modules need and #134 already advances the pin; #134's pin-bump commit shows in the diff until it merges. The OPTIONS edit is independent of the REPO/REF/SHA512 pin lines that #142 and #143 rewrite, so it composes with whichever pin lands and needs only ordering, not textual reconciliation, against those PRs.