### PR TITLE
fix(extension): skip MEOS timezone init when no zoneinfo on system (unblocks musl probe)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,23 @@ include extension-ci-tools/makefiles/duckdb_extension.Makefile
 # LoadInternal also calls ExtensionHelper::AutoLoadExtension(db, "icu") so
 # the timezone option is honoured. Autoload looks for the extension on disk
 # at $HOME/.duckdb/extensions/<duckdb_version>/<platform>/icu.duckdb_extension
-# and falls back to a hub download. Inside the linux_amd64 test docker
-# container that path is empty and there is no network egress, so the
-# autoload fails. We copy the icu.duckdb_extension that was built locally
-# as part of this extension's build (declared in extension_config.cmake)
-# into the expected path before running the unittester.
+# and falls back to a hub download. That fails both inside the linux_amd64
+# test docker container (empty path, no network egress) and on the macOS
+# osx_arm64 test runner (hub icu not reliably resolvable). We copy the
+# icu.duckdb_extension that was built locally as part of this extension's
+# build (declared in extension_config.cmake) into the expected path,
+# matched to the DuckDB platform string, before running the unittester.
 DUCKDB_VERSION_TAG := v1.4.4
 
 define stage_icu
 	@if [ -f ./build/$(1)/extension/icu/icu.duckdb_extension ]; then \
-	  platform=$$(uname -m | sed 's/x86_64/linux_amd64/;s/aarch64/linux_arm64/'); \
+	  case "$$(uname -s)-$$(uname -m)" in \
+	    Linux-x86_64)  platform=linux_amd64 ;; \
+	    Linux-aarch64) platform=linux_arm64 ;; \
+	    Darwin-arm64)  platform=osx_arm64 ;; \
+	    Darwin-x86_64) platform=osx_amd64 ;; \
+	    *)             platform=$$(uname -m) ;; \
+	  esac; \
 	  target=$$HOME/.duckdb/extensions/$(DUCKDB_VERSION_TAG)/$$platform; \
 	  mkdir -p "$$target" && cp -f ./build/$(1)/extension/icu/icu.duckdb_extension "$$target/" && \
 	  echo "Staged icu.duckdb_extension at $$target/"; \

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,32 @@ include extension-ci-tools/makefiles/duckdb_extension.Makefile
 # both MEOS (meos_initialize_timezone) and DuckDB (DBConfig::SetOptionByName
 # "TimeZone") to Europe/Brussels.  Tests pass on any OS timezone — the
 # extension is the single source of truth, no TZ env var needed.
+#
+# LoadInternal also calls ExtensionHelper::AutoLoadExtension(db, "icu") so
+# the timezone option is honoured. Autoload looks for the extension on disk
+# at $HOME/.duckdb/extensions/<duckdb_version>/<platform>/icu.duckdb_extension
+# and falls back to a hub download. Inside the linux_amd64 test docker
+# container that path is empty and there is no network egress, so the
+# autoload fails. We copy the icu.duckdb_extension that was built locally
+# as part of this extension's build (declared in extension_config.cmake)
+# into the expected path before running the unittester.
+DUCKDB_VERSION_TAG := v1.4.4
+
+define stage_icu
+	@if [ -f ./build/$(1)/extension/icu/icu.duckdb_extension ]; then \
+	  platform=$$(uname -m | sed 's/x86_64/linux_amd64/;s/aarch64/linux_arm64/'); \
+	  target=$$HOME/.duckdb/extensions/$(DUCKDB_VERSION_TAG)/$$platform; \
+	  mkdir -p "$$target" && cp -f ./build/$(1)/extension/icu/icu.duckdb_extension "$$target/" && \
+	  echo "Staged icu.duckdb_extension at $$target/"; \
+	fi
+endef
+
 test_release_internal:
+	$(call stage_icu,release)
 	./build/release/$(TEST_PATH) "$(PROJ_DIR)test/*"
 test_debug_internal:
+	$(call stage_icu,debug)
 	./build/debug/$(TEST_PATH) "$(PROJ_DIR)test/*"
 test_reldebug_internal:
+	$(call stage_icu,reldebug)
 	./build/reldebug/$(TEST_PATH) "$(PROJ_DIR)test/*"

--- a/src/include/tydef.hpp
+++ b/src/include/tydef.hpp
@@ -11,11 +11,27 @@ extern "C" {
     #include <meos_internal.h>
 }
 
-// Forward-compat alias for the meosType → MeosType rename (MobilityDB
-// pr785-sync-script).  Vcpkg's MEOS exposes `MeosType`; existing
-// MobilityDuck code still uses `meosType`.  This alias bridges the two
-// without touching every reference site.
-using meosType = MeosType;
+// MEOS naming history: `meosType` is the **pre-consolidation** spelling
+// and `MeosType` is the **post-consolidation** target (the rename is
+// part of the upstream consolidation sweep, not yet reached by the
+// vcpkg pin).  The current pin
+// (`vcpkg_ports/meos/portfile.cmake` REF f11b7443ee98…) is still
+// pre-consolidation and exposes `meosType` — see
+// meos/include/temporal/meos_catalog.h, where line 121 declares
+// `} meosType;`.  MobilityDuck's source consistently uses
+// `meosType` (verified via `grep -rn '\bmeosType\b' src/`), which
+// matches the pin, so no alias is needed today.
+//
+// An earlier version of this file added `using meosType = MeosType;`
+// as a forward-looking bridge for the eventual consolidation bump.
+// That alias references `MeosType`, which the current pin does NOT
+// yet expose, so it broke the build:
+//   "'MeosType' does not name a type; did you mean 'meosType'?".
+//
+// When the MEOS pin is bumped past the consolidation point, restore
+// a bridge here (`using meosType = MeosType;` becomes valid then) or
+// sweep the source `meosType → MeosType` in one PR — whichever the
+// project prefers at that time.
 
 namespace duckdb {
 

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -220,8 +220,17 @@ static void LoadInternal(ExtensionLoader &loader) {
         /* Set the MEOS timezone to Europe/Brussels so that all temporal-type
          * text I/O uses a consistent, named timezone on every platform.
          * Brussels is a non-UTC zone that surfaces bugs hidden by UTC (e.g.
-         * off-by-one-hour errors in timestamp handling). */
-        meos_initialize_timezone("Europe/Brussels");
+         * off-by-one-hour errors in timestamp handling).
+         *
+         * Skip the timezone init when no IANA timezone database is present
+         * on the system (Alpine/musl images, minimal containers, edge
+         * devices).  Without `/usr/share/zoneinfo`, MEOS's pgtz code
+         * fails on `opendir`; skipping the timezone init lets the
+         * extension load against UTC instead of erroring at startup. */
+        struct stat tz_st {};
+        if (stat("/usr/share/zoneinfo", &tz_st) == 0 && (tz_st.st_mode & S_IFDIR)) {
+            meos_initialize_timezone("Europe/Brussels");
+        }
         meos_initialize_error_handler(&MobilityduckMeosErrorHandler);
     });
 

--- a/src/temporal/set.cpp
+++ b/src/temporal/set.cpp
@@ -945,6 +945,14 @@ static inline Set *date_to_set_duckdb(DateADT d) {
     return date_to_set(ToMeosDate(duckdb::date_t(d)));
 }
 
+// macOS LP64: int64 (long) and int64_t (long long) are the same width but
+// distinct types, so clang rejects passing bigint_to_set where a
+// Set *(*)(int64_t) is expected as a non-type template arg. The cast is a
+// no-op on Linux. See SetUnionScalarFunction<int64_t, ...> below.
+static inline Set *bigint_to_set_duckdb(int64_t i) {
+    return bigint_to_set(static_cast<int64>(i));
+}
+
 struct SetPtrState {
     Set *accumulated;
 };
@@ -1069,7 +1077,7 @@ void SetTypes::RegisterSetUnionAgg(ExtensionLoader &loader) {
             LogicalType::INTEGER, SetTypes::intset()));
     set_union_set.AddFunction(
         AggregateFunction::UnaryAggregateDestructor<SetPtrState, int64_t, string_t,
-            SetUnionScalarFunction<int64_t, bigint_to_set>>(
+            SetUnionScalarFunction<int64_t, bigint_to_set_duckdb>>(
             LogicalType::BIGINT, SetTypes::bigintset()));
     set_union_set.AddFunction(
         AggregateFunction::UnaryAggregateDestructor<SetPtrState, double, string_t,

--- a/src/temporal/span_table_functions.cpp
+++ b/src/temporal/span_table_functions.cpp
@@ -44,7 +44,9 @@ struct BinsBindData : public FunctionData {
         r->blob = blob;
         r->vsize = vsize;
         r->vorigin = vorigin;
-        return r;
+        // DuckDB 1.4.4 disallows implicit derived->base unique_ptr conversion;
+        // explicit base-type construction from the moved-from derived pointer.
+        return unique_ptr_cast<BinsBindData, FunctionData>(std::move(r));
     }
     bool Equals(const FunctionData &other_p) const override {
         auto &other = other_p.Cast<BinsBindData>();


### PR DESCRIPTION
## Summary

Skip the MEOS `meos_initialize_timezone("Europe/Brussels")` call when `/usr/share/zoneinfo` isn't present on the system. This unblocks the **musl probe** (PR #172) without requiring a separate fix to the upstream `extension-ci-tools` Dockerfile.

## Background

`meos_initialize_timezone(...)` calls into MEOS's `pgtz` code which opens `/usr/share/zoneinfo` to load the timezone database. On minimal containers (Alpine/musl, edge-device runtimes) `tzdata` is not installed by default, so the call surfaces:

```
could not open directory "/usr/share/zoneinfo": No such file or directory
could not open directory "/usr/share/zoneinfo": No such file or directory
make: *** [Makefile:36: test_release_internal] Error 1
```

…and the test runner downstream then errors. This was the exact failure mode on the musl probe (#172, `linux_amd64_musl` row) — MEOS C compiled+linked green, but the runtime timezone init failed.

## The fix

Guard the `meos_initialize_timezone` call with a portable `stat` + `S_IFDIR` check on the canonical zoneinfo directory:

```cpp
struct stat tz_st {};
if (stat("/usr/share/zoneinfo", &tz_st) == 0 && (tz_st.st_mode & S_IFDIR)) {
    meos_initialize_timezone("Europe/Brussels");
}
```

If zoneinfo isn't present, the extension loads against MEOS's default (UTC) instead of erroring at startup.

## Behaviour matrix

| Host | Pre-fix | Post-fix |
|---|---|---|
| Linux x86_64 (Ubuntu/manylinux2_28) with tzdata | ✅ Brussels TZ | ✅ Brussels TZ (unchanged) |
| Linux arm64 with tzdata | ✅ Brussels TZ | ✅ Brussels TZ (unchanged) |
| macOS with tzdata | ✅ Brussels TZ | ✅ Brussels TZ (unchanged) |
| musl/Alpine without tzdata | ❌ "could not open directory" → tests fail | ✅ UTC default; extension loads |
| Future edge-device runtimes | Same failure mode | ✅ Resilient |

## Alternative: upstream Dockerfile fix

The complementary fix is `apk add tzdata` in `extension-ci-tools/docker/linux_amd64_musl/Dockerfile`. Both unblock the musl probe; having both gives belt-and-suspenders coverage and lets the extension load on any tzdata-less host (not just the CI image).

The extension-side fix in this PR has the additional benefit that it makes MobilityDuck deployable on edge devices and minimal containers without requiring the operator to install tzdata.

## Verification

Linux x86_64 build green (4 polyfills inherited from the substrate stack + 1 TZ-resilient commit):

```
$ cmake --build build/release --config Release --target mobilityduck_loadable_extension -- -j1
[72/72] Linking CXX shared library extension/mobilityduck/mobilityduck.duckdb_extension

$ ./build/release/duckdb -c "LOAD '...mobilityduck.duckdb_extension'; SELECT asText(TGEOGPOINT(ST_Point(1, 2), to_timestamp(946684800)));"
POINT(1 2)@2000-01-01 01:00:00+01
```

The Brussels TZ output is preserved on a host with zoneinfo present.

## Refs

- #172 — musl probe surfacing the bug
- `[[duckdb-extension-ci-env]]` — the CI Docker env documentation
