### PR TITLE
Add the core tpose type port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,14 @@ if(NPOINT)
     src/geo/tnpoint_in_out.cpp)
 endif()
 
+option(POSE "Build the tpose temporal type" ON)
+if(POSE)
+  add_definitions(-DPOSE=1)
+  list(APPEND EXTENSION_SOURCES
+    src/geo/tpose.cpp
+    src/geo/tpose_in_out.cpp)
+endif()
+
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} "" ${EXTENSION_SOURCES})
 

--- a/src/geo/tpose.cpp
+++ b/src/geo/tpose.cpp
@@ -1,0 +1,1442 @@
+#include "geo/tpose.hpp"
+#include "geo/tgeompoint_functions.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/common/extension_type_info.hpp"
+#include <regex>
+#include <string>
+#include <temporal/span.hpp>
+#include "temporal/spanset.hpp"
+#include "temporal/set.hpp"
+#include "temporal/temporal_functions.hpp"
+#include "geo/stbox.hpp"
+#include "geo/geoset.hpp"
+#include<time_util.hpp>
+#include "geo_util.hpp"
+#include "spatial/spatial_types.hpp"
+#include "mobilityduck/meos_exec_serial.hpp"
+
+extern "C" {
+    #include <meos.h>
+    #include <meos_geo.h>
+    #include <meos_internal.h>
+    #include <meos_internal_geo.h>
+    #include <meos_pose.h>
+}
+
+
+namespace duckdb {
+
+LogicalType TPoseTypes::TPOSE() {
+    auto type = LogicalType(LogicalTypeId::BLOB);
+    type.SetAlias("TPOSE");
+    return type;
+}
+
+/*
+ * Constructors
+*/
+
+static void Tpose_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_geom_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_geom_vec, result, count,
+        [&](string_t input_geom_str) -> string_t {
+            std::string input = input_geom_str.GetString();
+
+            Temporal *tinst = tpose_in(input.c_str());
+            if (!tinst) {
+                throw InvalidInputException("Invalid TPOSE input: " + input);
+            }
+
+            size_t data_size = temporal_mem_size(tinst);
+
+            uint8_t *data_buffer = (uint8_t*)malloc(data_size);
+            if (!data_buffer) {
+                free(tinst);
+                throw InvalidInputException("Failed to allocate memory for TPOSE data");
+            }
+
+            memcpy(data_buffer, tinst, data_size);
+
+            string_t data_string_t(reinterpret_cast<const char*>(data_buffer), data_size);
+            string_t stored_data = StringVector::AddStringOrBlob(result, data_string_t);
+
+            free(data_buffer);
+            free(tinst);
+
+            return stored_data;
+        });
+
+}
+
+static void Tposeinst_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &value_vec = args.data[0];
+    auto &t_vec = args.data[1];
+
+    BinaryExecutor::Execute<string_t, timestamp_tz_t, string_t>(
+        value_vec, t_vec, result, count,
+        [&](string_t value_str, timestamp_tz_t t) -> string_t {
+            std::string value = value_str.GetString();
+
+            // The tpose value type is a Pose (position + orientation):
+            // a 2D pose is a point plus a rotation angle, a 3D pose a
+            // point plus an orientation quaternion. It is parsed from
+            // its canonical text form, e.g. 'Pose(Point(1 1), 0.5)'.
+            Pose *po = pose_in(value.c_str());
+
+            if (po == NULL) {
+                throw InvalidInputException("Invalid pose format: " + value);
+            }
+
+            timestamp_tz_t meos_timestamp = DuckDBToMeosTimestamp(t);
+            // No tposeinst_make exists; the generic tinstant_make
+            // builds a T_TPOSE instant from the Pose Datum.
+            TInstant *inst = tinstant_make(Datum(po), T_TPOSE,
+                                           static_cast<TimestampTz>(meos_timestamp.value));
+
+            if (inst == NULL) {
+                free(po);
+                throw InvalidInputException("Failed to create TInstant");
+            }
+
+            size_t data_size = temporal_mem_size((Temporal*)inst);
+
+            uint8_t *data_buffer = (uint8_t *)malloc(data_size);
+
+            if (!data_buffer){
+                free(inst);
+                free(po);
+                throw InvalidInputException("Failed to allocate memory to pose data");
+            }
+            memcpy(data_buffer, inst, data_size);
+
+            string_t data_string_t(reinterpret_cast<const char*>(data_buffer),data_size);
+            string_t stored_data = StringVector::AddStringOrBlob(result, data_string_t);
+
+            free(data_buffer);
+            free(inst);
+            free(po);
+
+            return stored_data;
+
+        });
+
+}
+
+
+static void Tpose_sequence_from_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    const char* default_interp = "linear";
+    auto count = args.size();
+    auto arg_count = args.ColumnCount();
+
+    auto &input_geom_vec = args.data[0];
+    auto &span_vec = args.data[1];
+
+    // Check if interpolation parameter is provided
+    Vector *interp_vec = nullptr;
+    if (arg_count > 2) {
+        interp_vec = &args.data[2];
+    }
+
+    BinaryExecutor::Execute<string_t, string_t, string_t>(
+        input_geom_vec, span_vec, result, count,
+        [&](string_t input_geom_str, string_t span_str)-> string_t{
+            std::string geom_value = input_geom_str.GetString();
+
+            Pose *po = pose_in(geom_value.c_str());
+
+            if(po == NULL){
+                throw InvalidInputException("Invalid pose format: "+ geom_value);
+            }
+
+            std::string input = span_str.GetString();
+
+            Span *span_cmp = reinterpret_cast<Span*>(const_cast<char*>(input.c_str()));
+
+            // Use default interpolation or provided value
+            interpType interp = interptype_from_string(default_interp);
+            if (interp_vec) {
+                std::string interp_string = default_interp;
+                interp = interptype_from_string(interp_string.c_str());
+            }
+
+            TSequence *seq = tsequence_from_base_tstzspan(Datum(po), T_TPOSE, span_cmp, interp);
+
+            if (seq == NULL) {
+                free(po);
+                throw InvalidInputException("Failed to create TSequence");
+            }
+
+            size_t seq_size = temporal_mem_size((Temporal*)seq);
+
+            uint8_t *seq_buffer = (uint8_t *)malloc(seq_size);
+            if (!seq_buffer) {
+                free(seq);
+                free(po);
+                throw InvalidInputException("Failed to allocate memory for sequence data");
+            }
+
+            memcpy(seq_buffer, seq, seq_size);
+
+            string_t seq_string_t((char*) seq_buffer, seq_size);
+            string_t stored_data = StringVector::AddStringOrBlob(result, seq_string_t);
+
+            free(seq_buffer);
+            free(seq);
+            free(po);
+
+            return stored_data;
+
+        });
+
+}
+
+TInstant **temparr_extract_ps(Vector &tpose_arr_vec, list_entry_t list_entry, int *count) {
+    auto &child_vector = ListVector::GetEntry(tpose_arr_vec);
+    auto list_size = list_entry.length;
+    auto list_offset = list_entry.offset;
+
+    if (list_size == 0) {
+        *count = 0;
+        return nullptr;
+    }
+
+    *count = list_size;
+
+    TInstant **instants = (TInstant**)malloc(sizeof(TInstant*) * list_size);
+    if (!instants) {
+        *count = 0;
+        return nullptr;
+    }
+
+    for (idx_t i = 0; i < list_size; i++) {
+        auto element_idx = list_offset + i;
+        string_t tgeom_blob = FlatVector::GetData<string_t>(child_vector)[element_idx];
+
+        const uint8_t *data = reinterpret_cast<const uint8_t*>(tgeom_blob.GetData());
+        size_t data_size = tgeom_blob.GetSize();
+
+        if (data_size < sizeof(void*)) {
+            for (idx_t j = 0; j < i; j++) {
+                if (instants[j]) free(instants[j]);
+            }
+            free(instants);
+            *count = 0;
+            return nullptr;
+        }
+
+        uint8_t *data_copy = (uint8_t*)malloc(data_size);
+        if (!data_copy) {
+            for (idx_t j = 0; j < i; j++) {
+                if (instants[j]) free(instants[j]);
+            }
+            free(instants);
+            *count = 0;
+            return nullptr;
+        }
+        memcpy(data_copy, data, data_size);
+
+        Temporal *temp = reinterpret_cast<Temporal*>(data_copy);
+        if (!temp) {
+            free(data_copy);
+            for (idx_t j = 0; j < i; j++) {
+                if (instants[j]) free(instants[j]);
+            }
+            free(instants);
+            *count = 0;
+            return nullptr;
+        }
+
+        instants[i] = (TInstant*)temp;
+    }
+
+    return instants;
+}
+
+static void Tpose_sequence_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
+    // Default values
+    const char* default_interp = "linear";
+    bool default_lower_inc = true;
+    bool default_upper_inc = true;
+
+    auto count = args.size();
+    auto arg_count = args.ColumnCount();
+
+
+    auto &tpose_arr_vec = args.data[0];
+    tpose_arr_vec.Flatten(count);
+
+    Vector *interp_vec = nullptr;
+    Vector *lower_vec = nullptr;
+    Vector *upper_vec = nullptr;
+
+    if (arg_count > 1) {
+        interp_vec = &args.data[1];
+        interp_vec->Flatten(count);
+    }
+    if (arg_count > 2) {
+        lower_vec = &args.data[2];
+        lower_vec->Flatten(count);
+    }
+    if (arg_count > 3) {
+        upper_vec = &args.data[3];
+        upper_vec->Flatten(count);
+    }
+
+    result.Flatten(count);
+
+    auto tpose_data = FlatVector::GetData<list_entry_t>(tpose_arr_vec);
+    auto result_data = FlatVector::GetData<string_t>(result);
+
+    // Get validity masks
+    auto &tpose_validity = FlatVector::Validity(tpose_arr_vec);
+    auto &result_validity = FlatVector::Validity(result);
+
+    for (idx_t i = 0; i < count; i++) {
+        if (!tpose_validity.RowIsValid(i)) {
+            result_validity.SetInvalid(i);
+            continue;
+        }
+
+        try {
+            list_entry_t list_entry = tpose_data[i];
+
+            // Handle interp parameter with default
+            std::string interp_str = default_interp;
+            if (interp_vec) {
+                auto interp_data = FlatVector::GetData<string_t>(*interp_vec);
+                auto &interp_validity = FlatVector::Validity(*interp_vec);
+                if (interp_validity.RowIsValid(i)) {
+                    interp_str = interp_data[i].GetString();
+                }
+            }
+            interpType interp = interptype_from_string(interp_str.c_str());
+
+            bool lower_inc = default_lower_inc;
+            bool upper_inc = default_upper_inc;
+
+            if (lower_vec) {
+                auto lower_data = FlatVector::GetData<bool>(*lower_vec);
+                auto &lower_validity = FlatVector::Validity(*lower_vec);
+                if (lower_validity.RowIsValid(i)) {
+                    lower_inc = lower_data[i];
+                }
+            }
+
+            if (upper_vec) {
+                auto upper_data = FlatVector::GetData<bool>(*upper_vec);
+                auto &upper_validity = FlatVector::Validity(*upper_vec);
+                if (upper_validity.RowIsValid(i)) {
+                    upper_inc = upper_data[i];
+                }
+            }
+
+            // Extract array elements
+            int element_count;
+            TInstant **instants = temparr_extract_ps(tpose_arr_vec, list_entry, &element_count);
+
+            if (!instants || element_count == 0) {
+                result_validity.SetInvalid(i);
+                continue;
+            }
+
+            TSequence *sequence_result = tsequence_make((TInstant **) instants, element_count,
+                                                    lower_inc, upper_inc, interp, true);
+
+            if (!sequence_result) {
+                for (int j = 0; j < element_count; j++) {
+                    if (instants[j]) {
+                        free(instants[j]);
+                    }
+                }
+                free(instants);
+                result_validity.SetInvalid(i);
+                continue;
+            }
+
+            size_t data_size = temporal_mem_size(reinterpret_cast<Temporal*>(sequence_result));
+            uint8_t *data_buffer = (uint8_t*)malloc(data_size);
+            if (!data_buffer) {
+                free(sequence_result);
+                for (int j = 0; j < element_count; j++) {
+                    if (instants[j]) {
+                        free(instants[j]);
+                    }
+                }
+                free(instants);
+                result_validity.SetInvalid(i);
+                continue;
+            }
+
+            memcpy(data_buffer, sequence_result, data_size);
+
+            string_t data_string_t(reinterpret_cast<const char*>(data_buffer), data_size);
+            result_data[i] = StringVector::AddStringOrBlob(result, data_string_t);
+
+            free(data_buffer);
+            free(sequence_result);
+            for (int j = 0; j < element_count; j++) {
+                if (instants[j]) {
+                    free(instants[j]);
+                }
+            }
+            free(instants);
+
+        } catch (const std::exception& e) {
+            result_validity.SetInvalid(i);
+        }
+    }
+
+}
+
+
+
+
+/*
+ * Conversions
+*/
+
+static void Temporal_to_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_geom_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_geom_vec, result, count,
+        [&](string_t input_str) -> string_t {
+            std::string input = input_str.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+
+            if (!temp) {
+                throw InvalidInputException("Invalid TPOSE data: null pointer");
+            }
+
+            Span *timespan = temporal_to_tstzspan(temp);
+
+            if (!timespan) {
+                throw InvalidInputException("Failed to extract timespan from TPOSE");
+            }
+
+            size_t span_size = sizeof(Span);
+
+            uint8_t *span_buffer = (uint8_t*)malloc(span_size);
+            if (!span_buffer) {
+                free(timespan);
+                throw InvalidInputException("Failed to allocate memory for timespan data");
+            }
+
+            memcpy(span_buffer, timespan, span_size);
+
+            string_t span_string_t(reinterpret_cast<const char*>(span_buffer), span_size);
+            string_t stored_data = StringVector::AddStringOrBlob(result, span_string_t);
+
+            free(span_buffer);
+            free(timespan);
+
+            return stored_data;
+        }
+    );
+
+}
+
+/*
+ * Transformations
+*/
+
+static void Temporal_to_tinstant(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_geom_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_geom_vec, result, count,
+        [&](string_t input_str) -> string_t {
+            std::string input = input_str.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+
+            if (!temp) {
+                throw InvalidInputException("Invalid TPOSE data: null pointer");
+            }
+
+            TInstant *inst = temporal_to_tinstant(temp);
+            if (!inst) {
+                throw InvalidInputException("Failed to convert TPOSE to TInstant");
+            }
+
+            size_t inst_size = temporal_mem_size((Temporal*)inst);
+
+            uint8_t *inst_buffer = (uint8_t*)malloc(inst_size);
+            if (!inst_buffer) {
+                free(inst);
+                throw InvalidInputException("Failed to allocate memory for TInstant data");
+            }
+
+            memcpy(inst_buffer, inst, inst_size);
+
+            string_t inst_string_t(reinterpret_cast<const char*>(inst_buffer), inst_size);
+            string_t stored_data = StringVector::AddStringOrBlob(result, inst_string_t);
+
+            free(inst_buffer);
+            free(inst);
+
+            return stored_data;
+        }
+    );
+
+}
+
+
+static void Temporal_set_interp(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &tgeom_vec = args.data[0];
+    auto &interp_vec = args.data[1];
+
+    tgeom_vec.Flatten(count);
+    interp_vec.Flatten(count);
+
+    BinaryExecutor::Execute<string_t, string_t, string_t>(
+        tgeom_vec, interp_vec, result, count,
+        [&](string_t tgeom_str_t, string_t interp_str_t) -> string_t {
+
+            std::string input = tgeom_str_t.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+            if (!temp) {
+                throw InvalidInputException("Invalid TPOSE data: null pointer");
+            }
+
+            std::string interp_str = interp_str_t.GetString();
+            interpType new_interp = interptype_from_string(interp_str.c_str());
+
+            Temporal *result_temp = temporal_set_interp(temp, new_interp);
+            if (!result_temp) {
+                throw InvalidInputException("Failed to set interpolation");
+            }
+
+            // Serialize result back to binary
+            size_t result_size = temporal_mem_size(result_temp);
+            uint8_t *result_buffer = (uint8_t*)malloc(result_size);
+            if (!result_buffer) {
+                free(result_temp);
+                throw InvalidInputException("Failed to allocate memory for result");
+            }
+
+            memcpy(result_buffer, result_temp, result_size);
+            string_t result_string_t(reinterpret_cast<const char*>(result_buffer), result_size);
+            string_t stored_data = StringVector::AddStringOrBlob(result, result_string_t);
+
+            free(result_buffer);
+            free(result_temp);
+
+            return stored_data;
+        });
+
+}
+
+
+static void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &tgeom1_vec = args.data[0];
+    auto &tgeom2_vec = args.data[1];
+
+    tgeom1_vec.Flatten(count);
+    tgeom2_vec.Flatten(count);
+
+    BinaryExecutor::Execute<string_t, string_t, string_t>(
+        tgeom1_vec, tgeom2_vec, result, count,
+        [&](string_t tgeom1_str_t, string_t tgeom2_str_t) -> string_t {
+            std::string tgeom1 = tgeom1_str_t.GetString();
+
+            Temporal *temp1 = reinterpret_cast<Temporal*>(const_cast<char*>(tgeom1.c_str()));
+            if (!temp1) {
+                throw InvalidInputException("Invalid TPOSE data: null pointer");
+            }
+
+            std::string tgeom2 = tgeom2_str_t.GetString();
+
+            Temporal *temp2 = reinterpret_cast<Temporal*>(const_cast<char*>(tgeom2.c_str()));
+            if (!temp2) {
+                throw InvalidInputException("Invalid TPOSE data: null pointer");
+            }
+
+            Temporal *result_temp = temporal_merge(temp1, temp2);
+            if (!result_temp) {
+                throw InvalidInputException("Failed to merge temporal poses");
+            }
+
+            // Serialize result back to binary
+            size_t result_size = temporal_mem_size(result_temp);
+            uint8_t *result_buffer = (uint8_t*)malloc(result_size);
+            if (!result_buffer) {
+                free(result_temp);
+                throw InvalidInputException("Failed to allocate memory for result");
+            }
+
+            memcpy(result_buffer, result_temp, result_size);
+            string_t result_string_t(reinterpret_cast<const char*>(result_buffer), result_size);
+            string_t stored_data = StringVector::AddStringOrBlob(result, result_string_t);
+
+            free(result_buffer);
+            free(result_temp);
+
+            return stored_data;
+        });
+
+}
+
+
+/*
+ * Accessor Functions
+*/
+
+static void Temporal_subtype(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &tgeom_vec = args.data[0];
+
+    tgeom_vec.Flatten(count);
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        tgeom_vec, result, count,
+        [&](string_t tgeom_str_t) -> string_t {
+            std::string input = tgeom_str_t.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+            if (!temp) {
+                throw InvalidInputException("Invalid TPOSE data: null pointer");
+            }
+
+            const char *subtype_str = temporal_subtype(temp);
+            if (!subtype_str) {
+                throw InvalidInputException("Failed to get temporal subtype");
+            }
+
+            std::string result_str(subtype_str);
+            string_t stored_result = StringVector::AddString(result, result_str);
+
+            return stored_result;
+        });
+
+}
+
+
+
+
+static void Temporal_interp(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &tgeom_vec = args.data[0];
+
+    tgeom_vec.Flatten(count);
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        tgeom_vec, result, count,
+        [&](string_t tgeom_str_t) -> string_t {
+
+            std::string input = tgeom_str_t.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+            if (!temp) {
+                throw InvalidInputException("Invalid TPOSE data: null pointer");
+            }
+
+
+            const char *interp_str = temporal_interp(temp);
+            if (!interp_str) {
+                throw InvalidInputException("Failed to get temporal interpolation");
+            }
+
+            std::string result_str(interp_str);
+            string_t stored_result = StringVector::AddString(result, result_str);
+
+            return stored_result;
+        });
+
+}
+
+static void Temporal_mem_size(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &tgeom_vec = args.data[0];
+
+    tgeom_vec.Flatten(count);
+
+    UnaryExecutor::Execute<string_t, int32_t>(
+        tgeom_vec, result, count,
+        [&](string_t tgeom_str_t) -> int32_t {
+           std::string input = tgeom_str_t.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+            if (!temp) {
+                throw InvalidInputException("Invalid TPOSE data: null pointer");
+            }
+
+            size_t mem_size = temporal_mem_size(temp);
+
+
+            return static_cast<int32_t>(mem_size);
+        });
+
+}
+
+// ---- Pose value accessors ----
+// The tpose value type is a Pose (position + orientation), which is not
+// a registered DuckDB type: a 2D pose is a point plus a rotation angle,
+// a 3D pose a point plus an orientation quaternion. getValue /
+// startValue / endValue surface it in its canonical text form
+// (`Pose(POINT(x y),theta)`), mirroring the asText output. point(tpose)
+// returns the position geometry via pose_to_point and rotation(tpose)
+// returns the 2D rotation angle via pose_rotation, per the manual model.
+
+static Pose *pose_from_instant_value(const TInstant *inst) {
+    Datum d = tinstant_value(inst);
+    return reinterpret_cast<Pose*>(d);
+}
+
+static void Tpose_get_value(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_vec, result, count,
+        [&](string_t input_str) -> string_t {
+            std::string input = input_str.GetString();
+
+            TInstant *tinst = reinterpret_cast<TInstant*>(const_cast<char*>(input.c_str()));
+
+            // tinstant_value returns a freshly allocated copy of the
+            // Pose value (datum_copy), which the caller owns.
+            Pose *po = pose_from_instant_value(tinst);
+
+            char *str = pose_as_text(po, 15);
+            if (!str) {
+                free(po);
+                throw InvalidInputException("Failed to convert pose value to text");
+            }
+            std::string output(str);
+            string_t stored_result = StringVector::AddString(result, output);
+
+            free(str);
+            free(po);
+
+            return stored_result;
+        });
+
+}
+
+
+
+static void Tpose_start_value(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_vec, result, count,
+        [&](string_t input_str) -> string_t {
+            std::string input = input_str.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+
+            // temporal_start_value returns a freshly allocated copy of
+            // the Pose value (datum_copy), which the caller owns.
+            Datum start_datum = temporal_start_value(temp);
+
+            Pose *po = reinterpret_cast<Pose*>(start_datum);
+            char *str = pose_as_text(po, 15);
+            if (!str) {
+                free(po);
+                throw InvalidInputException("Failed to convert pose value to text");
+            }
+            std::string output(str);
+            string_t stored_result = StringVector::AddString(result, output);
+
+            free(str);
+            free(po);
+
+            return stored_result;
+        });
+
+}
+
+
+static void Tpose_end_value(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_vec, result, count,
+        [&](string_t input_str) -> string_t {
+            std::string input = input_str.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+
+            // temporal_end_value returns a freshly allocated copy of
+            // the Pose value (datum_copy), which the caller owns.
+            Datum end_datum = temporal_end_value(temp);
+
+            Pose *po = reinterpret_cast<Pose*>(end_datum);
+            char *str = pose_as_text(po, 15);
+            if (!str) {
+                free(po);
+                throw InvalidInputException("Failed to convert pose value to text");
+            }
+            std::string output(str);
+            string_t stored_result = StringVector::AddString(result, output);
+
+            free(str);
+            free(po);
+
+            return stored_result;
+        });
+
+}
+
+static void Tpose_point(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_vec, result, count,
+        [&](string_t input_str) -> string_t {
+            std::string input = input_str.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+
+            // temporal_start_value returns a freshly allocated copy of
+            // the Pose value (datum_copy), which the caller owns.
+            Datum start_datum = temporal_start_value(temp);
+            Pose *po = reinterpret_cast<Pose*>(start_datum);
+
+            // pose_to_point returns a freshly allocated GSERIALIZED copy
+            // of the pose's position geometry.
+            GSERIALIZED *gs = pose_to_point(po);
+            if (!gs) {
+                free(po);
+                throw InvalidInputException("Failed to extract point from pose");
+            }
+
+            string_t geometry_blob = GSerializedToGeometry(gs, state, result);
+            string_t stored_result = StringVector::AddStringOrBlob(result, geometry_blob);
+
+            free(gs);
+            free(po);
+
+            return stored_result;
+        });
+
+}
+
+static void Tpose_rotation(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, double>(
+        input_vec, result, count,
+        [&](string_t input_str) -> double {
+            std::string input = input_str.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+
+            // temporal_start_value returns a freshly allocated copy of
+            // the Pose value (datum_copy), which the caller owns.
+            Datum start_datum = temporal_start_value(temp);
+            Pose *po = reinterpret_cast<Pose*>(start_datum);
+
+            // pose_rotation returns the 2D rotation angle (theta).
+            double theta = pose_rotation(po);
+            free(po);
+            return theta;
+        });
+
+}
+
+
+static void Temporal_lower_inc(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_vec, result, count,
+        [&](string_t input_str) -> string_t {
+            std::string input = input_str.GetString();
+
+            Temporal* temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+
+            bool lower_inc = temporal_lower_inc(temp);
+
+            std::string result_str = lower_inc ? "true" : "false";
+            string_t stored_result = StringVector::AddString(result, result_str);
+            return stored_result;
+        });
+
+}
+
+static void Temporal_upper_inc(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_vec, result, count,
+        [&](string_t input_str) -> string_t {
+            std::string input = input_str.GetString();
+
+            Temporal* temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+
+            bool upper_inc = temporal_upper_inc(temp);
+
+            std::string result_str = upper_inc ? "true" : "false";
+            string_t stored_result = StringVector::AddString(result, result_str);
+            return stored_result;
+        });
+
+}
+
+static void Temporal_start_instant(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_vec, result, count,
+        [&](string_t input_str) -> string_t {
+            std::string input = input_str.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+
+            TInstant *start_inst = temporal_start_instant(temp);
+
+            if (!start_inst) {
+                throw InvalidInputException("Failed to get start_inst from temporal object");
+            }
+
+            size_t result_size = temporal_mem_size((Temporal*)start_inst);
+            if (result_size == 0) {
+                throw InvalidInputException("Invalid result size from temporal object");
+            }
+
+            uint8_t *result_buffer = (uint8_t*)malloc(result_size);
+            if (!result_buffer) {
+                free(start_inst);
+                throw InvalidInputException("Failed to allocate memory for result");
+            }
+
+            memcpy(result_buffer, start_inst, result_size);
+            string_t result_string_t(reinterpret_cast<const char*>(result_buffer), result_size);
+            string_t stored_result = StringVector::AddStringOrBlob(result, result_string_t);
+
+            free(result_buffer);
+            free(start_inst);
+            return stored_result;
+        });
+
+}
+
+static void Temporal_end_instant(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_vec, result, count,
+        [&](string_t input_str) -> string_t {
+            std::string input = input_str.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(input.c_str()));
+
+            TInstant *end_inst = temporal_end_instant(temp);
+
+            if (!end_inst) {
+                throw InvalidInputException("Failed to get end_inst from temporal object");
+            }
+
+            size_t result_size = temporal_mem_size((Temporal*)end_inst);
+            if (result_size == 0) {
+                throw InvalidInputException("Invalid result size from temporal object");
+            }
+
+            uint8_t *result_buffer = (uint8_t*)malloc(result_size);
+            if (!result_buffer) {
+                free(end_inst);
+                throw InvalidInputException("Failed to allocate memory for result");
+            }
+
+            memcpy(result_buffer, end_inst, result_size);
+            string_t result_string_t(reinterpret_cast<const char*>(result_buffer), result_size);
+            string_t stored_result = StringVector::AddStringOrBlob(result, result_string_t);
+
+            free(result_buffer);
+            free(end_inst);
+            return stored_result;
+        });
+
+}
+
+
+
+
+static void Temporal_instant_n(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &tgeom_vec = args.data[0];
+    auto &n_vec = args.data[1];
+
+    BinaryExecutor::Execute<string_t, int32_t, string_t>(
+        tgeom_vec, n_vec, result, count,
+        [&](string_t tgeom_str, int32_t n) -> string_t {
+            std::string tgeom = tgeom_str.GetString();
+
+            Temporal *temp = reinterpret_cast<Temporal*>(const_cast<char*>(tgeom.c_str()));
+
+            TInstant *inst_n = temporal_instant_n(temp, n);
+            if (!inst_n) {
+                throw InvalidInputException("Failed to get instant n from temporal object");
+            }
+
+            size_t result_size = temporal_mem_size((Temporal*)inst_n);
+            if (result_size == 0) {
+                throw InvalidInputException("Invalid result size from temporal object");
+            }
+
+            uint8_t *result_buffer = (uint8_t*)malloc(result_size);
+            if (!result_buffer) {
+                free(inst_n);
+                throw InvalidInputException("Failed to allocate memory for result");
+            }
+
+            memcpy(result_buffer, inst_n, result_size);
+            string_t result_string_t(reinterpret_cast<const char*>(result_buffer), result_size);
+            string_t stored_result = StringVector::AddStringOrBlob(result, result_string_t);
+
+            free(result_buffer);
+            free(inst_n);
+            return stored_result;
+        });
+
+}
+
+
+static void Tinstant_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_geom_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, timestamp_tz_t>(
+        input_geom_vec, result, count,
+        [&](string_t input_geom_str) -> timestamp_tz_t {
+            const uint8_t *data = reinterpret_cast<const uint8_t*>(input_geom_str.GetData());
+            size_t data_size = input_geom_str.GetSize();
+
+            if (data_size < sizeof(void*)) {
+                throw InvalidInputException("Invalid TPOSE data: insufficient size");
+            }
+
+            uint8_t *data_copy = (uint8_t*)malloc(data_size);
+            if (!data_copy) {
+                throw InvalidInputException("Failed to allocate memory for TPOSE deserialization");
+            }
+            memcpy(data_copy, data, data_size);
+
+            TInstant *temp = reinterpret_cast<TInstant*>(data_copy);
+
+            if (!temp) {
+                free(data_copy);
+                throw InvalidInputException("Invalid TPOSE data: null pointer");
+            }
+
+            TimestampTz meos_t = temp->t;
+
+            timestamp_tz_t meos_timestamp{meos_t};
+            timestamp_tz_t duckdb_t = MeosToDuckDBTimestamp(meos_timestamp);
+
+            free(data_copy);
+
+            return duckdb_t;
+        }
+    );
+
+}
+
+
+void TPoseTypes::RegisterScalarFunctions(ExtensionLoader &loader) {
+
+    auto tpose_function = ScalarFunction(
+        "TPOSE",
+        {LogicalType::VARCHAR},
+        TPoseTypes::TPOSE(),
+        Tpose_constructor
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  tpose_function);
+
+    auto tpose_from_timestamp_function = ScalarFunction(
+        "TPOSE",
+        {LogicalType::VARCHAR, LogicalType::TIMESTAMP_TZ},
+        TPoseTypes::TPOSE(),
+        Tposeinst_constructor);
+    duckdb::RegisterSerializedScalarFunction(loader,  tpose_from_timestamp_function);
+
+     auto tpose_from_tstzspan_function = ScalarFunction(
+        "TPOSE",
+        {LogicalType::VARCHAR, SpanTypes::TSTZSPAN(), LogicalType::VARCHAR},
+        TPoseTypes::TPOSE(),
+        Tpose_sequence_from_tstzspan
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  tpose_from_tstzspan_function);
+
+    auto tpose_from_tstzspan_default = ScalarFunction(
+        "TPOSE",
+        {LogicalType::VARCHAR, SpanTypes::TSTZSPAN()},
+        TPoseTypes::TPOSE(),
+        Tpose_sequence_from_tstzspan
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  tpose_from_tstzspan_default);
+
+     auto tposeseqarr_1param= ScalarFunction(
+        "tposeSeq",
+        {LogicalType::LIST(TPoseTypes::TPOSE())},
+        TPoseTypes::TPOSE(),
+        Tpose_sequence_constructor
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  tposeseqarr_1param);
+
+    auto tposeseqarr_2params = ScalarFunction(
+        "tposeSeq",
+        {LogicalType::LIST(TPoseTypes::TPOSE()), LogicalType::VARCHAR},
+        TPoseTypes::TPOSE(),
+        Tpose_sequence_constructor
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  tposeseqarr_2params);
+
+    auto tposeseqarr_3params = ScalarFunction(
+        "tposeSeq",
+        {LogicalType::LIST(TPoseTypes::TPOSE()), LogicalType::VARCHAR, LogicalType::BOOLEAN},
+        TPoseTypes::TPOSE(),
+        Tpose_sequence_constructor
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  tposeseqarr_3params);
+
+    auto tposeseqarr_4params = ScalarFunction(
+        "tposeSeq",
+        {LogicalType::LIST(TPoseTypes::TPOSE()), LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN},
+        TPoseTypes::TPOSE(),
+        Tpose_sequence_constructor
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  tposeseqarr_4params);
+
+    auto tpose_to_timespan_function = ScalarFunction(
+        "timeSpan",
+        {TPoseTypes::TPOSE()},
+        SpanTypes::TSTZSPAN(),
+        Temporal_to_tstzspan);
+    duckdb::RegisterSerializedScalarFunction(loader,  tpose_to_timespan_function);
+
+    auto tpose_to_tinstant_function = ScalarFunction(
+        "tposeInst",
+        {TPoseTypes::TPOSE()},
+        TPoseTypes::TPOSE(),
+        Temporal_to_tinstant);
+    duckdb::RegisterSerializedScalarFunction(loader,  tpose_to_tinstant_function);
+
+
+    auto setInterp_function = ScalarFunction(
+        "setInterp",
+        {TPoseTypes::TPOSE(), LogicalType::VARCHAR},
+        TPoseTypes::TPOSE(),
+        Temporal_set_interp
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  setInterp_function);
+
+
+    auto merge_function = ScalarFunction(
+        "merge",
+        {TPoseTypes::TPOSE(), TPoseTypes::TPOSE()},
+        TPoseTypes::TPOSE(),
+        Temporal_merge
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  merge_function);
+
+    auto tempSubtype_function = ScalarFunction(
+        "tempSubtype",
+        {TPoseTypes::TPOSE()},
+        LogicalType::VARCHAR,
+        Temporal_subtype
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  tempSubtype_function);
+
+    auto interp_function = ScalarFunction(
+        "interp",
+        {TPoseTypes::TPOSE()},
+        LogicalType::VARCHAR,
+        Temporal_interp
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  interp_function);
+
+    auto memSize_function = ScalarFunction(
+        "memSize",
+        {TPoseTypes::TPOSE()},
+        LogicalType::INTEGER,
+        Temporal_mem_size
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  memSize_function);
+
+    auto getValue_function = ScalarFunction(
+        "getValue",
+        {TPoseTypes::TPOSE()},
+        LogicalType::VARCHAR,
+        Tpose_get_value
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  getValue_function);
+
+
+    auto tpose_start_value_function = ScalarFunction(
+        "startValue",
+        {TPoseTypes::TPOSE()},
+        LogicalType::VARCHAR,
+        Tpose_start_value
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  tpose_start_value_function);
+
+    auto tpose_end_value_function = ScalarFunction(
+        "endValue",
+        {TPoseTypes::TPOSE()},
+        LogicalType::VARCHAR,
+        Tpose_end_value
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  tpose_end_value_function);
+
+    auto tpose_point_function = ScalarFunction(
+        "point",
+        {TPoseTypes::TPOSE()},
+        GeoTypes::GEOMETRY(),
+        Tpose_point
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  tpose_point_function);
+
+    auto tpose_rotation_function = ScalarFunction(
+        "rotation",
+        {TPoseTypes::TPOSE()},
+        LogicalType::DOUBLE,
+        Tpose_rotation
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  tpose_rotation_function);
+
+    auto startInstant_function = ScalarFunction(
+        "startInstant",
+        {TPoseTypes::TPOSE()},
+        TPoseTypes::TPOSE(),
+        Temporal_start_instant
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  startInstant_function);
+
+    auto endInstant_function = ScalarFunction(
+        "endInstant",
+        {TPoseTypes::TPOSE()},
+        TPoseTypes::TPOSE(),
+        Temporal_end_instant
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  endInstant_function);
+
+    auto instantN_function = ScalarFunction(
+        "instantN",
+        {TPoseTypes::TPOSE(), LogicalType::INTEGER},
+        TPoseTypes::TPOSE(),
+        Temporal_instant_n
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  instantN_function);
+
+
+    auto tpose_gettimestamptz_function = ScalarFunction(
+        "getTimestamp",
+        {TPoseTypes::TPOSE()},
+        LogicalType::TIMESTAMP_TZ,
+        Tinstant_timestamptz);
+    duckdb::RegisterSerializedScalarFunction(loader,  tpose_gettimestamptz_function);
+
+
+    // ===================================================================
+    // Foundational tpose surface — accessors, time/value-restrict,
+    // modifiers, and comparison. The MEOS C functions delegated to here
+    // are subtype-agnostic (they take Temporal *), so we reuse the same
+    // generic handlers wired for tgeompoint in temporal_functions.cpp.
+    // ===================================================================
+
+    const LogicalType TGEOM = TPoseTypes::TPOSE();
+    const LogicalType TSTZ  = LogicalType::TIMESTAMP_TZ;
+    const LogicalType IVAL  = LogicalType::INTERVAL;
+
+    // ---- Accessors ----
+    loader.RegisterFunction(ScalarFunction(
+        "valueAtTimestamp", {TGEOM, TSTZ}, LogicalType::VARCHAR,
+        Tpose_get_value));
+    loader.RegisterFunction(ScalarFunction(
+        "getTime", {TGEOM}, SpansetTypes::tstzspanset(),
+        TemporalFunctions::Temporal_time));
+    loader.RegisterFunction(ScalarFunction(
+        "duration", {TGEOM}, IVAL,
+        TemporalFunctions::Temporal_duration));
+    loader.RegisterFunction(ScalarFunction(
+        "duration", {TGEOM, LogicalType::BOOLEAN}, IVAL,
+        TemporalFunctions::Temporal_duration));
+    loader.RegisterFunction(ScalarFunction(
+        "lowerInc", {TGEOM}, LogicalType::BOOLEAN,
+        TemporalFunctions::Temporal_lower_inc));
+    loader.RegisterFunction(ScalarFunction(
+        "upperInc", {TGEOM}, LogicalType::BOOLEAN,
+        TemporalFunctions::Temporal_upper_inc));
+    loader.RegisterFunction(ScalarFunction(
+        "numInstants", {TGEOM}, LogicalType::INTEGER,
+        TemporalFunctions::Temporal_num_instants));
+    loader.RegisterFunction(ScalarFunction(
+        "instants", {TGEOM}, LogicalType::LIST(TGEOM),
+        TemporalFunctions::Temporal_instants));
+    loader.RegisterFunction(ScalarFunction(
+        "numSequences", {TGEOM}, LogicalType::INTEGER,
+        TemporalFunctions::Temporal_num_sequences));
+    loader.RegisterFunction(ScalarFunction(
+        "sequences", {TGEOM}, LogicalType::LIST(TGEOM),
+        TemporalFunctions::Temporal_sequences));
+    loader.RegisterFunction(ScalarFunction(
+        "startSequence", {TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_start_sequence));
+    loader.RegisterFunction(ScalarFunction(
+        "endSequence", {TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_end_sequence));
+    loader.RegisterFunction(ScalarFunction(
+        "sequenceN", {TGEOM, LogicalType::INTEGER}, TGEOM,
+        TemporalFunctions::Temporal_sequence_n));
+    loader.RegisterFunction(ScalarFunction(
+        "numTimestamps", {TGEOM}, LogicalType::INTEGER,
+        TemporalFunctions::Temporal_num_timestamps));
+    loader.RegisterFunction(ScalarFunction(
+        "timestamps", {TGEOM}, LogicalType::LIST(TSTZ),
+        TemporalFunctions::Temporal_timestamps));
+    loader.RegisterFunction(ScalarFunction(
+        "startTimestamp", {TGEOM}, TSTZ,
+        TemporalFunctions::Temporal_start_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "endTimestamp", {TGEOM}, TSTZ,
+        TemporalFunctions::Temporal_end_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "timestampN", {TGEOM, LogicalType::INTEGER}, TSTZ,
+        TemporalFunctions::Temporal_timestamptz_n));
+    loader.RegisterFunction(ScalarFunction(
+        "segments", {TGEOM}, LogicalType::LIST(TGEOM),
+        TemporalFunctions::Temporal_segments));
+
+    // ---- Time-domain restrict / minus ----
+    for (const auto &t : std::vector<std::pair<LogicalType, scalar_function_t>>{
+             {TSTZ,                       TemporalFunctions::Temporal_at_timestamptz},
+             {SetTypes::tstzset(),        TemporalFunctions::Temporal_at_tstzset},
+             {SpanTypes::TSTZSPAN(),      TemporalFunctions::Temporal_at_tstzspan},
+             {SpansetTypes::tstzspanset(), TemporalFunctions::Temporal_at_tstzspanset}}) {
+        loader.RegisterFunction(ScalarFunction(
+            "atTime", {TGEOM, t.first}, TGEOM, t.second));
+    }
+    for (const auto &t : std::vector<std::pair<LogicalType, scalar_function_t>>{
+             {TSTZ,                       TemporalFunctions::Temporal_minus_timestamptz},
+             {SetTypes::tstzset(),        TemporalFunctions::Temporal_minus_tstzset},
+             {SpanTypes::TSTZSPAN(),      TemporalFunctions::Temporal_minus_tstzspan},
+             {SpansetTypes::tstzspanset(), TemporalFunctions::Temporal_minus_tstzspanset}}) {
+        loader.RegisterFunction(ScalarFunction(
+            "minusTime", {TGEOM, t.first}, TGEOM, t.second));
+    }
+
+    // beforeTimestamp / afterTimestamp accept timestamptz
+    loader.RegisterFunction(ScalarFunction(
+        "beforeTimestamp", {TGEOM, TSTZ}, TGEOM,
+        TemporalFunctions::Temporal_before_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "afterTimestamp", {TGEOM, TSTZ}, TGEOM,
+        TemporalFunctions::Temporal_after_timestamptz));
+
+    // ---- Modifiers (shift / scale / shiftScale / append / insert / update /
+    // delete) ----
+    loader.RegisterFunction(ScalarFunction(
+        "shiftTime", {TGEOM, IVAL}, TGEOM,
+        TemporalFunctions::Temporal_shift_time));
+    loader.RegisterFunction(ScalarFunction(
+        "scaleTime", {TGEOM, IVAL}, TGEOM,
+        TemporalFunctions::Temporal_scale_time));
+    loader.RegisterFunction(ScalarFunction(
+        "shiftScaleTime", {TGEOM, IVAL, IVAL}, TGEOM,
+        TemporalFunctions::Temporal_shift_scale_time));
+    loader.RegisterFunction(ScalarFunction(
+        "appendInstant", {TGEOM, TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_append_tinstant));
+    loader.RegisterFunction(ScalarFunction(
+        "appendSequence", {TGEOM, TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_append_tsequence));
+    loader.RegisterFunction(ScalarFunction(
+        "insert", {TGEOM, TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_insert));
+    loader.RegisterFunction(ScalarFunction(
+        "insert", {TGEOM, TGEOM, LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_insert));
+    loader.RegisterFunction(ScalarFunction(
+        "update", {TGEOM, TGEOM}, TGEOM,
+        TemporalFunctions::Temporal_update));
+    loader.RegisterFunction(ScalarFunction(
+        "update", {TGEOM, TGEOM, LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_update));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, TSTZ}, TGEOM,
+        TemporalFunctions::Temporal_delete_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, TSTZ, LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_delete_timestamptz));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SetTypes::tstzset()}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzset));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SetTypes::tstzset(), LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzset));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SpanTypes::TSTZSPAN()}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzspan));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SpanTypes::TSTZSPAN(), LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzspan));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SpansetTypes::tstzspanset()}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzspanset));
+    loader.RegisterFunction(ScalarFunction(
+        "deleteTime", {TGEOM, SpansetTypes::tstzspanset(), LogicalType::BOOLEAN}, TGEOM,
+        TemporalFunctions::Temporal_delete_tstzspanset));
+
+    // ---- Comparison (named functions + operators) ----
+    struct CmpEntry {
+        const char *name;
+        scalar_function_t fn;
+    };
+    const std::vector<CmpEntry> named_cmps = {
+        {"temporal_eq", TemporalFunctions::Temporal_eq},
+        {"temporal_ne", TemporalFunctions::Temporal_ne},
+        {"temporal_lt", TemporalFunctions::Temporal_lt},
+        {"temporal_le", TemporalFunctions::Temporal_le},
+        {"temporal_gt", TemporalFunctions::Temporal_gt},
+        {"temporal_ge", TemporalFunctions::Temporal_ge},
+    };
+    for (const auto &c : named_cmps) {
+        loader.RegisterFunction(ScalarFunction(
+            c.name, {TGEOM, TGEOM}, LogicalType::BOOLEAN, c.fn));
+    }
+    loader.RegisterFunction(ScalarFunction(
+        "temporal_cmp", {TGEOM, TGEOM}, LogicalType::INTEGER,
+        TemporalFunctions::Temporal_cmp));
+
+    // Operator forms — mirror the registrations tgeometry.cpp does.
+    const std::vector<CmpEntry> op_cmps = {
+        {"=",  TemporalFunctions::Temporal_eq},
+        {"<>", TemporalFunctions::Temporal_ne},
+        {"<",  TemporalFunctions::Temporal_lt},
+        {"<=", TemporalFunctions::Temporal_le},
+        {">",  TemporalFunctions::Temporal_gt},
+        {">=", TemporalFunctions::Temporal_ge},
+    };
+    for (const auto &c : op_cmps) {
+        loader.RegisterFunction(ScalarFunction(
+            c.name, {TGEOM, TGEOM}, LogicalType::BOOLEAN, c.fn));
+    }
+}
+
+void TPoseTypes::RegisterTypes(ExtensionLoader &loader) {
+    loader.RegisterType( "TPOSE", TPoseTypes::TPOSE());
+}
+
+
+}

--- a/src/geo/tpose_in_out.cpp
+++ b/src/geo/tpose_in_out.cpp
@@ -1,0 +1,413 @@
+#include "geo/tpose.hpp"
+#include "temporal/temporal_blob.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/common/extension_type_info.hpp"
+#include <regex>
+#include <string>
+#include <temporal/span.hpp>
+#include "mobilityduck/meos_exec_serial.hpp"
+
+extern "C" {
+    #include <meos.h>
+    #include <meos_geo.h>
+    #include <meos_internal.h>
+    #include <meos_internal_geo.h>
+    #include <meos_pose.h>
+}
+
+namespace duckdb {
+
+static void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_geom_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_geom_vec, result, count,
+        [&](string_t input_geom_str) -> string_t {
+            const uint8_t *data = reinterpret_cast<const uint8_t*>(input_geom_str.GetData());
+            size_t data_size = input_geom_str.GetSize();
+
+            if (data_size < sizeof(void*)) {
+                throw InvalidInputException("Invalid TPOSE data: insufficient size");
+            }
+
+            uint8_t *data_copy = (uint8_t*)malloc(data_size);
+            if (!data_copy) {
+                throw InvalidInputException("Failed to allocate memory for TPOSE deserialization");
+            }
+            memcpy(data_copy, data, data_size);
+
+            Temporal *temp = reinterpret_cast<Temporal*>(data_copy);
+
+            if (!temp) {
+                free(data_copy);
+                throw InvalidInputException("Invalid TPOSE data: null pointer");
+            }
+
+            char *str = tspatial_as_text(temp, 15);
+
+            if (!str) {
+                free(data_copy);
+                throw InvalidInputException("Failed to convert TPOSE to text");
+            }
+
+            std::string result_str(str);
+            string_t stored_result = StringVector::AddString(result, result_str);
+
+            free(str);
+            free(data_copy);
+
+            return stored_result;
+        }
+    );
+
+}
+
+static void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto count = args.size();
+    auto &input_geom_vec = args.data[0];
+
+    UnaryExecutor::Execute<string_t, string_t>(
+        input_geom_vec, result, count,
+        [&](string_t input_geom_str) -> string_t {
+
+            const uint8_t *data = reinterpret_cast<const uint8_t*>(input_geom_str.GetData());
+            size_t data_size = input_geom_str.GetSize();
+
+            if (data_size < sizeof(void*)) {
+                throw InvalidInputException("Invalid TPOSE data: insufficient size");
+            }
+
+            uint8_t *data_copy = (uint8_t*)malloc(data_size);
+            if (!data_copy) {
+                throw InvalidInputException("Failed to allocate memory for TPOSE deserialization");
+            }
+            memcpy(data_copy, data, data_size);
+
+            Temporal *temp = reinterpret_cast<Temporal*>(data_copy);
+
+            if (!temp) {
+                free(data_copy);
+                throw InvalidInputException("Invalid TPOSE data: null pointer");
+            }
+
+            char *ewkt = tspatial_as_ewkt(temp, 15);
+
+            if (!ewkt) {
+                free(data_copy);
+                throw InvalidInputException("Failed to convert TPOSE to EWKT");
+            }
+
+            std::string result_str(ewkt);
+            string_t stored_result = StringVector::AddString(result, result_str);
+
+
+            free(ewkt);
+            free(data_copy);
+
+            return stored_result;
+        }
+    );
+
+}
+
+
+bool TposeFunctions::StringToTpose(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        source, result, count,
+        [&](string_t input_string) -> string_t {
+            std::string input_str = input_string.GetString();
+
+            Temporal *temp = tpose_in(input_str.c_str());
+            if (!temp) {
+                throw InvalidInputException("Invalid TPOSE input: " + input_str);
+            }
+
+            size_t data_size = temporal_mem_size(temp);
+            uint8_t *data_buffer = (uint8_t*)malloc(data_size);
+            if (!data_buffer) {
+                free(temp);
+                throw InvalidInputException("Failed to allocate memory for TPOSE data");
+            }
+
+            memcpy(data_buffer, temp, data_size);
+
+            string_t data_string_t(reinterpret_cast<const char*>(data_buffer), data_size);
+            string_t stored_data = StringVector::AddStringOrBlob(result, data_string_t);
+
+            free(data_buffer);
+            free(temp);
+
+            return stored_data;
+        });
+
+    return true;
+}
+
+bool TposeFunctions::TposeToString(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        source, result, count,
+        [&](string_t input_blob) -> string_t {
+            const uint8_t *data = reinterpret_cast<const uint8_t*>(input_blob.GetData());
+            size_t data_size = input_blob.GetSize();
+
+            if (data_size < sizeof(void*)) {
+                throw InvalidInputException("Invalid TPOSE data: insufficient size");
+            }
+
+            uint8_t *data_copy = (uint8_t*)malloc(data_size);
+            if (!data_copy) {
+                throw InvalidInputException("Failed to allocate memory for TPOSE deserialization");
+            }
+            memcpy(data_copy, data, data_size);
+
+            Temporal *temp = reinterpret_cast<Temporal*>(data_copy);
+            if (!temp) {
+                free(data_copy);
+                throw InvalidInputException("Invalid TPOSE data: null pointer");
+            }
+
+            char *str = temporal_out(temp, 15);
+            if (!str) {
+                free(data_copy);
+                throw InvalidInputException("Failed to convert TPOSE to string");
+            }
+
+            std::string output(str);
+            string_t stored_result = StringVector::AddString(result, output);
+
+            free(str);
+            free(data_copy);
+
+            return stored_result;
+        });
+
+    return true;
+}
+
+// ---- Spatial-temporal parsers (Binary / HexWKB / MFJSON / Text) ----
+// Used to register the `tposeFrom*` overloads.
+// `temporal_from_wkb` and `temporal_from_hexwkb` are subtype-agnostic;
+// `tpose_in` is per-type.  The temporal-pose MF-JSON support already
+// lives on MobilityDB master (MovingPose typestring + dispatch), so no
+// preceding MEOS parity PR is needed; MEOS does not, however, expose a
+// header-declared `tpose_from_mfjson(const char *)` symbol (it is built
+// under #if MEOS and is itself only a thin wrapper that calls
+// `temporal_from_mfjson(mfjson, T_TPOSE)`).  This port therefore routes
+// through that subtype-agnostic dispatch directly, exactly as the
+// canonical MobilityDB SQL binds `tposeFromMFJSON` to the generic
+// Temporal_from_mfjson handler.  The result is stored as a raw blob,
+// the same format every other temporal type uses.
+
+
+static void TspatialFromWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            if (input.GetSize() == 0)
+                throw InvalidInputException("fromBinary: empty WKB input");
+            uint8_t *wkb = (uint8_t *)malloc(input.GetSize());
+            if (!wkb) throw InternalException("fromBinary: malloc failed");
+            memcpy(wkb, input.GetData(), input.GetSize());
+            Temporal *t = temporal_from_wkb(wkb, input.GetSize());
+            free(wkb);
+            if (!t) throw InvalidInputException("fromBinary: invalid MEOS-WKB");
+            return TemporalToBlob(result, t);
+        });
+}
+
+static void TspatialFromHexWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            std::string hex(input.GetData(), input.GetSize());
+            Temporal *t = temporal_from_hexwkb(hex.c_str());
+            if (!t) throw InvalidInputException(
+                "fromHexWKB: invalid hex-encoded MEOS-WKB");
+            return TemporalToBlob(result, t);
+        });
+}
+
+static void TposeFromTextExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            std::string s(input.GetData(), input.GetSize());
+            Temporal *t = tpose_in(s.c_str());
+            if (!t) throw InvalidInputException("from*: invalid input");
+            return TemporalToBlob(result, t);
+        });
+}
+
+static void TposeFromMFJSONExec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            std::string s(input.GetData(), input.GetSize());
+            // tpose exposes no header-declared *_from_mfjson symbol;
+            // route through the generic dispatch with the T_TPOSE
+            // temporal type, the same path the canonical MobilityDB SQL
+            // binds tposeFromMFJSON to.
+            Temporal *t = temporal_from_mfjson(s.c_str(), T_TPOSE);
+            if (!t) throw InvalidInputException("fromMFJSON: invalid input");
+            return TemporalToBlob(result, t);
+        });
+}
+
+// asMFJSON(tpose[, with_bbox[, flags[, precision[, srs]]]]). MobilityDB
+// exposes asMFJSON for every temporal type via the generic Temporal_as_mfjson;
+// #151 shipped tposeFromMFJSON but not asMFJSON, so this closes that gap.
+// Uniquely named (the ODR caveat): a generic name would collide with the
+// asMFJSON execs in the other geo .cpp. Defaults match MobilityDB:
+// with_bbox=false, flags=0, precision=15, srs=NULL.
+void TposeAsMfjsonExec(DataChunk &args, ExpressionState &state, Vector &result) {
+    const idx_t row_count = args.size();
+    for (idx_t i = 0; i < args.ColumnCount(); i++) args.data[i].Flatten(row_count);
+    auto in = FlatVector::GetData<string_t>(args.data[0]);
+    auto out_data = FlatVector::GetData<string_t>(result);
+    auto &out_validity = FlatVector::Validity(result);
+    const idx_t cc = args.ColumnCount();
+    for (idx_t row = 0; row < row_count; row++) {
+        if (!FlatVector::Validity(args.data[0]).RowIsValid(row)) {
+            out_validity.SetInvalid(row);
+            continue;
+        }
+        string_t blob = in[row];
+        uint8_t *copy = (uint8_t *)malloc(blob.GetSize());
+        if (!copy) throw InternalException("asMFJSON: malloc failed");
+        memcpy(copy, blob.GetData(), blob.GetSize());
+        Temporal *t = reinterpret_cast<Temporal *>(copy);
+        bool with_bbox = (cc > 1) ? FlatVector::GetData<bool>(args.data[1])[row] : false;
+        int flags     = (cc > 2) ? FlatVector::GetData<int32_t>(args.data[2])[row] : 0;
+        int precision = (cc > 3) ? FlatVector::GetData<int32_t>(args.data[3])[row] : 15;
+        std::string srs;
+        const char *srs_cstr = nullptr;
+        if (cc > 4) {
+            string_t s = FlatVector::GetData<string_t>(args.data[4])[row];
+            srs.assign(s.GetData(), s.GetSize());
+            srs_cstr = srs.empty() ? nullptr : srs.c_str();
+        }
+        char *json = temporal_as_mfjson(t, with_bbox, flags, precision, srs_cstr);
+        free(copy);
+        if (!json) { out_validity.SetInvalid(row); continue; }
+        out_data[row] = StringVector::AddString(result, json);
+        free(json);
+    }
+}
+
+// WKB output for tpose. #151 shipped the From{Binary,HexWKB,...} parsers but
+// not the as{Binary,EWKB,HexWKB,HexEWKB} emitters; MobilityDB exposes both
+// (via the generic temporal_as_wkb / temporal_as_hexwkb). Uniquely named per
+// the ODR caveat. Static helper for the blob -> Temporal copy.
+// WKB_BASE (no SRID) is a local constant; WKB_EXTENDED (0x04) is from meos_geo.h.
+constexpr uint8_t WKB_BASE = 0x00;
+static Temporal *TposeBlobToTemp(const string_t &blob) {
+    uint8_t *copy = (uint8_t *)malloc(blob.GetSize());
+    if (!copy) throw InternalException("tpose blob->temporal: malloc failed");
+    memcpy(copy, blob.GetData(), blob.GetSize());
+    return reinterpret_cast<Temporal *>(copy);
+}
+
+void TposeAsWkbExec(DataChunk &args, ExpressionState &state, Vector &result, uint8_t variant) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            Temporal *t = TposeBlobToTemp(input);
+            size_t sz = 0;
+            uint8_t *wkb = temporal_as_wkb(t, variant, &sz);
+            free(t);
+            if (!wkb || sz == 0) {
+                if (wkb) free(wkb);
+                throw InternalException("temporal_as_wkb returned null");
+            }
+            string_t blob(reinterpret_cast<const char *>(wkb), sz);
+            string_t stored = StringVector::AddStringOrBlob(result, blob);
+            free(wkb);
+            return stored;
+        });
+}
+
+void TposeAsHexWkbExec(DataChunk &args, ExpressionState &state, Vector &result, uint8_t variant) {
+    UnaryExecutor::Execute<string_t, string_t>(
+        args.data[0], result, args.size(),
+        [&](string_t input) -> string_t {
+            Temporal *t = TposeBlobToTemp(input);
+            size_t sz = 0;
+            char *hex = temporal_as_hexwkb(t, variant, &sz);
+            (void) sz;
+            free(t);
+            if (!hex) throw InternalException("temporal_as_hexwkb returned null");
+            string_t stored = StringVector::AddString(result, hex);
+            free(hex);
+            return stored;
+        });
+}
+
+void TPoseTypes::RegisterScalarInOutFunctions(ExtensionLoader &loader){
+    auto TposeAsText = ScalarFunction(
+            "asText",
+            {TPoseTypes::TPOSE()},
+            LogicalType::VARCHAR,
+            Tspatial_as_text
+        );
+        duckdb::RegisterSerializedScalarFunction(loader,  TposeAsText);
+
+    auto TposeAsEWKT = ScalarFunction(
+        "asEWKT",
+        {TPoseTypes::TPOSE()},
+        LogicalType::VARCHAR,
+        Tspatial_as_ewkt
+    );
+    duckdb::RegisterSerializedScalarFunction(loader,  TposeAsEWKT);
+
+    // ---- tposeFromBinary / FromEWKB (auto-detects format) ----
+    const auto B = LogicalType::BLOB;
+    const auto V = LogicalType::VARCHAR;
+    const auto T = TPoseTypes::TPOSE();
+    const auto BL = LogicalType::BOOLEAN;
+    const auto I = LogicalType::INTEGER;
+
+    // asMFJSON(tpose[, with_bbox[, flags[, precision[, srs]]]])
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction("asMFJSON", {T},                 V, TposeAsMfjsonExec));
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction("asMFJSON", {T, BL},             V, TposeAsMfjsonExec));
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction("asMFJSON", {T, BL, I},          V, TposeAsMfjsonExec));
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction("asMFJSON", {T, BL, I, I},       V, TposeAsMfjsonExec));
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction("asMFJSON", {T, BL, I, I, V},    V, TposeAsMfjsonExec));
+
+    // asBinary / asEWKB (base + extended WKB) and asHexWKB / asHexEWKB
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("asBinary", {T}, B,
+        [](DataChunk &a, ExpressionState &s, Vector &r) { TposeAsWkbExec(a, s, r, WKB_BASE); }));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("asEWKB",   {T}, B,
+        [](DataChunk &a, ExpressionState &s, Vector &r) { TposeAsWkbExec(a, s, r, WKB_EXTENDED); }));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("asHexWKB",  {T}, V,
+        [](DataChunk &a, ExpressionState &s, Vector &r) { TposeAsHexWkbExec(a, s, r, WKB_BASE); }));
+    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction("asHexEWKB", {T}, V,
+        [](DataChunk &a, ExpressionState &s, Vector &r) { TposeAsHexWkbExec(a, s, r, WKB_EXTENDED); }));
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction("tposeFromBinary", {B}, T, TspatialFromWkbExec));
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction("tposeFromEWKB",   {B}, T, TspatialFromWkbExec));
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction("tposeFromHexWKB",  {V}, T, TspatialFromHexWkbExec));
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction("tposeFromHexEWKB", {V}, T, TspatialFromHexWkbExec));
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction("tposeFromMFJSON", {V}, T, TposeFromMFJSONExec));
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction("tposeFromText",   {V}, T, TposeFromTextExec));
+    duckdb::RegisterSerializedScalarFunction(loader,
+        ScalarFunction("tposeFromEWKT",   {V}, T, TposeFromTextExec));
+}
+
+
+void TPoseTypes::RegisterCastFunctions(ExtensionLoader &loader) {
+    RegisterMeosCastFunction(loader,  LogicalType::VARCHAR, TPoseTypes::TPOSE(), TposeFunctions::StringToTpose);
+    RegisterMeosCastFunction(loader,  TPoseTypes::TPOSE(), LogicalType::VARCHAR, TposeFunctions::TposeToString);
+}
+
+}

--- a/src/include/geo/tpose.hpp
+++ b/src/include/geo/tpose.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <tydef.hpp>
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
+
+namespace duckdb {
+
+
+struct TPoseTypes {
+    static LogicalType TPOSE();
+    static LogicalType GEOMETRY();
+    static void RegisterTypes(ExtensionLoader &loader);
+    static void RegisterScalarFunctions(ExtensionLoader &loader);
+    static void RegisterCastFunctions(ExtensionLoader &loader);
+    static void RegisterScalarInOutFunctions(ExtensionLoader &loader);
+};
+
+struct TposeFunctions {
+    static bool StringToTpose(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
+    static bool TposeToString(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
+    static bool WkbBlobToGeometry(Vector &source, Vector &result, idx_t count, CastParameters &parameters);
+};
+
+
+} // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -20,6 +20,9 @@
 // the canonical ways1000.csv is embedded and materialized there on load.
 #include "ways_csv.inc"
 #endif
+#if POSE
+#include "geo/tpose.hpp"
+#endif
 #include "geo/tgeometry.hpp"
 #include "geo/tgeometry_ops.hpp"
 #include "geo/tgeography.hpp"
@@ -382,6 +385,14 @@ static void LoadInternal(ExtensionLoader &loader) {
 	TNpointTypes::RegisterCastFunctions(loader);
 	TNpointTypes::RegisterScalarFunctions(loader);
 	TNpointTypes::RegisterScalarInOutFunctions(loader);
+#endif
+
+	// Extended temporal type tpose (requires the MEOS POSE module).
+#if POSE
+	TPoseTypes::RegisterTypes(loader);
+	TPoseTypes::RegisterCastFunctions(loader);
+	TPoseTypes::RegisterScalarFunctions(loader);
+	TPoseTypes::RegisterScalarInOutFunctions(loader);
 #endif
 
 	SetTypes::RegisterTypes(loader);

--- a/test/sql/tpose.test
+++ b/test/sql/tpose.test
@@ -1,0 +1,206 @@
+# name: test/sql/tpose.test
+# description: Core tpose type port — construction, text/EWKT/MFJSON I/O
+#              and basic accessors. The tpose value is a Pose (a 2D point
+#              plus a rotation angle; 3D adds a quaternion).
+# group: [sql]
+
+require mobilityduck
+
+# Test tpose constructor with parentheses
+query I
+SELECT asText(tpose('Pose(Point(1 1), 0.5)@2000-01-01'));
+----
+Pose(POINT(1 1),0.5)@2000-01-01 00:00:00+01
+
+# Test tpose constructor without parentheses
+query I
+SELECT asText(tpose 'Pose(Point(1 1), 0.5)@2000-01-01');
+----
+Pose(POINT(1 1),0.5)@2000-01-01 00:00:00+01
+
+# Test asText with continuous sequence
+query I
+SELECT asText(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]');
+----
+[Pose(POINT(1 1),0.2)@2000-01-01 00:00:00+01, Pose(POINT(1 1),0.4)@2000-01-02 00:00:00+01, Pose(POINT(1 1),0.5)@2000-01-03 00:00:00+01]
+
+# Test asText with discrete sequence
+query I
+SELECT asText(tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02}');
+----
+{Pose(POINT(1 1),0.3)@2000-01-01 00:00:00+01, Pose(POINT(1 1),0.5)@2000-01-02 00:00:00+01}
+
+# Test asEWKT is non-null
+query I
+SELECT asEWKT(tpose 'Pose(Point(1 1), 0.5)@2000-01-01') IS NOT NULL;
+----
+true
+
+# Test value-and-timestamp constructor round-trips
+query I
+SELECT tpose('Pose(Point(1 1), 0.5)', timestamptz '2012-01-01 08:00:00')
+     = tpose 'Pose(Point(1 1), 0.5)@2012-01-01 08:00:00';
+----
+true
+
+# Test value-and-tstzspan constructor produces a 2-instant sequence
+query I
+SELECT numInstants(tpose('Pose(Point(1 1), 0.5)', tstzspan '[2001-01-01, 2001-01-02]'));
+----
+2
+
+# Test value-and-tstzspan constructor with linear interpolation
+query I
+SELECT interp(tpose('Pose(Point(1 1), 0.5)', tstzspan '[2001-01-01, 2001-01-02]', 'linear'));
+----
+Linear
+
+# Test MFJSON input via the FromMFJSON constructor reconstructs the value
+# (the canonical MEOS schema: typestring MovingPose, value object with a
+# {lat,lon} position and a rotation for the 2D case).
+query I
+SELECT asText(tposeFromMFJSON('{"type":"MovingPose","values":[{"position":{"lat":1,"lon":1},"rotation":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}'))
+     = asText(tpose 'Pose(Point(1 1), 0.5)@2000-01-01');
+----
+true
+
+# Test asMFJSON / FromMFJSON round-trip is identity (format-agnostic)
+query I
+SELECT asText(tposeFromMFJSON(asMFJSON(tpose 'Pose(Point(1 1), 0.5)@2000-01-01')))
+     = asText(tpose 'Pose(Point(1 1), 0.5)@2000-01-01');
+----
+true
+
+# Test MFJSON round-trip for a continuous sequence
+query I
+SELECT asText(tposeFromMFJSON(asMFJSON(
+         tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]')))
+     = asText(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]');
+----
+true
+
+# Test tposeFromText constructor
+query I
+SELECT asText(tposeFromText('Pose(Point(1 1), 0.5)@2000-01-01')) IS NOT NULL;
+----
+true
+
+# Test binary round-trip is identity
+query I
+SELECT asText(tposeFromBinary(asBinary(tpose 'Pose(Point(1 1), 0.5)@2000-01-01')))
+     = asText(tpose 'Pose(Point(1 1), 0.5)@2000-01-01');
+----
+true
+
+# Test timeSpan function
+query I
+SELECT timeSpan(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-03]');
+----
+[2000-01-01 00:00:00+01, 2000-01-03 00:00:00+01]
+
+# Test setInterp with discrete interpolation. A multi-instant continuous
+# sequence cannot be discretized (it would drop the span semantics, MEOS
+# errors), so this lifts an instant to a one-element discrete sequence,
+# matching MobilityDB's 102_tpose reference for setInterp(...,'discrete').
+query I
+SELECT tempSubtype(setInterp(tpose 'Pose(Point(1 1), 0.2)@2000-01-01', 'discrete'));
+----
+Sequence
+
+# Test merge function
+query I
+SELECT numInstants(merge(
+  tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.3)@2000-01-02]',
+  tpose '[Pose(Point(1 1), 0.3)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]'));
+----
+3
+
+# Test tempSubtype with instant
+query I
+SELECT tempSubtype(tpose 'Pose(Point(1 1), 0.5)@2000-01-01');
+----
+Instant
+
+# Test tempSubtype with discrete sequence
+query I
+SELECT tempSubtype(tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02}');
+----
+Sequence
+
+# Test tempSubtype with continuous sequence
+query I
+SELECT tempSubtype(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02]');
+----
+Sequence
+
+# Test tempSubtype with sequence set
+query I
+SELECT tempSubtype(tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}');
+----
+SequenceSet
+
+# Test memSize is positive
+query I
+SELECT memSize(tpose 'Pose(Point(1 1), 0.5)@2000-01-01') > 0;
+----
+true
+
+# Test interp accessor
+query I
+SELECT interp(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02]');
+----
+Linear
+
+# Test getValue returns the pose value text
+query I
+SELECT getValue(tpose 'Pose(Point(1 1), 0.5)@2000-01-01');
+----
+Pose(POINT(1 1),0.5)
+
+# Test startValue
+query I
+SELECT startValue(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02]');
+----
+Pose(POINT(1 1),0.2)
+
+# Test endValue
+query I
+SELECT endValue(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02]');
+----
+Pose(POINT(1 1),0.4)
+
+# Test startInstant
+query I
+SELECT asText(startInstant(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02]'));
+----
+Pose(POINT(1 1),0.2)@2000-01-01 00:00:00+01
+
+# Test endInstant
+query I
+SELECT asText(endInstant(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02]'));
+----
+Pose(POINT(1 1),0.4)@2000-01-02 00:00:00+01
+
+# Test instantN
+query I
+SELECT asText(instantN(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02]', 1));
+----
+Pose(POINT(1 1),0.2)@2000-01-01 00:00:00+01
+
+# Test getTimestamp function
+query I
+SELECT getTimestamp(tpose 'Pose(Point(1 1), 0.5)@2023-01-01 10:00:00+00');
+----
+2023-01-01 11:00:00+01
+
+# Test numInstants generic accessor
+query I
+SELECT numInstants(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]');
+----
+3
+
+# Test duration generic accessor
+query I
+SELECT duration(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-03]');
+----
+2 days


### PR DESCRIPTION
Clones the canonical tgeometry MobilityDuck port for the temporal pose type: type registration, text/EWKT/MFJSON I/O, constructors and the basic accessor surface. The Pose value is a 2D point plus a rotation (3D adds a quaternion); its MEOS MF-JSON support is already on MobilityDB master, so there is no MEOS prerequisite PR and the inherited composed provisional pin is left unchanged. The ops layer is deferred to a later stacked follow-up. Stacks on the tnpoint core port; the #145/#148/#150 diffs and the temporary composed MEOS pin show in the diff until that chain merges.