### PR TITLE
icu: graceful fallback when unavailable + version-agnostic multi-version staging (consolidates #136/#141)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,49 @@ include extension-ci-tools/makefiles/duckdb_extension.Makefile
 # both MEOS (meos_initialize_timezone) and DuckDB (DBConfig::SetOptionByName
 # "TimeZone") to Europe/Brussels.  Tests pass on any OS timezone — the
 # extension is the single source of truth, no TZ env var needed.
+#
+# LoadInternal also auto-loads ICU so the named "Europe/Brussels" zone
+# resolves. DuckDB autoloads ICU from
+#   $HOME/.duckdb/extensions/<version>/<platform>/icu.duckdb_extension
+# and otherwise falls back to a hub download — which fails inside the CI test
+# docker (empty path, no network egress) and on the macOS osx_arm64 runner
+# (hub ICU not reliably resolvable). So we stage the locally-built ICU into the
+# expected path before the unittester runs.
+#
+# Target DuckDB is the v1.4.x LTS line, with later versions (v1.5.x) supported
+# in a multi-version matrix the same way MobilityDB supports PostgreSQL 13-18 —
+# so the staging path must NOT hardcode the version or platform. We derive both
+# from the freshly-built duckdb binary (authoritative for whatever is being
+# tested); DUCKDB_VERSION_TAG and the uname map are fallbacks only.
+DUCKDB_VERSION_TAG := v1.4.4
+
+define stage_icu
+	@if [ -f ./build/$(1)/extension/icu/icu.duckdb_extension ]; then \
+	  duckdb_bin=./build/$(1)/duckdb; \
+	  version_tag=$$( [ -x "$$duckdb_bin" ] && "$$duckdb_bin" --version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 ); \
+	  platform=$$( [ -x "$$duckdb_bin" ] && echo 'PRAGMA platform;' | "$$duckdb_bin" -noheader -list 2>/dev/null | tr -d '[:space:]' ); \
+	  [ -n "$$version_tag" ] || version_tag=$(DUCKDB_VERSION_TAG); \
+	  if [ -z "$$platform" ]; then \
+	    case "$$(uname -s)-$$(uname -m)" in \
+	      Linux-x86_64)  platform=linux_amd64 ;; \
+	      Linux-aarch64) platform=linux_arm64 ;; \
+	      Darwin-arm64)  platform=osx_arm64 ;; \
+	      Darwin-x86_64) platform=osx_amd64 ;; \
+	      *)             platform=$$(uname -m) ;; \
+	    esac; \
+	  fi; \
+	  target=$$HOME/.duckdb/extensions/$$version_tag/$$platform; \
+	  mkdir -p "$$target" && cp -f ./build/$(1)/extension/icu/icu.duckdb_extension "$$target/" && \
+	  echo "Staged icu.duckdb_extension at $$target/ (duckdb $$version_tag / $$platform)"; \
+	fi
+endef
+
 test_release_internal:
+	$(call stage_icu,release)
 	./build/release/$(TEST_PATH) "$(PROJ_DIR)test/*"
 test_debug_internal:
+	$(call stage_icu,debug)
 	./build/debug/$(TEST_PATH) "$(PROJ_DIR)test/*"
 test_reldebug_internal:
+	$(call stage_icu,reldebug)
 	./build/reldebug/$(TEST_PATH) "$(PROJ_DIR)test/*"

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -34,6 +34,7 @@
 #include <mutex>
 #include <fstream>
 #include <cstdlib>
+#include <cstdio>
 #include <string>
 
 #if defined(_WIN32)
@@ -227,12 +228,26 @@ static void LoadInternal(ExtensionLoader &loader) {
 
     // Single-timezone model: ensure DuckDB's session timezone matches the
     // MEOS timezone so bare TIMESTAMPTZ display agrees with MEOS composite
-    // type strings.  Auto-load ICU (without it, the test framework keeps
-    // session timezone at UTC) and set the TimeZone option to Brussels.
+    // type strings.  This needs ICU for the named "Europe/Brussels" zone.
+    //
+    // If ICU cannot be auto-loaded (no on-disk copy AND no network egress:
+    // CI docker images, edge/musl deployments, offline installs), degrade
+    // gracefully to the session default (UTC) instead of failing the whole
+    // extension load.  Tests that assert Brussels display stage ICU locally
+    // via the Makefile's stage_icu.
     auto &db = loader.GetDatabaseInstance();
-    ExtensionHelper::AutoLoadExtension(db, "icu");
-    auto &config = DBConfig::GetConfig(db);
-    config.SetOptionByName("TimeZone", Value("Europe/Brussels"));
+    try {
+        ExtensionHelper::AutoLoadExtension(db, "icu");
+        auto &config = DBConfig::GetConfig(db);
+        config.SetOptionByName("TimeZone", Value("Europe/Brussels"));
+    } catch (const std::exception &e) {
+        // ICU unavailable: leave the session timezone at its default.
+        // Temporal-type text I/O is unaffected; only bare TIMESTAMPTZ display
+        // falls back to UTC.
+        fprintf(stderr,
+                "mobilityduck: ICU not available (%s); session timezone left "
+                "at default instead of Europe/Brussels.\n", e.what());
+    }
 
 
 	// Register scalar function: mobilityduck_openssl_version


### PR DESCRIPTION
## Summary

Makes the single-timezone model **resilient** and **multi-version-ready**, and consolidates the ICU test-staging work of #136 and #141 into one durable change.

### 1. Load resilience (graceful UTC fallback)
`LoadInternal` auto-loads ICU and sets the session `TimeZone` to `Europe/Brussels` (needed for the named zone). When ICU is unavailable — **no on-disk copy AND no network egress** (CI docker images, edge/musl deployments, offline installs) — the `SetOptionByName` previously **threw out of `LoadInternal` and failed the whole extension load**. This wraps the ICU autoload + TimeZone set so it degrades gracefully to the session default: the extension always loads, and only bare `TIMESTAMPTZ` display falls back to UTC when ICU is absent. Mirrors the MEOS-side timezone guard.

### 2. Version- and platform-agnostic ICU staging
DuckDB autoloads ICU from `$HOME/.duckdb/extensions/<version>/<platform>/`. The test harness stages the locally-built ICU there. Previously the version tag was hardcoded `v1.4.4` + a `uname` map. This derives **both the version tag and platform from the freshly-built `duckdb` binary** (`--version` + `PRAGMA platform`), with the hardcode/uname as fallbacks only — so staging follows whatever DuckDB is under test across the **v1.4.x LTS line and the v1.5.x multi-version matrix** (the analog of MobilityDB's PostgreSQL 13-18 support).

## Supersedes
Consolidates and supersedes #136 (amd64 docker ICU staging) and #141 (macOS osx_arm64 staging); recommend closing both once this lands.

## Verification
- Built + full sqllogictest suite green (1727 assertions, 76 cases) in the integrated branch.
- ICU staging confirmed to derive `v1.4.4` / `linux_amd64` dynamically.
- Resilience path proven via an injected-failure self-test: with ICU made unavailable, the extension **loads** (warns, falls back to UTC) instead of crashing.