### PR TITLE
Fix worker-thread and linkage crashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(EXTENSION_SOURCES
     src/spatial_ref_sys_csv.inc
     src/mobilityduck_extension.cpp        
     src/temporal/temporal.cpp
+    src/temporal/temporal_blob.cpp
     src/temporal/temporal_functions.cpp
     src/temporal/temporal_aggregates.cpp
     src/temporal/tbox.cpp

--- a/src/geo/stbox_functions.cpp
+++ b/src/geo/stbox_functions.cpp
@@ -1,4 +1,5 @@
 #include "meos_wrapper_simple.hpp"
+#include "temporal/temporal_blob.hpp"
 #include "common.hpp"
 
 #include "geo/stbox_functions.hpp"
@@ -50,7 +51,7 @@ inline STBox *Stbox_geodetic_xy_copy(const STBox *box) {
                       0.0, 0.0, stbox_hast(box) ? &box->period : nullptr);
 }
 
-inline void Stbox_normalize_geodetic_srid(STBox *box) {
+static void Stbox_normalize_geodetic_srid(STBox *box) {
     if ((stbox_isgeodetic(box) || MEOS_FLAGS_GET_GEODETIC(box->flags)) && box->srid == 0) {
         box->srid = 4326;
     }
@@ -62,7 +63,7 @@ inline void Stbox_normalize_geodetic_srid(STBox *box) {
  * In/out functions: VARCHAR <-> STBOX
  ****************************************************/
 
-inline void Stbox_in_common(Vector &source, Vector &result, idx_t count) {
+static void Stbox_in_common(Vector &source, Vector &result, idx_t count) {
     UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
         source, result, count,
         [&](string_t input_string, ValidityMask &mask, idx_t idx) -> string_t {
@@ -91,9 +92,6 @@ inline void Stbox_in_common(Vector &source, Vector &result, idx_t count) {
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 bool StboxFunctions::Stbox_in_cast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
@@ -135,9 +133,6 @@ bool StboxFunctions::Stbox_out(Vector &source, Vector &result, idx_t count, Cast
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
     return success;
 }
 
@@ -182,9 +177,6 @@ void StboxFunctions::Stbox_from_wkb(DataChunk &args, ExpressionState &state, Vec
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_from_hexwkb(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -213,9 +205,6 @@ void StboxFunctions::Stbox_from_hexwkb(DataChunk &args, ExpressionState &state, 
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_as_text(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -247,9 +236,6 @@ void StboxFunctions::Stbox_as_text(DataChunk &args, ExpressionState &state, Vect
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_as_wkb(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -282,9 +268,6 @@ void StboxFunctions::Stbox_as_wkb(DataChunk &args, ExpressionState &state, Vecto
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_as_hexwkb(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -317,9 +300,6 @@ void StboxFunctions::Stbox_as_hexwkb(DataChunk &args, ExpressionState &state, Ve
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -360,9 +340,6 @@ void StboxFunctions::Geo_timestamptz_to_stbox(DataChunk &args, ExpressionState &
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Geo_tstzspan_to_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -420,9 +397,6 @@ void StboxFunctions::Geo_tstzspan_to_stbox(DataChunk &args, ExpressionState &sta
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -462,9 +436,6 @@ void StboxFunctions::Geo_to_stbox_common(Vector &source, Vector &result, idx_t c
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Geo_to_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -515,9 +486,6 @@ bool StboxFunctions::Geo_to_stbox_cast(Vector &source, Vector &result, idx_t cou
             return stored_result;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 static void Timestamptz_to_stbox_common(Vector &source, Vector &result, idx_t count) {
@@ -543,9 +511,6 @@ static void Timestamptz_to_stbox_common(Vector &source, Vector &result, idx_t co
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Timestamptz_to_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -594,9 +559,6 @@ static void Tstzset_to_stbox_common(Vector &source, Vector &result, idx_t count)
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Tstzset_to_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -645,9 +607,6 @@ static void Tstzspan_to_stbox_common(Vector &source, Vector &result, idx_t count
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Tstzspan_to_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -732,9 +691,6 @@ void StboxFunctions::Stbox_hasx(DataChunk &args, ExpressionState &state, Vector 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_hasz(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -758,9 +714,6 @@ void StboxFunctions::Stbox_hasz(DataChunk &args, ExpressionState &state, Vector 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_hast(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -807,9 +760,6 @@ void StboxFunctions::Stbox_isgeodetic(DataChunk &args, ExpressionState &state, V
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_xmin(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -838,9 +788,6 @@ void StboxFunctions::Stbox_xmin(DataChunk &args, ExpressionState &state, Vector 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_xmax(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -870,9 +817,6 @@ void StboxFunctions::Stbox_xmax(DataChunk &args, ExpressionState &state, Vector 
         }
     );
 
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_ymin(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -901,9 +845,6 @@ void StboxFunctions::Stbox_ymin(DataChunk &args, ExpressionState &state, Vector 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_ymax(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -932,9 +873,6 @@ void StboxFunctions::Stbox_ymax(DataChunk &args, ExpressionState &state, Vector 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_zmin(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -963,9 +901,6 @@ void StboxFunctions::Stbox_zmin(DataChunk &args, ExpressionState &state, Vector 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_zmax(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -994,9 +929,6 @@ void StboxFunctions::Stbox_zmax(DataChunk &args, ExpressionState &state, Vector 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_tmin(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1026,9 +958,6 @@ void StboxFunctions::Stbox_tmin(DataChunk &args, ExpressionState &state, Vector 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_tmax(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1058,9 +987,6 @@ void StboxFunctions::Stbox_tmax(DataChunk &args, ExpressionState &state, Vector 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_tmin_inc(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1089,9 +1015,6 @@ void StboxFunctions::Stbox_tmin_inc(DataChunk &args, ExpressionState &state, Vec
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_tmax_inc(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1120,9 +1043,6 @@ void StboxFunctions::Stbox_tmax_inc(DataChunk &args, ExpressionState &state, Vec
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_area(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1158,9 +1078,6 @@ void StboxFunctions::Stbox_area(DataChunk &args, ExpressionState &state, Vector 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_volume(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1189,9 +1106,6 @@ void StboxFunctions::Stbox_volume(DataChunk &args, ExpressionState &state, Vecto
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -1228,9 +1142,6 @@ void StboxFunctions::Stbox_shift_time(DataChunk &args, ExpressionState &state, V
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_scale_time(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1264,9 +1175,6 @@ void StboxFunctions::Stbox_scale_time(DataChunk &args, ExpressionState &state, V
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_shift_scale_time(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1300,9 +1208,6 @@ void StboxFunctions::Stbox_shift_scale_time(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_get_space(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1334,9 +1239,6 @@ void StboxFunctions::Stbox_get_space(DataChunk &args, ExpressionState &state, Ve
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_expand_time(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1370,9 +1272,6 @@ void StboxFunctions::Stbox_expand_time(DataChunk &args, ExpressionState &state, 
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_expand_space(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1414,9 +1313,6 @@ void StboxFunctions::Stbox_expand_space(DataChunk &args, ExpressionState &state,
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -1468,9 +1364,6 @@ void StboxFunctions::Overlaps_stbox_stbox(DataChunk &args, ExpressionState &stat
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Contains_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1518,9 +1411,6 @@ void StboxFunctions::Contains_stbox_stbox(DataChunk &args, ExpressionState &stat
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Contained_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1568,9 +1458,6 @@ void StboxFunctions::Contained_stbox_stbox(DataChunk &args, ExpressionState &sta
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Same_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1618,9 +1505,6 @@ void StboxFunctions::Same_stbox_stbox(DataChunk &args, ExpressionState &state, V
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Adjacent_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1668,9 +1552,6 @@ void StboxFunctions::Adjacent_stbox_stbox(DataChunk &args, ExpressionState &stat
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Left_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1718,9 +1599,6 @@ void StboxFunctions::Left_stbox_stbox(DataChunk &args, ExpressionState &state, V
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Overleft_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1768,9 +1646,6 @@ void StboxFunctions::Overleft_stbox_stbox(DataChunk &args, ExpressionState &stat
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Right_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1818,9 +1693,6 @@ void StboxFunctions::Right_stbox_stbox(DataChunk &args, ExpressionState &state, 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Overright_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1868,9 +1740,6 @@ void StboxFunctions::Overright_stbox_stbox(DataChunk &args, ExpressionState &sta
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Below_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1918,9 +1787,6 @@ void StboxFunctions::Below_stbox_stbox(DataChunk &args, ExpressionState &state, 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Overbelow_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1968,9 +1834,6 @@ void StboxFunctions::Overbelow_stbox_stbox(DataChunk &args, ExpressionState &sta
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Above_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2018,9 +1881,6 @@ void StboxFunctions::Above_stbox_stbox(DataChunk &args, ExpressionState &state, 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Overabove_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2068,9 +1928,6 @@ void StboxFunctions::Overabove_stbox_stbox(DataChunk &args, ExpressionState &sta
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Before_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2118,9 +1975,6 @@ void StboxFunctions::Before_stbox_stbox(DataChunk &args, ExpressionState &state,
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Overbefore_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2168,9 +2022,6 @@ void StboxFunctions::Overbefore_stbox_stbox(DataChunk &args, ExpressionState &st
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::After_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2218,9 +2069,6 @@ void StboxFunctions::After_stbox_stbox(DataChunk &args, ExpressionState &state, 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Overafter_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2268,9 +2116,6 @@ void StboxFunctions::Overafter_stbox_stbox(DataChunk &args, ExpressionState &sta
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Front_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2318,9 +2163,6 @@ void StboxFunctions::Front_stbox_stbox(DataChunk &args, ExpressionState &state, 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Overfront_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2368,9 +2210,6 @@ void StboxFunctions::Overfront_stbox_stbox(DataChunk &args, ExpressionState &sta
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Back_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2418,9 +2257,6 @@ void StboxFunctions::Back_stbox_stbox(DataChunk &args, ExpressionState &state, V
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Overback_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2468,9 +2304,6 @@ void StboxFunctions::Overback_stbox_stbox(DataChunk &args, ExpressionState &stat
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Union_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2536,9 +2369,6 @@ void StboxFunctions::Union_stbox_stbox(DataChunk &args, ExpressionState &state, 
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Intersection_stbox_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2604,9 +2434,6 @@ void StboxFunctions::Intersection_stbox_stbox(DataChunk &args, ExpressionState &
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 // Comparison operators
@@ -2637,9 +2464,6 @@ void StboxFunctions::Stbox_eq(DataChunk &args, ExpressionState &state, Vector &r
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_ne(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2669,9 +2493,6 @@ void StboxFunctions::Stbox_ne(DataChunk &args, ExpressionState &state, Vector &r
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_le(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2701,9 +2522,6 @@ void StboxFunctions::Stbox_le(DataChunk &args, ExpressionState &state, Vector &r
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_lt(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2733,9 +2551,6 @@ void StboxFunctions::Stbox_lt(DataChunk &args, ExpressionState &state, Vector &r
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_ge(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2765,9 +2580,6 @@ void StboxFunctions::Stbox_ge(DataChunk &args, ExpressionState &state, Vector &r
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_gt(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2797,9 +2609,6 @@ void StboxFunctions::Stbox_gt(DataChunk &args, ExpressionState &state, Vector &r
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void StboxFunctions::Stbox_cmp(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2829,9 +2638,6 @@ void StboxFunctions::Stbox_cmp(DataChunk &args, ExpressionState &state, Vector &
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -2854,12 +2660,6 @@ inline Temporal *BlobToTempTile(string_t b) {
     return reinterpret_cast<Temporal *>(copy);
 }
 
-inline Temporal *BlobToTemp(string_t b) {
-    size_t sz = b.GetSize();
-    uint8_t *copy = (uint8_t *)malloc(sz);
-    memcpy(copy, b.GetData(), sz);
-    return reinterpret_cast<Temporal *>(copy);
-}
 
 string_t StboxToResultBlob(Vector &result, const STBox *box) {
     string_t blob(reinterpret_cast<const char *>(box), sizeof(STBox));
@@ -2934,7 +2734,6 @@ void StboxFunctions::Stbox_space_tiles(DataChunk &args, ExpressionState &state, 
         free(bounds); free(origin);
         EmitStboxList(result, row, list_entries, boxes, count, total);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void StboxFunctions::Stbox_time_tiles(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2968,7 +2767,6 @@ void StboxFunctions::Stbox_time_tiles(DataChunk &args, ExpressionState &state, V
         free(bounds);
         EmitStboxList(result, row, list_entries, boxes, count, total);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void StboxFunctions::Stbox_space_time_tiles(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3012,7 +2810,6 @@ void StboxFunctions::Stbox_space_time_tiles(DataChunk &args, ExpressionState &st
         free(bounds); free(origin);
         EmitStboxList(result, row, list_entries, boxes, count, total);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void StboxFunctions::Tgeo_space_boxes(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3049,7 +2846,6 @@ void StboxFunctions::Tgeo_space_boxes(DataChunk &args, ExpressionState &state, V
         free(temp); free(origin);
         EmitStboxList(result, row, list_entries, boxes, count, total);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void StboxFunctions::Tgeo_space_time_boxes(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3094,7 +2890,6 @@ void StboxFunctions::Tgeo_space_time_boxes(DataChunk &args, ExpressionState &sta
         free(temp); free(origin);
         EmitStboxList(result, row, list_entries, boxes, count, total);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void StboxFunctions::Stbox_get_space_tile(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3132,7 +2927,6 @@ void StboxFunctions::Stbox_get_space_tile(DataChunk &args, ExpressionState &stat
         out_data[row] = StboxToResultBlob(result, box);
         free(box);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void StboxFunctions::Stbox_get_time_tile(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3165,7 +2959,6 @@ void StboxFunctions::Stbox_get_time_tile(DataChunk &args, ExpressionState &state
         out_data[row] = StboxToResultBlob(result, box);
         free(box);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void StboxFunctions::Stbox_get_space_time_tile(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3214,7 +3007,6 @@ void StboxFunctions::Stbox_get_space_time_tile(DataChunk &args, ExpressionState 
         out_data[row] = StboxToResultBlob(result, box);
         free(box);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 #define DEFINE_TSPATIAL_TOPO(OP, MEOS)                                                                                                       \
@@ -3222,7 +3014,7 @@ void StboxFunctions::OP##_tspatial_stbox(DataChunk &args, ExpressionState &state
     BinaryExecutor::Execute<string_t, string_t, bool>(                                                                                       \
         args.data[0], args.data[1], result, args.size(),                                                                                     \
         [](string_t bt, string_t bs) -> bool {                                                                                               \
-            Temporal *t = BlobToTemp(bt);                                                                                                    \
+            Temporal *t = BlobToTemporal(bt);                                                                                                    \
             STBox    *s = BlobToStbox(bs);                                                                                                   \
             bool r = MEOS##_tspatial_stbox(t, s);                                                                                            \
             free(t); free(s);                                                                                                                \
@@ -3234,7 +3026,7 @@ void StboxFunctions::OP##_stbox_tspatial(DataChunk &args, ExpressionState &state
         args.data[0], args.data[1], result, args.size(),                                                                                     \
         [](string_t bs, string_t bt) -> bool {                                                                                               \
             STBox    *s = BlobToStbox(bs);                                                                                                   \
-            Temporal *t = BlobToTemp(bt);                                                                                                    \
+            Temporal *t = BlobToTemporal(bt);                                                                                                    \
             bool r = MEOS##_stbox_tspatial(s, t);                                                                                            \
             free(s); free(t);                                                                                                                \
             return r;                                                                                                                        \
@@ -3244,8 +3036,8 @@ void StboxFunctions::OP##_tspatial_tspatial(DataChunk &args, ExpressionState &st
     BinaryExecutor::Execute<string_t, string_t, bool>(                                                                                       \
         args.data[0], args.data[1], result, args.size(),                                                                                     \
         [](string_t b1, string_t b2) -> bool {                                                                                               \
-            Temporal *t1 = BlobToTemp(b1);                                                                                                   \
-            Temporal *t2 = BlobToTemp(b2);                                                                                                   \
+            Temporal *t1 = BlobToTemporal(b1);                                                                                                   \
+            Temporal *t2 = BlobToTemporal(b2);                                                                                                   \
             bool r = MEOS##_tspatial_tspatial(t1, t2);                                                                                       \
             free(t1); free(t2);                                                                                                              \
             return r;                                                                                                                        \

--- a/src/geo/tgeogpoint.cpp
+++ b/src/geo/tgeogpoint.cpp
@@ -1726,7 +1726,6 @@ void TgeogAsMfjsonExec(DataChunk &args, ExpressionState &state, Vector &result) 
         out_data[row] = StringVector::AddString(result, json);
         free(json);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeogFromMfjsonExec(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1813,7 +1812,7 @@ LogicalType TGeogpointType::TGEOGPOINT() {
  * Constructors
 */
 
-inline void Tgeogpoint_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tgeogpoint_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
     
@@ -1846,12 +1845,9 @@ inline void Tgeogpoint_constructor(DataChunk &args, ExpressionState &state, Vect
             return stored_data;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Tgeogpointinst_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tgeogpointinst_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &value_vec = args.data[0];
     auto &t_vec = args.data[1];
@@ -1901,13 +1897,10 @@ inline void Tgeogpointinst_constructor(DataChunk &args, ExpressionState &state, 
 
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Tgeogpoint_sequence_from_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tgeogpoint_sequence_from_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
     const char* default_interp = "step";
     auto count = args.size();
     auto arg_count = args.ColumnCount();
@@ -1972,9 +1965,6 @@ inline void Tgeogpoint_sequence_from_tstzspan(DataChunk &args, ExpressionState &
 
         });
 
-    if (count == 1){
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 TInstant **temparr_extract_gp(Vector &tgeogpoint_arr_vec, list_entry_t list_entry, int *count) {
@@ -2039,7 +2029,7 @@ TInstant **temparr_extract_gp(Vector &tgeogpoint_arr_vec, list_entry_t list_entr
     return instants;
 }
 
-inline void Tgeogpoint_sequence_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tgeogpoint_sequence_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
     // Default values
     const char* default_interp = "linear";
     bool default_lower_inc = true;
@@ -2173,9 +2163,6 @@ inline void Tgeogpoint_sequence_constructor(DataChunk &args, ExpressionState &st
         }
     }
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -2185,7 +2172,7 @@ inline void Tgeogpoint_sequence_constructor(DataChunk &args, ExpressionState &st
  * Conversions
 */
 
-inline void Temporal_to_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_to_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -2226,16 +2213,13 @@ inline void Temporal_to_tstzspan(DataChunk &args, ExpressionState &state, Vector
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /*
  * Transformations
 */
 
-inline void Temporal_to_tinstant(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_to_tinstant(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -2275,13 +2259,10 @@ inline void Temporal_to_tinstant(DataChunk &args, ExpressionState &state, Vector
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Temporal_set_interp(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_set_interp(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
     auto &interp_vec = args.data[1];
@@ -2326,13 +2307,10 @@ inline void Temporal_set_interp(DataChunk &args, ExpressionState &state, Vector 
             return stored_data;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom1_vec = args.data[0];
     auto &tgeom2_vec = args.data[1];
@@ -2380,9 +2358,6 @@ inline void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &resu
             return stored_data;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -2390,7 +2365,7 @@ inline void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &resu
  * Accessor Functions
 */
 
-inline void Temporal_subtype(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_subtype(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
 
@@ -2417,15 +2392,12 @@ inline void Temporal_subtype(DataChunk &args, ExpressionState &state, Vector &re
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
 
 
-inline void Temporal_interp(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_interp(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
 
@@ -2454,12 +2426,9 @@ inline void Temporal_interp(DataChunk &args, ExpressionState &state, Vector &res
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Temporal_mem_size(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_mem_size(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
 
@@ -2481,12 +2450,9 @@ inline void Temporal_mem_size(DataChunk &args, ExpressionState &state, Vector &r
             return static_cast<int32_t>(mem_size);
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Tinstant_value(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tinstant_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
     
@@ -2510,14 +2476,11 @@ inline void Tinstant_value(DataChunk &args, ExpressionState &state, Vector &resu
             return stored_result;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
 
-inline void Temporal_start_value(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_start_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
     
@@ -2540,13 +2503,10 @@ inline void Temporal_start_value(DataChunk &args, ExpressionState &state, Vector
             return stored_result;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Temporal_end_value(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_end_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
     
@@ -2570,13 +2530,10 @@ inline void Temporal_end_value(DataChunk &args, ExpressionState &state, Vector &
             return stored_result;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Temporal_lower_inc(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_lower_inc(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
 
@@ -2594,12 +2551,9 @@ inline void Temporal_lower_inc(DataChunk &args, ExpressionState &state, Vector &
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Temporal_upper_inc(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_upper_inc(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
 
@@ -2617,12 +2571,9 @@ inline void Temporal_upper_inc(DataChunk &args, ExpressionState &state, Vector &
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Temporal_start_instant(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_start_instant(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
 
@@ -2659,12 +2610,9 @@ inline void Temporal_start_instant(DataChunk &args, ExpressionState &state, Vect
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Temporal_end_instant(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_end_instant(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
 
@@ -2701,15 +2649,12 @@ inline void Temporal_end_instant(DataChunk &args, ExpressionState &state, Vector
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
 
 
-inline void Temporal_instant_n(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_instant_n(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
     auto &n_vec = args.data[1];
@@ -2746,13 +2691,10 @@ inline void Temporal_instant_n(DataChunk &args, ExpressionState &state, Vector &
             return stored_result;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Tinstant_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tinstant_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -2790,12 +2732,9 @@ inline void Tinstant_timestamptz(DataChunk &args, ExpressionState &state, Vector
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void ExecuteTGeometrySeq(DataChunk &args, ExpressionState &state, Vector &result) {
+static void ExecuteTGeometrySeq(DataChunk &args, ExpressionState &state, Vector &result) {
     const char* default_interp = "step";
     auto count = args.size();
     auto &tgeogpoint_vec = args.data[0];
@@ -2864,9 +2803,6 @@ inline void ExecuteTGeometrySeq(DataChunk &args, ExpressionState &state, Vector 
             return stored_data;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 

--- a/src/geo/tgeogpoint_functions.cpp
+++ b/src/geo/tgeogpoint_functions.cpp
@@ -44,9 +44,6 @@ bool TgeogpointFunctions::Tpoint_in(Vector &source, Vector &result, idx_t count,
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
     return true;
 }
 
@@ -89,9 +86,6 @@ void TgeogpointFunctions::Tpointinst_constructor(DataChunk &args, ExpressionStat
             free(ret_data);
             return stored_data;
         });
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 } // namespace duckdb

--- a/src/geo/tgeogpoint_in_out.cpp
+++ b/src/geo/tgeogpoint_in_out.cpp
@@ -16,7 +16,7 @@ extern "C" {
 
 namespace duckdb {
 
-inline void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -43,7 +43,7 @@ inline void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &re
                 throw InvalidInputException("Invalid TGEOGPOINT data: null pointer");
             }
 
-            char *str = tspatial_as_text(temp, 0);
+            char *str = tspatial_as_text(temp, 15);
             
             if (!str) {
                 free(data_copy);
@@ -60,12 +60,9 @@ inline void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &re
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -93,7 +90,7 @@ inline void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &re
                 throw InvalidInputException("Invalid TGEOGPOINT data: null pointer");
             }
 
-            char *ewkt = tspatial_as_ewkt(temp, 0);
+            char *ewkt = tspatial_as_ewkt(temp, 15);
             
             if (!ewkt) {
                 free(data_copy);
@@ -111,9 +108,6 @@ inline void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &re
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -146,9 +140,6 @@ bool TgeogpointFunctions::StringToTgeogpoint(Vector &source, Vector &result, idx
             return stored_data;
         });
         
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
     return true;
 }
 
@@ -190,9 +181,6 @@ bool TgeogpointFunctions::TgeogpointToString(Vector &source, Vector &result, idx
             return stored_result;
         });
         
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
     return true;   
 }
 

--- a/src/geo/tgeogpoint_ops.cpp
+++ b/src/geo/tgeogpoint_ops.cpp
@@ -3,6 +3,7 @@
 // purely registration-and-glue; the heavy lifting stays in libmeos.
 
 #include "meos_wrapper_simple.hpp"
+#include "temporal/temporal_blob.hpp"
 
 #include "common.hpp"
 #include "geo/tgeogpoint.hpp"
@@ -34,20 +35,14 @@ namespace {
 // Argument-decoding helpers
 // ====================================================================
 
-inline Temporal *DecodeTemporalCopy(string_t blob) {
-    size_t sz = blob.GetSize();
-    Temporal *t = (Temporal *) malloc(sz);
-    memcpy(t, blob.GetData(), sz);
-    return t;
-}
 
-inline STBox *DecodeStboxCopy(string_t blob) {
+static STBox *DecodeStboxCopy(string_t blob) {
     STBox *b = (STBox *) malloc(sizeof(STBox));
     memcpy(b, blob.GetData(), sizeof(STBox));
     return b;
 }
 
-inline Span *DecodeSpanCopy(string_t blob) {
+static Span *DecodeSpanCopy(string_t blob) {
     Span *s = (Span *) malloc(sizeof(Span));
     memcpy(s, blob.GetData(), sizeof(Span));
     return s;
@@ -62,7 +57,7 @@ void TspatialStboxBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::Execute<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t b_blob) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             STBox *b = DecodeStboxCopy(b_blob);
             bool r = FN(t, b);
             free(t); free(b);
@@ -81,7 +76,7 @@ void StboxTspatialBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
         args.data[0], args.data[1], result, args.size(),
         [&](string_t b_blob, string_t t_blob) {
             STBox *b = DecodeStboxCopy(b_blob);
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             bool r = FN(t, b);
             free(t); free(b);
             return r;
@@ -93,8 +88,8 @@ void TspatialTspatialBoolExec(DataChunk &args, ExpressionState &, Vector &result
     BinaryExecutor::Execute<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t a, string_t b) {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             bool r = FN(t1, t2);
             free(t1); free(t2);
             return r;
@@ -106,7 +101,7 @@ void TemporalTstzspanBoolExec(DataChunk &args, ExpressionState &, Vector &result
     BinaryExecutor::Execute<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t s_blob) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             Span *s = DecodeSpanCopy(s_blob);
             bool r = FN(t, s);
             free(t); free(s);
@@ -120,7 +115,7 @@ void TstzspanTemporalBoolExec(DataChunk &args, ExpressionState &, Vector &result
         args.data[0], args.data[1], result, args.size(),
         [&](string_t s_blob, string_t t_blob) {
             Span *s = DecodeSpanCopy(s_blob);
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             bool r = FN(s, t);
             free(t); free(s);
             return r;
@@ -137,7 +132,7 @@ void TgeoGeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(t, gs);
@@ -152,7 +147,7 @@ void GeoTgeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(gs, t);
@@ -167,8 +162,8 @@ void TgeoTgeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             int r = FN(t1, t2);
             free(t1); free(t2);
             if (r < 0) { mask.SetInvalid(idx); return false; }
@@ -181,7 +176,7 @@ void TgeoGeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t t_blob, string_t g_blob, double dist, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(t, gs, dist);
@@ -196,7 +191,7 @@ void GeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(gs, t, dist);
@@ -213,7 +208,7 @@ void GeoTgeoDistIntExec_FromTgeoGeo(DataChunk &args, ExpressionState &, Vector &
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(t, gs, dist);
@@ -228,8 +223,8 @@ void TgeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t a, string_t b, double dist, ValidityMask &mask, idx_t idx) {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             int r = FN(t1, t2, dist);
             free(t1); free(t2);
             if (r < 0) { mask.SetInvalid(idx); return false; }
@@ -243,20 +238,13 @@ void TgeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
 // covering the whole input duration.
 // ====================================================================
 
-inline string_t TemporalToBlob(Vector &result, Temporal *t) {
-    size_t sz = temporal_mem_size(t);
-    string_t out = StringVector::AddStringOrBlob(
-        result, reinterpret_cast<const char *>(t), sz);
-    free(t);
-    return out;
-}
 
 template <Temporal *(*FN)(const Temporal *, const GSERIALIZED *)>
 void TgeoGeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(t, gs);
@@ -271,7 +259,7 @@ void GeoTgeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(gs, t);
@@ -286,8 +274,8 @@ void TgeoTgeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             Temporal *r = FN(t1, t2);
             free(t1); free(t2);
             if (!r) { mask.SetInvalid(idx); return string_t(); }
@@ -301,7 +289,7 @@ void TgeoGeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t t_blob, string_t g_blob, double dist, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(t, gs, dist);
@@ -316,7 +304,7 @@ void GeoTgeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(gs, t, dist);
@@ -331,8 +319,8 @@ void TgeoTgeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t a, string_t b, double dist, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             Temporal *r = FN(t1, t2, dist);
             free(t1); free(t2);
             if (!r) { mask.SetInvalid(idx); return string_t(); }
@@ -349,7 +337,7 @@ void TgeoGeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(t, gs);
@@ -364,8 +352,8 @@ void TgeoTgeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             Temporal *r = FN(t1, t2);
             free(t1); free(t2);
             if (!r) { mask.SetInvalid(idx); return string_t(); }
@@ -379,14 +367,14 @@ void TgeoTgeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
 // tgeogpoint <-> tgeography coercions.
 // ====================================================================
 
-inline string_t StboxToBlob(Vector &result, STBox *box) {
+static string_t StboxToBlob(Vector &result, STBox *box) {
     string_t out = StringVector::AddStringOrBlob(
         result, reinterpret_cast<const char *>(box), sizeof(STBox));
     free(box);
     return out;
 }
 
-inline string_t GeoToBlobAsHex(Vector &result, GSERIALIZED *gs) {
+static string_t GeoToBlobAsHex(Vector &result, GSERIALIZED *gs) {
     if (!gs) return string_t();
     size_t sz = 0;
     uint8_t *ewkb = geo_as_ewkb(gs, NULL, &sz);
@@ -401,7 +389,7 @@ void TspatialSridExec(DataChunk &args, ExpressionState &, Vector &result) {
     UnaryExecutor::Execute<string_t, int32_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             int32_t srid = tspatial_srid(t);
             free(t);
             return srid;
@@ -412,7 +400,7 @@ void TspatialSetSridExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::Execute<string_t, int32_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t blob, int32_t srid) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tspatial_set_srid(t, srid);
             free(t);
             if (!r) throw InvalidInputException("setSRID failed");
@@ -424,7 +412,7 @@ void TspatialTransformExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::Execute<string_t, int32_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t blob, int32_t srid) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tspatial_transform(t, srid);
             free(t);
             if (!r) throw InvalidInputException("transform failed");
@@ -436,7 +424,7 @@ void TspatialToStboxExec(DataChunk &args, ExpressionState &, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             STBox *box = tspatial_to_stbox(t);
             free(t);
             return StboxToBlob(result, box);
@@ -449,7 +437,7 @@ void TgeogpointToTgeographyExec(DataChunk &args, ExpressionState &, Vector &resu
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tgeogpoint_to_tgeography(t);
             free(t);
             if (!r) throw InvalidInputException("tgeography(tgeogpoint) failed");
@@ -461,7 +449,7 @@ void TgeographyToTgeogpointExec(DataChunk &args, ExpressionState &, Vector &resu
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tgeography_to_tgeogpoint(t);
             free(t);
             if (!r) throw InvalidInputException("tgeogpoint(tgeography) failed");
@@ -473,7 +461,7 @@ void TgeoCentroidExec(DataChunk &args, ExpressionState &state, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) -> string_t {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tgeo_centroid(t);
             free(t);
             if (!r) throw InvalidInputException("centroid failed");
@@ -485,7 +473,7 @@ void TgeoConvexHullExec(DataChunk &args, ExpressionState &state, Vector &result)
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) -> string_t {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             GSERIALIZED *gs = tgeo_convex_hull(t);
             free(t);
             return GeoToBlobAsHex(result, gs);
@@ -498,7 +486,7 @@ void TgeoTraversedAreaExec(DataChunk &args, ExpressionState &, Vector &result) {
         BinaryExecutor::Execute<string_t, bool, string_t>(
             args.data[0], args.data[1], result, cnt,
             [&](string_t blob, bool unary_union) -> string_t {
-                Temporal *t = DecodeTemporalCopy(blob);
+                Temporal *t = BlobToTemporal(blob);
                 GSERIALIZED *gs = tgeo_traversed_area(t, unary_union);
                 free(t);
                 return GeoToBlobAsHex(result, gs);
@@ -507,7 +495,7 @@ void TgeoTraversedAreaExec(DataChunk &args, ExpressionState &, Vector &result) {
         UnaryExecutor::Execute<string_t, string_t>(
             args.data[0], result, cnt,
             [&](string_t blob) -> string_t {
-                Temporal *t = DecodeTemporalCopy(blob);
+                Temporal *t = BlobToTemporal(blob);
                 GSERIALIZED *gs = tgeo_traversed_area(t, false);
                 free(t);
                 return GeoToBlobAsHex(result, gs);
@@ -836,7 +824,7 @@ void TGeogpointOps::RegisterScalarFunctions(ExtensionLoader &loader) {
                 result_validity.SetInvalid(i);
                 continue;
             }
-            Temporal *t = DecodeTemporalCopy(t_data[i]);
+            Temporal *t = BlobToTemporal(t_data[i]);
             GSERIALIZED *origin = geompoint_make3dz(0, 0.0, 0.0, 0.0);
             int count = 0;
             STBox *boxes = tgeo_space_boxes(
@@ -876,7 +864,7 @@ void TGeogpointOps::RegisterScalarFunctions(ExtensionLoader &loader) {
                 result_validity.SetInvalid(i);
                 continue;
             }
-            Temporal *t = DecodeTemporalCopy(t_data[i]);
+            Temporal *t = BlobToTemporal(t_data[i]);
             GSERIALIZED *origin = geompoint_make3dz(0, 0.0, 0.0, 0.0);
             MeosInterval iv = IntervaltToInterval(dur_data[i]);
             constexpr int64_t DEFAULT_TIME_ORIGIN_MEOS = 2LL * 86400LL * 1000000LL;
@@ -906,7 +894,7 @@ void TGeogpointOps::RegisterScalarFunctions(ExtensionLoader &loader) {
             BinaryExecutor::Execute<string_t, double, string_t>(
                 args.data[0], args.data[1], result, args.size(),
                 [&](string_t blob, double eps) {
-                    Temporal *t = DecodeTemporalCopy(blob);
+                    Temporal *t = BlobToTemporal(blob);
                     Temporal *r = FN(t, eps);
                     free(t);
                     if (!r) throw InvalidInputException("simplify failed");
@@ -930,7 +918,7 @@ void TGeogpointOps::RegisterScalarFunctions(ExtensionLoader &loader) {
                     continue;
                 }
                 bool sync = has_third ? FlatVector::GetData<bool>(args.data[2])[i] : true;
-                Temporal *t = DecodeTemporalCopy(blob_data[i]);
+                Temporal *t = BlobToTemporal(blob_data[i]);
                 Temporal *r = FN(t, eps_data[i], sync);
                 free(t);
                 if (!r) {
@@ -952,7 +940,7 @@ void TGeogpointOps::RegisterScalarFunctions(ExtensionLoader &loader) {
             BinaryExecutor::Execute<string_t, interval_t, string_t>(
                 args.data[0], args.data[1], result, args.size(),
                 [&](string_t blob, interval_t iv) {
-                    Temporal *t = DecodeTemporalCopy(blob);
+                    Temporal *t = BlobToTemporal(blob);
                     MeosInterval miv = IntervaltToInterval(iv);
                     Temporal *r = temporal_simplify_min_tdelta(t, &miv);
                     free(t);

--- a/src/geo/tgeography.cpp
+++ b/src/geo/tgeography.cpp
@@ -34,7 +34,7 @@ LogicalType TGeographyTypes::TGEOGRAPHY() {
  * Constructors
 */
 
-inline void Tgeog_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tgeog_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
     
@@ -67,12 +67,9 @@ inline void Tgeog_constructor(DataChunk &args, ExpressionState &state, Vector &r
             return stored_data;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Tgeoginst_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tgeoginst_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &value_vec = args.data[0];
     auto &t_vec = args.data[1];
@@ -116,13 +113,10 @@ inline void Tgeoginst_constructor(DataChunk &args, ExpressionState &state, Vecto
 
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Tgeography_sequence_from_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tgeography_sequence_from_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
     const char* default_interp = "step";
     auto count = args.size();
     auto arg_count = args.ColumnCount();
@@ -187,9 +181,6 @@ inline void Tgeography_sequence_from_tstzspan(DataChunk &args, ExpressionState &
 
         });
 
-    if (count == 1){
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 TInstant **temparr_extract_g(Vector &tgeography_arr_vec, list_entry_t list_entry, int *count) {
@@ -254,7 +245,7 @@ TInstant **temparr_extract_g(Vector &tgeography_arr_vec, list_entry_t list_entry
     return instants;
 }
 
-inline void Tgeography_sequence_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tgeography_sequence_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
     // Default values
     const char* default_interp = "step";
     bool default_lower_inc = true;
@@ -388,9 +379,6 @@ inline void Tgeography_sequence_constructor(DataChunk &args, ExpressionState &st
         }
     }
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -400,7 +388,7 @@ inline void Tgeography_sequence_constructor(DataChunk &args, ExpressionState &st
  * Conversions
 */
 
-inline void Temporal_to_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_to_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -441,16 +429,13 @@ inline void Temporal_to_tstzspan(DataChunk &args, ExpressionState &state, Vector
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /*
  * Transformations
 */
 
-inline void Temporal_to_tinstant(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_to_tinstant(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -490,13 +475,10 @@ inline void Temporal_to_tinstant(DataChunk &args, ExpressionState &state, Vector
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Temporal_set_interp(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_set_interp(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
     auto &interp_vec = args.data[1];
@@ -541,13 +523,10 @@ inline void Temporal_set_interp(DataChunk &args, ExpressionState &state, Vector 
             return stored_data;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom1_vec = args.data[0];
     auto &tgeom2_vec = args.data[1];
@@ -595,9 +574,6 @@ inline void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &resu
             return stored_data;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -605,7 +581,7 @@ inline void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &resu
  * Accessor Functions
 */
 
-inline void Temporal_subtype(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_subtype(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
 
@@ -632,15 +608,12 @@ inline void Temporal_subtype(DataChunk &args, ExpressionState &state, Vector &re
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
 
 
-inline void Temporal_interp(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_interp(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
 
@@ -669,12 +642,9 @@ inline void Temporal_interp(DataChunk &args, ExpressionState &state, Vector &res
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Temporal_mem_size(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_mem_size(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
 
@@ -696,12 +666,9 @@ inline void Temporal_mem_size(DataChunk &args, ExpressionState &state, Vector &r
             return static_cast<int32_t>(mem_size);
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Tinstant_value(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tinstant_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
     
@@ -725,14 +692,11 @@ inline void Tinstant_value(DataChunk &args, ExpressionState &state, Vector &resu
             return stored_result;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
 
-inline void Temporal_start_value(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_start_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
     
@@ -755,13 +719,10 @@ inline void Temporal_start_value(DataChunk &args, ExpressionState &state, Vector
             return stored_result;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Temporal_end_value(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_end_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
     
@@ -785,13 +746,10 @@ inline void Temporal_end_value(DataChunk &args, ExpressionState &state, Vector &
             return stored_result;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Temporal_lower_inc(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_lower_inc(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
 
@@ -809,12 +767,9 @@ inline void Temporal_lower_inc(DataChunk &args, ExpressionState &state, Vector &
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Temporal_upper_inc(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_upper_inc(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
 
@@ -832,12 +787,9 @@ inline void Temporal_upper_inc(DataChunk &args, ExpressionState &state, Vector &
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Temporal_start_instant(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_start_instant(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
 
@@ -874,12 +826,9 @@ inline void Temporal_start_instant(DataChunk &args, ExpressionState &state, Vect
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Temporal_end_instant(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_end_instant(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
 
@@ -916,15 +865,12 @@ inline void Temporal_end_instant(DataChunk &args, ExpressionState &state, Vector
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
 
 
-inline void Temporal_instant_n(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_instant_n(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
     auto &n_vec = args.data[1];
@@ -961,13 +907,10 @@ inline void Temporal_instant_n(DataChunk &args, ExpressionState &state, Vector &
             return stored_result;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Tinstant_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tinstant_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -1005,12 +948,9 @@ inline void Tinstant_timestamptz(DataChunk &args, ExpressionState &state, Vector
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void ExecuteTGeometrySeq(DataChunk &args, ExpressionState &state, Vector &result) {
+static void ExecuteTGeometrySeq(DataChunk &args, ExpressionState &state, Vector &result) {
     const char* default_interp = "step";
     auto count = args.size();
     auto &tgeography_vec = args.data[0];
@@ -1079,9 +1019,6 @@ inline void ExecuteTGeometrySeq(DataChunk &args, ExpressionState &state, Vector 
             return stored_data;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 

--- a/src/geo/tgeography_in_out.cpp
+++ b/src/geo/tgeography_in_out.cpp
@@ -1,4 +1,5 @@
 #include "geo/tgeography.hpp"
+#include "temporal/temporal_blob.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/common/extension_type_info.hpp"
 #include <regex>
@@ -15,7 +16,7 @@ extern "C" {
 
 namespace duckdb {
 
-inline void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -42,7 +43,7 @@ inline void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &re
                 throw InvalidInputException("Invalid TGEOGRAPHY data: null pointer");
             }
 
-            char *str = tspatial_as_text(temp, 0);
+            char *str = tspatial_as_text(temp, 15);
             
             if (!str) {
                 free(data_copy);
@@ -59,12 +60,9 @@ inline void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &re
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -92,7 +90,7 @@ inline void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &re
                 throw InvalidInputException("Invalid TGEOGRAPHY data: null pointer");
             }
 
-            char *ewkt = tspatial_as_ewkt(temp, 0);
+            char *ewkt = tspatial_as_ewkt(temp, 15);
             
             if (!ewkt) {
                 free(data_copy);
@@ -110,9 +108,6 @@ inline void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &re
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -145,9 +140,6 @@ bool TgeographyFunctions::StringToTgeography(Vector &source, Vector &result, idx
             return stored_data;
         });
         
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
     return true;
 }
 
@@ -189,9 +181,6 @@ bool TgeographyFunctions::TgeographyToString(Vector &source, Vector &result, idx
             return stored_result;
         });
         
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
     return true;   
 }
 
@@ -199,15 +188,8 @@ bool TgeographyFunctions::TgeographyToString(Vector &source, Vector &result, idx
 // Mirror of the helpers in tgeometry_in_out.cpp; per-type for MFJSON /
 // text since MEOS uses tgeography_from_mfjson / tgeography_in there.
 
-inline string_t StoreTempAsBlobGeog(Vector &result, Temporal *t) {
-    size_t sz = temporal_mem_size(t);
-    string_t stored = StringVector::AddStringOrBlob(
-        result, string_t(reinterpret_cast<const char *>(t), sz));
-    free(t);
-    return stored;
-}
 
-inline void TgeographyFromWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
+static void TgeographyFromWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t input) -> string_t {
@@ -219,11 +201,11 @@ inline void TgeographyFromWkbExec(DataChunk &args, ExpressionState &, Vector &re
             Temporal *t = temporal_from_wkb(wkb, input.GetSize());
             free(wkb);
             if (!t) throw InvalidInputException("fromBinary: invalid MEOS-WKB");
-            return StoreTempAsBlobGeog(result, t);
+            return TemporalToBlob(result, t);
         });
 }
 
-inline void TgeographyFromHexWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
+static void TgeographyFromHexWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t input) -> string_t {
@@ -231,19 +213,19 @@ inline void TgeographyFromHexWkbExec(DataChunk &args, ExpressionState &, Vector 
             Temporal *t = temporal_from_hexwkb(hex.c_str());
             if (!t) throw InvalidInputException(
                 "fromHexWKB: invalid hex-encoded MEOS-WKB");
-            return StoreTempAsBlobGeog(result, t);
+            return TemporalToBlob(result, t);
         });
 }
 
 template <Temporal *(*FN)(const char *)>
-inline void TgeographyFromStringExec(DataChunk &args, ExpressionState &, Vector &result) {
+static void TgeographyFromStringExec(DataChunk &args, ExpressionState &, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t input) -> string_t {
             std::string s(input.GetData(), input.GetSize());
             Temporal *t = FN(s.c_str());
             if (!t) throw InvalidInputException("from*: invalid input");
-            return StoreTempAsBlobGeog(result, t);
+            return TemporalToBlob(result, t);
         });
 }
 

--- a/src/geo/tgeography_ops.cpp
+++ b/src/geo/tgeography_ops.cpp
@@ -3,6 +3,7 @@
 // purely registration-and-glue; the heavy lifting stays in libmeos.
 
 #include "meos_wrapper_simple.hpp"
+#include "temporal/temporal_blob.hpp"
 
 #include "common.hpp"
 #include "geo/tgeography.hpp"
@@ -35,20 +36,14 @@ namespace {
 // Argument-decoding helpers
 // ====================================================================
 
-inline Temporal *DecodeTemporalCopy(string_t blob) {
-    size_t sz = blob.GetSize();
-    Temporal *t = (Temporal *) malloc(sz);
-    memcpy(t, blob.GetData(), sz);
-    return t;
-}
 
-inline STBox *DecodeStboxCopy(string_t blob) {
+static STBox *DecodeStboxCopy(string_t blob) {
     STBox *b = (STBox *) malloc(sizeof(STBox));
     memcpy(b, blob.GetData(), sizeof(STBox));
     return b;
 }
 
-inline Span *DecodeSpanCopy(string_t blob) {
+static Span *DecodeSpanCopy(string_t blob) {
     Span *s = (Span *) malloc(sizeof(Span));
     memcpy(s, blob.GetData(), sizeof(Span));
     return s;
@@ -63,7 +58,7 @@ void TspatialStboxBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::Execute<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t b_blob) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             STBox *b = DecodeStboxCopy(b_blob);
             bool r = FN(t, b);
             free(t); free(b);
@@ -82,7 +77,7 @@ void StboxTspatialBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
         args.data[0], args.data[1], result, args.size(),
         [&](string_t b_blob, string_t t_blob) {
             STBox *b = DecodeStboxCopy(b_blob);
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             bool r = FN(t, b);
             free(t); free(b);
             return r;
@@ -94,8 +89,8 @@ void TspatialTspatialBoolExec(DataChunk &args, ExpressionState &, Vector &result
     BinaryExecutor::Execute<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t a, string_t b) {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             bool r = FN(t1, t2);
             free(t1); free(t2);
             return r;
@@ -107,7 +102,7 @@ void TemporalTstzspanBoolExec(DataChunk &args, ExpressionState &, Vector &result
     BinaryExecutor::Execute<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t s_blob) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             Span *s = DecodeSpanCopy(s_blob);
             bool r = FN(t, s);
             free(t); free(s);
@@ -121,7 +116,7 @@ void TstzspanTemporalBoolExec(DataChunk &args, ExpressionState &, Vector &result
         args.data[0], args.data[1], result, args.size(),
         [&](string_t s_blob, string_t t_blob) {
             Span *s = DecodeSpanCopy(s_blob);
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             bool r = FN(s, t);
             free(t); free(s);
             return r;
@@ -138,7 +133,7 @@ void TgeoGeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(t, gs);
@@ -153,7 +148,7 @@ void GeoTgeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(gs, t);
@@ -168,8 +163,8 @@ void TgeoTgeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             int r = FN(t1, t2);
             free(t1); free(t2);
             if (r < 0) { mask.SetInvalid(idx); return false; }
@@ -182,7 +177,7 @@ void TgeoGeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t t_blob, string_t g_blob, double dist, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(t, gs, dist);
@@ -197,7 +192,7 @@ void GeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(gs, t, dist);
@@ -214,7 +209,7 @@ void GeoTgeoDistIntExec_FromTgeoGeo(DataChunk &args, ExpressionState &, Vector &
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(t, gs, dist);
@@ -229,8 +224,8 @@ void TgeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t a, string_t b, double dist, ValidityMask &mask, idx_t idx) {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             int r = FN(t1, t2, dist);
             free(t1); free(t2);
             if (r < 0) { mask.SetInvalid(idx); return false; }
@@ -244,20 +239,13 @@ void TgeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
 // covering the whole input duration.
 // ====================================================================
 
-inline string_t TemporalToBlob(Vector &result, Temporal *t) {
-    size_t sz = temporal_mem_size(t);
-    string_t out = StringVector::AddStringOrBlob(
-        result, reinterpret_cast<const char *>(t), sz);
-    free(t);
-    return out;
-}
 
 template <Temporal *(*FN)(const Temporal *, const GSERIALIZED *)>
 void TgeoGeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(t, gs);
@@ -272,7 +260,7 @@ void GeoTgeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(gs, t);
@@ -287,8 +275,8 @@ void TgeoTgeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             Temporal *r = FN(t1, t2);
             free(t1); free(t2);
             if (!r) { mask.SetInvalid(idx); return string_t(); }
@@ -302,7 +290,7 @@ void TgeoGeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t t_blob, string_t g_blob, double dist, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(t, gs, dist);
@@ -317,7 +305,7 @@ void GeoTgeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(gs, t, dist);
@@ -332,8 +320,8 @@ void TgeoTgeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t a, string_t b, double dist, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             Temporal *r = FN(t1, t2, dist);
             free(t1); free(t2);
             if (!r) { mask.SetInvalid(idx); return string_t(); }
@@ -350,7 +338,7 @@ void TgeoGeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(t, gs);
@@ -365,8 +353,8 @@ void TgeoTgeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             Temporal *r = FN(t1, t2);
             free(t1); free(t2);
             if (!r) { mask.SetInvalid(idx); return string_t(); }
@@ -380,14 +368,14 @@ void TgeoTgeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
 // tgeography <-> tgeogpoint coercions.
 // ====================================================================
 
-inline string_t StboxToBlob(Vector &result, STBox *box) {
+static string_t StboxToBlob(Vector &result, STBox *box) {
     string_t out = StringVector::AddStringOrBlob(
         result, reinterpret_cast<const char *>(box), sizeof(STBox));
     free(box);
     return out;
 }
 
-inline string_t GeoToBlobAsHex(Vector &result, GSERIALIZED *gs) {
+static string_t GeoToBlobAsHex(Vector &result, GSERIALIZED *gs) {
     if (!gs) return string_t();
     size_t sz = 0;
     uint8_t *ewkb = geo_as_ewkb(gs, NULL, &sz);
@@ -402,7 +390,7 @@ void TspatialSridExec(DataChunk &args, ExpressionState &, Vector &result) {
     UnaryExecutor::Execute<string_t, int32_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             int32_t srid = tspatial_srid(t);
             free(t);
             return srid;
@@ -413,7 +401,7 @@ void TspatialSetSridExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::Execute<string_t, int32_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t blob, int32_t srid) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tspatial_set_srid(t, srid);
             free(t);
             if (!r) throw InvalidInputException("setSRID failed");
@@ -425,7 +413,7 @@ void TspatialTransformExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::Execute<string_t, int32_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t blob, int32_t srid) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tspatial_transform(t, srid);
             free(t);
             if (!r) throw InvalidInputException("transform failed");
@@ -437,7 +425,7 @@ void TspatialToStboxExec(DataChunk &args, ExpressionState &, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             STBox *box = tspatial_to_stbox(t);
             free(t);
             return StboxToBlob(result, box);
@@ -451,7 +439,7 @@ void TgeographyToTgeometryExec(DataChunk &args, ExpressionState &, Vector &resul
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tgeography_to_tgeometry(t);
             free(t);
             if (!r) throw InvalidInputException("tgeometry(tgeography) failed");
@@ -463,7 +451,7 @@ void TgeometryToTgeographyExec(DataChunk &args, ExpressionState &, Vector &resul
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tgeometry_to_tgeography(t);
             free(t);
             if (!r) throw InvalidInputException("tgeography(tgeometry) failed");
@@ -475,7 +463,7 @@ void TgeoCentroidExec(DataChunk &args, ExpressionState &state, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) -> string_t {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tgeo_centroid(t);
             free(t);
             if (!r) throw InvalidInputException("centroid failed");
@@ -487,7 +475,7 @@ void TgeoConvexHullExec(DataChunk &args, ExpressionState &state, Vector &result)
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) -> string_t {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             GSERIALIZED *gs = tgeo_convex_hull(t);
             free(t);
             return GeoToBlobAsHex(result, gs);
@@ -500,7 +488,7 @@ void TgeoTraversedAreaExec(DataChunk &args, ExpressionState &, Vector &result) {
         BinaryExecutor::Execute<string_t, bool, string_t>(
             args.data[0], args.data[1], result, cnt,
             [&](string_t blob, bool unary_union) -> string_t {
-                Temporal *t = DecodeTemporalCopy(blob);
+                Temporal *t = BlobToTemporal(blob);
                 GSERIALIZED *gs = tgeo_traversed_area(t, unary_union);
                 free(t);
                 return GeoToBlobAsHex(result, gs);
@@ -509,7 +497,7 @@ void TgeoTraversedAreaExec(DataChunk &args, ExpressionState &, Vector &result) {
         UnaryExecutor::Execute<string_t, string_t>(
             args.data[0], result, cnt,
             [&](string_t blob) -> string_t {
-                Temporal *t = DecodeTemporalCopy(blob);
+                Temporal *t = BlobToTemporal(blob);
                 GSERIALIZED *gs = tgeo_traversed_area(t, false);
                 free(t);
                 return GeoToBlobAsHex(result, gs);
@@ -839,7 +827,7 @@ void TGeographyOps::RegisterScalarFunctions(ExtensionLoader &loader) {
                 result_validity.SetInvalid(i);
                 continue;
             }
-            Temporal *t = DecodeTemporalCopy(t_data[i]);
+            Temporal *t = BlobToTemporal(t_data[i]);
             GSERIALIZED *origin = geompoint_make3dz(0, 0.0, 0.0, 0.0);
             int count = 0;
             STBox *boxes = tgeo_space_boxes(
@@ -879,7 +867,7 @@ void TGeographyOps::RegisterScalarFunctions(ExtensionLoader &loader) {
                 result_validity.SetInvalid(i);
                 continue;
             }
-            Temporal *t = DecodeTemporalCopy(t_data[i]);
+            Temporal *t = BlobToTemporal(t_data[i]);
             GSERIALIZED *origin = geompoint_make3dz(0, 0.0, 0.0, 0.0);
             MeosInterval iv = IntervaltToInterval(dur_data[i]);
             constexpr int64_t DEFAULT_TIME_ORIGIN_MEOS = 2LL * 86400LL * 1000000LL;
@@ -909,7 +897,7 @@ void TGeographyOps::RegisterScalarFunctions(ExtensionLoader &loader) {
             BinaryExecutor::Execute<string_t, double, string_t>(
                 args.data[0], args.data[1], result, args.size(),
                 [&](string_t blob, double eps) {
-                    Temporal *t = DecodeTemporalCopy(blob);
+                    Temporal *t = BlobToTemporal(blob);
                     Temporal *r = FN(t, eps);
                     free(t);
                     if (!r) throw InvalidInputException("simplify failed");
@@ -933,7 +921,7 @@ void TGeographyOps::RegisterScalarFunctions(ExtensionLoader &loader) {
                     continue;
                 }
                 bool sync = has_third ? FlatVector::GetData<bool>(args.data[2])[i] : true;
-                Temporal *t = DecodeTemporalCopy(blob_data[i]);
+                Temporal *t = BlobToTemporal(blob_data[i]);
                 Temporal *r = FN(t, eps_data[i], sync);
                 free(t);
                 if (!r) {
@@ -955,7 +943,7 @@ void TGeographyOps::RegisterScalarFunctions(ExtensionLoader &loader) {
             BinaryExecutor::Execute<string_t, interval_t, string_t>(
                 args.data[0], args.data[1], result, args.size(),
                 [&](string_t blob, interval_t iv) {
-                    Temporal *t = DecodeTemporalCopy(blob);
+                    Temporal *t = BlobToTemporal(blob);
                     MeosInterval miv = IntervaltToInterval(iv);
                     Temporal *r = temporal_simplify_min_tdelta(t, &miv);
                     free(t);

--- a/src/geo/tgeometry.cpp
+++ b/src/geo/tgeometry.cpp
@@ -35,7 +35,7 @@ LogicalType TGeometryTypes::TGEOMETRY() {
  * Constructors
 */
 
-inline void Tgeo_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tgeo_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
     
@@ -68,12 +68,9 @@ inline void Tgeo_constructor(DataChunk &args, ExpressionState &state, Vector &re
             return stored_data;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Tgeoinst_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tgeoinst_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &value_vec = args.data[0];
     auto &t_vec = args.data[1];
@@ -117,13 +114,10 @@ inline void Tgeoinst_constructor(DataChunk &args, ExpressionState &state, Vector
 
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Tgeometry_sequence_from_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tgeometry_sequence_from_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
     const char* default_interp = "step";
     auto count = args.size();
     auto arg_count = args.ColumnCount();
@@ -188,9 +182,6 @@ inline void Tgeometry_sequence_from_tstzspan(DataChunk &args, ExpressionState &s
 
         });
 
-    if (count == 1){
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 TInstant **temparr_extract(Vector &tgeometry_arr_vec, list_entry_t list_entry, int *count) {
@@ -255,7 +246,7 @@ TInstant **temparr_extract(Vector &tgeometry_arr_vec, list_entry_t list_entry, i
     return instants;
 }
 
-inline void Tgeometry_sequence_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tgeometry_sequence_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
     // Default values
     const char* default_interp = "step";
     bool default_lower_inc = true;
@@ -389,9 +380,6 @@ inline void Tgeometry_sequence_constructor(DataChunk &args, ExpressionState &sta
         }
     }
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -401,7 +389,7 @@ inline void Tgeometry_sequence_constructor(DataChunk &args, ExpressionState &sta
  * Conversions
 */
 
-inline void Temporal_to_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_to_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -442,16 +430,13 @@ inline void Temporal_to_tstzspan(DataChunk &args, ExpressionState &state, Vector
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /*
  * Transformations
 */
 
-inline void Temporal_to_tinstant(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_to_tinstant(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -491,13 +476,10 @@ inline void Temporal_to_tinstant(DataChunk &args, ExpressionState &state, Vector
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Temporal_set_interp(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_set_interp(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
     auto &interp_vec = args.data[1];
@@ -542,13 +524,10 @@ inline void Temporal_set_interp(DataChunk &args, ExpressionState &state, Vector 
             return stored_data;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom1_vec = args.data[0];
     auto &tgeom2_vec = args.data[1];
@@ -596,9 +575,6 @@ inline void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &resu
             return stored_data;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -606,7 +582,7 @@ inline void Temporal_merge(DataChunk &args, ExpressionState &state, Vector &resu
  * Accessor Functions
 */
 
-inline void Temporal_subtype(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_subtype(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
 
@@ -633,15 +609,12 @@ inline void Temporal_subtype(DataChunk &args, ExpressionState &state, Vector &re
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
 
 
-inline void Temporal_interp(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_interp(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
 
@@ -670,12 +643,9 @@ inline void Temporal_interp(DataChunk &args, ExpressionState &state, Vector &res
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Temporal_mem_size(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_mem_size(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
 
@@ -697,12 +667,9 @@ inline void Temporal_mem_size(DataChunk &args, ExpressionState &state, Vector &r
             return static_cast<int32_t>(mem_size);
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Tinstant_value(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tinstant_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
     
@@ -726,14 +693,11 @@ inline void Tinstant_value(DataChunk &args, ExpressionState &state, Vector &resu
             return stored_result;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
 
-inline void Temporal_start_value(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_start_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
     
@@ -756,13 +720,10 @@ inline void Temporal_start_value(DataChunk &args, ExpressionState &state, Vector
             return stored_result;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Temporal_end_value(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_end_value(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
     
@@ -786,13 +747,10 @@ inline void Temporal_end_value(DataChunk &args, ExpressionState &state, Vector &
             return stored_result;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Temporal_lower_inc(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_lower_inc(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
 
@@ -810,12 +768,9 @@ inline void Temporal_lower_inc(DataChunk &args, ExpressionState &state, Vector &
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Temporal_upper_inc(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_upper_inc(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
 
@@ -833,12 +788,9 @@ inline void Temporal_upper_inc(DataChunk &args, ExpressionState &state, Vector &
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Temporal_start_instant(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_start_instant(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
 
@@ -875,12 +827,9 @@ inline void Temporal_start_instant(DataChunk &args, ExpressionState &state, Vect
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Temporal_end_instant(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_end_instant(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_vec = args.data[0];
 
@@ -917,15 +866,12 @@ inline void Temporal_end_instant(DataChunk &args, ExpressionState &state, Vector
             return stored_result;
         });
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
 
 
-inline void Temporal_instant_n(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Temporal_instant_n(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &tgeom_vec = args.data[0];
     auto &n_vec = args.data[1];
@@ -962,13 +908,10 @@ inline void Temporal_instant_n(DataChunk &args, ExpressionState &state, Vector &
             return stored_result;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
-inline void Tinstant_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tinstant_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -1006,12 +949,9 @@ inline void Tinstant_timestamptz(DataChunk &args, ExpressionState &state, Vector
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void ExecuteTGeometrySeq(DataChunk &args, ExpressionState &state, Vector &result) {
+static void ExecuteTGeometrySeq(DataChunk &args, ExpressionState &state, Vector &result) {
     const char* default_interp = "step";
     auto count = args.size();
     auto &tgeometry_vec = args.data[0];
@@ -1080,9 +1020,6 @@ inline void ExecuteTGeometrySeq(DataChunk &args, ExpressionState &state, Vector 
             return stored_data;
         });
     
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 

--- a/src/geo/tgeometry_in_out.cpp
+++ b/src/geo/tgeometry_in_out.cpp
@@ -1,4 +1,5 @@
 #include "geo/tgeometry.hpp"
+#include "temporal/temporal_blob.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/common/extension_type_info.hpp"
 #include <regex>
@@ -15,7 +16,7 @@ extern "C" {
 
 namespace duckdb {
 
-inline void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -42,7 +43,7 @@ inline void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &re
                 throw InvalidInputException("Invalid TGEOMETRY data: null pointer");
             }
 
-            char *str = tspatial_as_text(temp, 0);
+            char *str = tspatial_as_text(temp, 15);
             
             if (!str) {
                 free(data_copy);
@@ -59,12 +60,9 @@ inline void Tspatial_as_text(DataChunk &args, ExpressionState &state, Vector &re
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &result) {
+static void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &result) {
     auto count = args.size();
     auto &input_geom_vec = args.data[0];
 
@@ -92,7 +90,7 @@ inline void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &re
                 throw InvalidInputException("Invalid TGEOMETRY data: null pointer");
             }
 
-            char *ewkt = tspatial_as_ewkt(temp, 0);
+            char *ewkt = tspatial_as_ewkt(temp, 15);
             
             if (!ewkt) {
                 free(data_copy);
@@ -110,9 +108,6 @@ inline void Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &re
         }
     );
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -145,9 +140,6 @@ bool TgeometryFunctions::StringToTgeometry(Vector &source, Vector &result, idx_t
             return stored_data;
         });
         
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
     return true;
 }
 
@@ -189,9 +181,6 @@ bool TgeometryFunctions::TgeometryToString(Vector &source, Vector &result, idx_t
             return stored_result;
         });
         
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
     return true;   
 }
 
@@ -202,15 +191,8 @@ bool TgeometryFunctions::TgeometryToString(Vector &source, Vector &result, idx_t
 // `tgeography_in` are per-type.  The result is stored as a raw blob, the
 // same format every other temporal type uses.
 
-inline string_t StoreTempAsBlob(Vector &result, Temporal *t) {
-    size_t sz = temporal_mem_size(t);
-    string_t stored = StringVector::AddStringOrBlob(
-        result, string_t(reinterpret_cast<const char *>(t), sz));
-    free(t);
-    return stored;
-}
 
-inline void TspatialFromWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
+static void TspatialFromWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t input) -> string_t {
@@ -222,11 +204,11 @@ inline void TspatialFromWkbExec(DataChunk &args, ExpressionState &, Vector &resu
             Temporal *t = temporal_from_wkb(wkb, input.GetSize());
             free(wkb);
             if (!t) throw InvalidInputException("fromBinary: invalid MEOS-WKB");
-            return StoreTempAsBlob(result, t);
+            return TemporalToBlob(result, t);
         });
 }
 
-inline void TspatialFromHexWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
+static void TspatialFromHexWkbExec(DataChunk &args, ExpressionState &, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t input) -> string_t {
@@ -234,19 +216,19 @@ inline void TspatialFromHexWkbExec(DataChunk &args, ExpressionState &, Vector &r
             Temporal *t = temporal_from_hexwkb(hex.c_str());
             if (!t) throw InvalidInputException(
                 "fromHexWKB: invalid hex-encoded MEOS-WKB");
-            return StoreTempAsBlob(result, t);
+            return TemporalToBlob(result, t);
         });
 }
 
 template <Temporal *(*FN)(const char *)>
-inline void TspatialFromStringExec(DataChunk &args, ExpressionState &, Vector &result) {
+static void TspatialFromStringExec(DataChunk &args, ExpressionState &, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t input) -> string_t {
             std::string s(input.GetData(), input.GetSize());
             Temporal *t = FN(s.c_str());
             if (!t) throw InvalidInputException("from*: invalid input");
-            return StoreTempAsBlob(result, t);
+            return TemporalToBlob(result, t);
         });
 }
 

--- a/src/geo/tgeometry_ops.cpp
+++ b/src/geo/tgeometry_ops.cpp
@@ -3,6 +3,7 @@
 // purely registration-and-glue; the heavy lifting stays in libmeos.
 
 #include "meos_wrapper_simple.hpp"
+#include "temporal/temporal_blob.hpp"
 
 #include "common.hpp"
 #include "geo/tgeometry.hpp"
@@ -35,20 +36,14 @@ namespace {
 // Argument-decoding helpers
 // ====================================================================
 
-inline Temporal *DecodeTemporalCopy(string_t blob) {
-    size_t sz = blob.GetSize();
-    Temporal *t = (Temporal *) malloc(sz);
-    memcpy(t, blob.GetData(), sz);
-    return t;
-}
 
-inline STBox *DecodeStboxCopy(string_t blob) {
+static STBox *DecodeStboxCopy(string_t blob) {
     STBox *b = (STBox *) malloc(sizeof(STBox));
     memcpy(b, blob.GetData(), sizeof(STBox));
     return b;
 }
 
-inline Span *DecodeSpanCopy(string_t blob) {
+static Span *DecodeSpanCopy(string_t blob) {
     Span *s = (Span *) malloc(sizeof(Span));
     memcpy(s, blob.GetData(), sizeof(Span));
     return s;
@@ -63,7 +58,7 @@ void TspatialStboxBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::Execute<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t b_blob) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             STBox *b = DecodeStboxCopy(b_blob);
             bool r = FN(t, b);
             free(t); free(b);
@@ -82,7 +77,7 @@ void StboxTspatialBoolExec(DataChunk &args, ExpressionState &, Vector &result) {
         args.data[0], args.data[1], result, args.size(),
         [&](string_t b_blob, string_t t_blob) {
             STBox *b = DecodeStboxCopy(b_blob);
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             bool r = FN(t, b);
             free(t); free(b);
             return r;
@@ -94,8 +89,8 @@ void TspatialTspatialBoolExec(DataChunk &args, ExpressionState &, Vector &result
     BinaryExecutor::Execute<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t a, string_t b) {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             bool r = FN(t1, t2);
             free(t1); free(t2);
             return r;
@@ -107,7 +102,7 @@ void TemporalTstzspanBoolExec(DataChunk &args, ExpressionState &, Vector &result
     BinaryExecutor::Execute<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t s_blob) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             Span *s = DecodeSpanCopy(s_blob);
             bool r = FN(t, s);
             free(t); free(s);
@@ -121,7 +116,7 @@ void TstzspanTemporalBoolExec(DataChunk &args, ExpressionState &, Vector &result
         args.data[0], args.data[1], result, args.size(),
         [&](string_t s_blob, string_t t_blob) {
             Span *s = DecodeSpanCopy(s_blob);
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             bool r = FN(s, t);
             free(t); free(s);
             return r;
@@ -138,7 +133,7 @@ void TgeoGeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(t, gs);
@@ -153,7 +148,7 @@ void GeoTgeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(gs, t);
@@ -168,8 +163,8 @@ void TgeoTgeoIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             int r = FN(t1, t2);
             free(t1); free(t2);
             if (r < 0) { mask.SetInvalid(idx); return false; }
@@ -182,7 +177,7 @@ void TgeoGeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t t_blob, string_t g_blob, double dist, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(t, gs, dist);
@@ -197,7 +192,7 @@ void GeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(gs, t, dist);
@@ -214,7 +209,7 @@ void GeoTgeoDistIntExec_FromTgeoGeo(DataChunk &args, ExpressionState &, Vector &
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             int r = FN(t, gs, dist);
@@ -229,8 +224,8 @@ void TgeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, bool>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t a, string_t b, double dist, ValidityMask &mask, idx_t idx) {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             int r = FN(t1, t2, dist);
             free(t1); free(t2);
             if (r < 0) { mask.SetInvalid(idx); return false; }
@@ -244,20 +239,13 @@ void TgeoTgeoDistIntExec(DataChunk &args, ExpressionState &, Vector &result) {
 // covering the whole input duration.
 // ====================================================================
 
-inline string_t TemporalToBlob(Vector &result, Temporal *t) {
-    size_t sz = temporal_mem_size(t);
-    string_t out = StringVector::AddStringOrBlob(
-        result, reinterpret_cast<const char *>(t), sz);
-    free(t);
-    return out;
-}
 
 template <Temporal *(*FN)(const Temporal *, const GSERIALIZED *)>
 void TgeoGeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(t, gs);
@@ -272,7 +260,7 @@ void GeoTgeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t g_blob, string_t t_blob, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(gs, t);
@@ -287,8 +275,8 @@ void TgeoTgeoTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             Temporal *r = FN(t1, t2);
             free(t1); free(t2);
             if (!r) { mask.SetInvalid(idx); return string_t(); }
@@ -302,7 +290,7 @@ void TgeoGeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t t_blob, string_t g_blob, double dist, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(t, gs, dist);
@@ -317,7 +305,7 @@ void GeoTgeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t g_blob, string_t t_blob, double dist, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(gs, t, dist);
@@ -332,8 +320,8 @@ void TgeoTgeoDistTempExec(DataChunk &args, ExpressionState &, Vector &result) {
     TernaryExecutor::ExecuteWithNulls<string_t, string_t, double, string_t>(
         args.data[0], args.data[1], args.data[2], result, args.size(),
         [&](string_t a, string_t b, double dist, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             Temporal *r = FN(t1, t2, dist);
             free(t1); free(t2);
             if (!r) { mask.SetInvalid(idx); return string_t(); }
@@ -350,7 +338,7 @@ void TgeoGeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t t_blob, string_t g_blob, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t = DecodeTemporalCopy(t_blob);
+            Temporal *t = BlobToTemporal(t_blob);
             int32 srid = tspatial_srid(t);
             GSERIALIZED *gs = GeometryToGSerialized(g_blob, srid);
             Temporal *r = FN(t, gs);
@@ -365,8 +353,8 @@ void TgeoTgeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t a, string_t b, ValidityMask &mask, idx_t idx) -> string_t {
-            Temporal *t1 = DecodeTemporalCopy(a);
-            Temporal *t2 = DecodeTemporalCopy(b);
+            Temporal *t1 = BlobToTemporal(a);
+            Temporal *t2 = BlobToTemporal(b);
             Temporal *r = FN(t1, t2);
             free(t1); free(t2);
             if (!r) { mask.SetInvalid(idx); return string_t(); }
@@ -380,14 +368,14 @@ void TgeoTgeoDistanceExec(DataChunk &args, ExpressionState &, Vector &result) {
 // tgeometry <-> tgeompoint coercions.
 // ====================================================================
 
-inline string_t StboxToBlob(Vector &result, STBox *box) {
+static string_t StboxToBlob(Vector &result, STBox *box) {
     string_t out = StringVector::AddStringOrBlob(
         result, reinterpret_cast<const char *>(box), sizeof(STBox));
     free(box);
     return out;
 }
 
-inline string_t GeoToBlobAsHex(Vector &result, GSERIALIZED *gs) {
+static string_t GeoToBlobAsHex(Vector &result, GSERIALIZED *gs) {
     if (!gs) return string_t();
     size_t sz = 0;
     uint8_t *ewkb = geo_as_ewkb(gs, NULL, &sz);
@@ -402,7 +390,7 @@ void TspatialSridExec(DataChunk &args, ExpressionState &, Vector &result) {
     UnaryExecutor::Execute<string_t, int32_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             int32_t srid = tspatial_srid(t);
             free(t);
             return srid;
@@ -413,7 +401,7 @@ void TspatialSetSridExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::Execute<string_t, int32_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t blob, int32_t srid) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tspatial_set_srid(t, srid);
             free(t);
             if (!r) throw InvalidInputException("setSRID failed");
@@ -425,7 +413,7 @@ void TspatialTransformExec(DataChunk &args, ExpressionState &, Vector &result) {
     BinaryExecutor::Execute<string_t, int32_t, string_t>(
         args.data[0], args.data[1], result, args.size(),
         [&](string_t blob, int32_t srid) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tspatial_transform(t, srid);
             free(t);
             if (!r) throw InvalidInputException("transform failed");
@@ -437,7 +425,7 @@ void TspatialToStboxExec(DataChunk &args, ExpressionState &, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             STBox *box = tspatial_to_stbox(t);
             free(t);
             return StboxToBlob(result, box);
@@ -448,7 +436,7 @@ void TgeometryToTgeompointExec(DataChunk &args, ExpressionState &, Vector &resul
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tgeometry_to_tgeompoint(t);
             free(t);
             if (!r) throw InvalidInputException("tgeompoint(tgeometry) failed");
@@ -460,7 +448,7 @@ void TgeompointToTgeometryExec(DataChunk &args, ExpressionState &, Vector &resul
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tgeompoint_to_tgeometry(t);
             free(t);
             if (!r) throw InvalidInputException("tgeometry(tgeompoint) failed");
@@ -472,7 +460,7 @@ void TgeoCentroidExec(DataChunk &args, ExpressionState &state, Vector &result) {
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) -> string_t {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             Temporal *r = tgeo_centroid(t);
             free(t);
             if (!r) throw InvalidInputException("centroid failed");
@@ -484,7 +472,7 @@ void TgeoConvexHullExec(DataChunk &args, ExpressionState &state, Vector &result)
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t blob) -> string_t {
-            Temporal *t = DecodeTemporalCopy(blob);
+            Temporal *t = BlobToTemporal(blob);
             GSERIALIZED *gs = tgeo_convex_hull(t);
             free(t);
             return GeoToBlobAsHex(result, gs);
@@ -497,7 +485,7 @@ void TgeoTraversedAreaExec(DataChunk &args, ExpressionState &, Vector &result) {
         BinaryExecutor::Execute<string_t, bool, string_t>(
             args.data[0], args.data[1], result, cnt,
             [&](string_t blob, bool unary_union) -> string_t {
-                Temporal *t = DecodeTemporalCopy(blob);
+                Temporal *t = BlobToTemporal(blob);
                 GSERIALIZED *gs = tgeo_traversed_area(t, unary_union);
                 free(t);
                 return GeoToBlobAsHex(result, gs);
@@ -506,7 +494,7 @@ void TgeoTraversedAreaExec(DataChunk &args, ExpressionState &, Vector &result) {
         UnaryExecutor::Execute<string_t, string_t>(
             args.data[0], result, cnt,
             [&](string_t blob) -> string_t {
-                Temporal *t = DecodeTemporalCopy(blob);
+                Temporal *t = BlobToTemporal(blob);
                 GSERIALIZED *gs = tgeo_traversed_area(t, false);
                 free(t);
                 return GeoToBlobAsHex(result, gs);
@@ -835,7 +823,7 @@ void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
                 result_validity.SetInvalid(i);
                 continue;
             }
-            Temporal *t = DecodeTemporalCopy(t_data[i]);
+            Temporal *t = BlobToTemporal(t_data[i]);
             GSERIALIZED *origin = geompoint_make3dz(0, 0.0, 0.0, 0.0);
             int count = 0;
             STBox *boxes = tgeo_space_boxes(
@@ -875,7 +863,7 @@ void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
                 result_validity.SetInvalid(i);
                 continue;
             }
-            Temporal *t = DecodeTemporalCopy(t_data[i]);
+            Temporal *t = BlobToTemporal(t_data[i]);
             GSERIALIZED *origin = geompoint_make3dz(0, 0.0, 0.0, 0.0);
             MeosInterval iv = IntervaltToInterval(dur_data[i]);
             constexpr int64_t DEFAULT_TIME_ORIGIN_MEOS = 2LL * 86400LL * 1000000LL;
@@ -905,7 +893,7 @@ void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
             BinaryExecutor::Execute<string_t, double, string_t>(
                 args.data[0], args.data[1], result, args.size(),
                 [&](string_t blob, double eps) {
-                    Temporal *t = DecodeTemporalCopy(blob);
+                    Temporal *t = BlobToTemporal(blob);
                     Temporal *r = FN(t, eps);
                     free(t);
                     if (!r) throw InvalidInputException("simplify failed");
@@ -929,7 +917,7 @@ void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
                     continue;
                 }
                 bool sync = has_third ? FlatVector::GetData<bool>(args.data[2])[i] : true;
-                Temporal *t = DecodeTemporalCopy(blob_data[i]);
+                Temporal *t = BlobToTemporal(blob_data[i]);
                 Temporal *r = FN(t, eps_data[i], sync);
                 free(t);
                 if (!r) {
@@ -951,7 +939,7 @@ void TGeometryOps::RegisterScalarFunctions(ExtensionLoader &loader) {
             BinaryExecutor::Execute<string_t, interval_t, string_t>(
                 args.data[0], args.data[1], result, args.size(),
                 [&](string_t blob, interval_t iv) {
-                    Temporal *t = DecodeTemporalCopy(blob);
+                    Temporal *t = BlobToTemporal(blob);
                     MeosInterval miv = IntervaltToInterval(iv);
                     Temporal *r = temporal_simplify_min_tdelta(t, &miv);
                     free(t);

--- a/src/geo/tgeompoint.cpp
+++ b/src/geo/tgeompoint.cpp
@@ -1,4 +1,5 @@
 #include "meos_wrapper_simple.hpp"
+#include "temporal/temporal_blob.hpp"
 
 #include "common.hpp"
 #include "geo/tgeompoint.hpp"
@@ -1775,12 +1776,6 @@ namespace {
 constexpr uint8_t WKB_BASE = 0x00;
 /* WKB_EXTENDED is provided by meos_geo.h as #define WKB_EXTENDED 0x04 */
 
-inline Temporal *BlobToTemp(string_t b) {
-    size_t sz = b.GetSize();
-    uint8_t *copy = (uint8_t *)malloc(sz);
-    memcpy(copy, b.GetData(), sz);
-    return reinterpret_cast<Temporal *>(copy);
-}
 
 inline Temporal *BlobToTempMVT(string_t b) {
     size_t sz = b.GetSize();
@@ -1799,7 +1794,7 @@ void TgeoAsWkbExec(DataChunk &args, ExpressionState &state, Vector &result, uint
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t input) -> string_t {
-            Temporal *t = BlobToTemp(input);
+            Temporal *t = BlobToTemporal(input);
             size_t sz = 0;
             uint8_t *wkb = temporal_as_wkb(t, variant, &sz);
             free(t);
@@ -1818,7 +1813,7 @@ void TgeoAsHexWkbExec(DataChunk &args, ExpressionState &state, Vector &result, u
     UnaryExecutor::Execute<string_t, string_t>(
         args.data[0], result, args.size(),
         [&](string_t input) -> string_t {
-            Temporal *t = BlobToTemp(input);
+            Temporal *t = BlobToTemporal(input);
             size_t sz = 0;
             char *hex = temporal_as_hexwkb(t, variant, &sz);
             (void) sz;
@@ -1873,7 +1868,7 @@ void TgeoAsMfjsonExec(DataChunk &args, ExpressionState &state, Vector &result) {
             out_validity.SetInvalid(row);
             continue;
         }
-        Temporal *t = BlobToTemp(in[row]);
+        Temporal *t = BlobToTemporal(in[row]);
         bool with_bbox = (cc > 1) ? FlatVector::GetData<bool>(args.data[1])[row] : false;
         int flags = (cc > 2) ? FlatVector::GetData<int32_t>(args.data[2])[row] : 0;
         int precision = (cc > 3) ? FlatVector::GetData<int32_t>(args.data[3])[row] : 15;
@@ -1893,7 +1888,6 @@ void TgeoAsMfjsonExec(DataChunk &args, ExpressionState &state, Vector &result) {
         out_data[row] = StringVector::AddString(result, json);
         free(json);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 inline STBox *BlobToStboxMVT(string_t b) {
@@ -1969,7 +1963,6 @@ void TgeoAsMVTGeomExec(DataChunk &args, ExpressionState &state, Vector &result) 
         }
         if (times) free(times);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeoFromMfjsonExec(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2267,7 +2260,6 @@ void TgeoGeoMeasureExec(DataChunk &args, ExpressionState &state, Vector &result)
         out_data[row] = StringVector::AddStringOrBlob(result, enc);
         free(geom);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 } // namespace

--- a/src/geo/tgeompoint_functions.cpp
+++ b/src/geo/tgeompoint_functions.cpp
@@ -153,9 +153,6 @@ static void spatialarr_wkt_array(DataChunk &args, ExpressionState &state, Vector
 
 	ListVector::SetListSize(result, total_offset);
 
-	if (row_count == 1) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	}
 }
 
 } // namespace
@@ -192,9 +189,6 @@ bool TgeompointFunctions::Tpoint_in(Vector &source, Vector &result, idx_t count,
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
     return true;
 }
 
@@ -228,9 +222,6 @@ void TgeompointFunctions::Tspatial_as_text(DataChunk &args, ExpressionState &sta
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tspatial_as_ewkt(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -263,9 +254,6 @@ void TgeompointFunctions::Tspatial_as_ewkt(DataChunk &args, ExpressionState &sta
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Spatialarr_as_text(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -318,12 +306,9 @@ void TgeompointFunctions::Tpointinst_constructor(DataChunk &args, ExpressionStat
             free(ret_data);
             return stored_data;
         });
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
-inline void Tspatial_to_stbox_common(Vector &source, Vector &result, idx_t count) {
+static void Tspatial_to_stbox_common(Vector &source, Vector &result, idx_t count) {
     UnaryExecutor::Execute<string_t, string_t>(
         source, result, count,
         [&](string_t input_blob) -> string_t {
@@ -361,9 +346,6 @@ inline void Tspatial_to_stbox_common(Vector &source, Vector &result, idx_t count
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tspatial_to_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -405,9 +387,6 @@ void TgeompointFunctions::Tgeompoint_start_value(DataChunk &args, ExpressionStat
             return stored_result;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tgeompoint_end_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -440,9 +419,6 @@ void TgeompointFunctions::Tgeompoint_end_value(DataChunk &args, ExpressionState 
             return stored_result;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tgeompoint_sequence_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -549,16 +525,13 @@ void TgeompointFunctions::Tgeompoint_sequence_constructor(DataChunk &args, Expre
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
  * Conversion functions
  ****************************************************/
 
-inline void Temporal_to_tstzspan_common(Vector &source, Vector &result, idx_t count) {
+static void Temporal_to_tstzspan_common(Vector &source, Vector &result, idx_t count) {
     UnaryExecutor::Execute<string_t, string_t>(
         source, result, count,
         [&](string_t input_blob) {
@@ -588,9 +561,6 @@ inline void Temporal_to_tstzspan_common(Vector &source, Vector &result, idx_t co
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Temporal_to_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -639,9 +609,6 @@ void TgeompointFunctions::Tgeompoint_value(DataChunk &args, ExpressionState &sta
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -692,9 +659,6 @@ void TgeompointFunctions::Tgeompoint_at_value(DataChunk &args, ExpressionState &
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tgeompoint_value_at_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -733,9 +697,6 @@ void TgeompointFunctions::Tgeompoint_value_at_timestamptz(DataChunk &args, Expre
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -773,9 +734,6 @@ void TgeompointFunctions::Tgeompoint_stops(DataChunk &args, ExpressionState &sta
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -809,9 +767,6 @@ void TgeompointFunctions::Tpoint_get_x(DataChunk &args, ExpressionState &state, 
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tpoint_get_y(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -842,9 +797,6 @@ void TgeompointFunctions::Tpoint_get_y(DataChunk &args, ExpressionState &state, 
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tpoint_get_z(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -875,9 +827,6 @@ void TgeompointFunctions::Tpoint_get_z(DataChunk &args, ExpressionState &state, 
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tpoint_length(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -898,9 +847,6 @@ void TgeompointFunctions::Tpoint_length(DataChunk &args, ExpressionState &state,
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tpoint_cumulative_length(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -931,9 +877,6 @@ void TgeompointFunctions::Tpoint_cumulative_length(DataChunk &args, ExpressionSt
             return stored_result;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tpoint_twcentroid(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -960,9 +903,6 @@ void TgeompointFunctions::Tpoint_twcentroid(DataChunk &args, ExpressionState &st
             return stored_result;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tpoint_direction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -988,9 +928,6 @@ void TgeompointFunctions::Tpoint_direction(DataChunk &args, ExpressionState &sta
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tpoint_azimuth(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1021,9 +958,6 @@ void TgeompointFunctions::Tpoint_azimuth(DataChunk &args, ExpressionState &state
             return stored_result;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tpoint_angular_difference(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1054,9 +988,6 @@ void TgeompointFunctions::Tpoint_angular_difference(DataChunk &args, ExpressionS
             return stored_result;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tpoint_is_simple(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1077,72 +1008,68 @@ void TgeompointFunctions::Tpoint_is_simple(DataChunk &args, ExpressionState &sta
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tpoint_make_simple(DataChunk &args, ExpressionState &state, Vector &result) {
-	idx_t total_count = 0;
-	UnaryExecutor::Execute<string_t, list_entry_t>(
-	    args.data[0], result, args.size(),
-	    [&](string_t input_blob) -> list_entry_t {
-		    const uint8_t *data = reinterpret_cast<const uint8_t *>(input_blob.GetData());
-		    size_t data_size = input_blob.GetSize();
-		    if (data_size < sizeof(void *)) {
-			    throw InvalidInputException("Invalid TGEOMPOINT data: insufficient size");
-		    }
-		    uint8_t *data_copy = (uint8_t *)malloc(data_size);
-		    memcpy(data_copy, data, data_size);
-		    Temporal *temp = reinterpret_cast<Temporal *>(data_copy);
-		    if (!temp) {
-			    free(data_copy);
-			    throw InvalidInputException("Invalid TGEOMPOINT data: null pointer");
-		    }
+	const idx_t count = args.size();
 
-		    int frag_count = 0;
-		    Temporal **fragments = tpoint_make_simple(temp, &frag_count);
-		    free(data_copy);
+	UnifiedVectorFormat in;
+	args.data[0].ToUnifiedFormat(count, in);
+	auto in_data = UnifiedVectorFormat::GetData<string_t>(in);
 
-		    if (!fragments || frag_count <= 0) {
-			    if (fragments) {
-				    free(fragments);
-			    }
-			    throw InvalidInputException("makeSimple: failed to split temporal point");
-		    }
+	auto list_data = FlatVector::GetData<list_entry_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+	auto &child_vec = ListVector::GetEntry(result);
+	idx_t offset = 0;
 
-		    const list_entry_t entry(total_count, static_cast<uint64_t>(frag_count));
-		    total_count += frag_count;
-		    ListVector::Reserve(result, total_count);
+	for (idx_t row = 0; row < count; row++) {
+		const idx_t idx = in.sel->get_index(row);
+		if (!in.validity.RowIsValid(idx)) {
+			result_validity.SetInvalid(row);
+			continue;
+		}
 
-		    auto &child_vec = ListVector::GetEntry(result);
-		    auto child_data = FlatVector::GetData<string_t>(child_vec);
+		const string_t &input_blob = in_data[idx];
+		size_t data_size = input_blob.GetSize();
+		if (data_size < sizeof(void *)) {
+			throw InvalidInputException("Invalid TGEOMPOINT data: insufficient size");
+		}
+		uint8_t *data_copy = (uint8_t *)malloc(data_size);
+		memcpy(data_copy, input_blob.GetData(), data_size);
+		Temporal *temp = reinterpret_cast<Temporal *>(data_copy);
 
-		    for (int i = 0; i < frag_count; i++) {
-			    Temporal *frag = fragments[i];
-			    if (!frag) {
-				    for (int k = i; k < frag_count; k++) {
-					    if (fragments[k]) {
-						    free(fragments[k]);
-					    }
-				    }
-				    free(fragments);
-				    throw InvalidInputException("makeSimple: null fragment in result array");
-			    }
-			    size_t frag_size = temporal_mem_size(frag);
-			    uint8_t *frag_buf = (uint8_t *)malloc(frag_size);
-			    memcpy(frag_buf, frag, frag_size);
-			    string_t frag_blob(reinterpret_cast<const char *>(frag_buf), frag_size);
-			    string_t stored = StringVector::AddStringOrBlob(child_vec, frag_blob);
-			    free(frag_buf);
-			    free(frag);
-			    child_data[entry.offset + static_cast<idx_t>(i)] = stored;
-		    }
-		    free(fragments);
-		    return entry;
-	    });
-	ListVector::SetListSize(result, total_count);
-	if (args.size() == 1) {
+		int frag_count = 0;
+		Temporal **fragments = tpoint_make_simple(temp, &frag_count);
+		if (!fragments || frag_count <= 0) {
+			free(data_copy);
+			if (fragments) {
+				free(fragments);
+			}
+			throw InvalidInputException("makeSimple: failed to split temporal point");
+		}
+
+		// Reserve the child capacity for this row's fragments, then re-fetch the
+		// child data pointer: Reserve may reallocate the child's data array.
+		ListVector::Reserve(result, offset + frag_count);
+		auto child_data = FlatVector::GetData<string_t>(child_vec);
+
+		for (int i = 0; i < frag_count; i++) {
+			Temporal *frag = fragments[i];
+			size_t frag_size = temporal_mem_size(frag);
+			child_data[offset + static_cast<idx_t>(i)] =
+			    StringVector::AddStringOrBlob(child_vec,
+			                                  string_t(reinterpret_cast<const char *>(frag), frag_size));
+			free(frag);
+		}
+		free(fragments);
+		free(data_copy);
+
+		list_data[row] = list_entry_t(offset, static_cast<uint64_t>(frag_count));
+		offset += frag_count;
+	}
+
+	ListVector::SetListSize(result, offset);
+	if (args.AllConstant()) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
 }
@@ -1175,9 +1102,6 @@ void TgeompointFunctions::Tpoint_trajectory(DataChunk &args, ExpressionState &st
             return stored_result;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tpoint_trajectory_gs(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1211,9 +1135,6 @@ void TgeompointFunctions::Tpoint_trajectory_gs(DataChunk &args, ExpressionState 
             return stored_result;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tgeo_at_geom(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1256,9 +1177,6 @@ void TgeompointFunctions::Tgeo_at_geom(DataChunk &args, ExpressionState &state, 
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tgeo_minus_geom(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1304,9 +1222,6 @@ void TgeompointFunctions::Tgeo_minus_geom(DataChunk &args, ExpressionState &stat
 		    return stored_data;
 	    });
 
-	if (count == 1) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	}
 }
 
 void TgeompointFunctions::Tgeo_minus_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1357,9 +1272,6 @@ void TgeompointFunctions::Tgeo_minus_stbox(DataChunk &args, ExpressionState &sta
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tgeo_at_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1419,9 +1331,6 @@ void TgeompointFunctions::Tgeo_at_stbox(DataChunk &args, ExpressionState &state,
                 return run(tgeom_blob, stbox_blob, border_inc, mask, idx);
             });
     }
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tspatial_transform(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1462,9 +1371,6 @@ void TgeompointFunctions::Tspatial_transform(DataChunk &args, ExpressionState &s
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -1501,9 +1407,6 @@ void TgeompointFunctions::Econtains_geo_tgeo(DataChunk &args, ExpressionState &s
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Acontains_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1537,9 +1440,6 @@ void TgeompointFunctions::Acontains_geo_tgeo(DataChunk &args, ExpressionState &s
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Edisjoint_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1576,9 +1476,6 @@ void TgeompointFunctions::Edisjoint_geo_tgeo(DataChunk &args, ExpressionState &s
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Edisjoint_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1615,9 +1512,6 @@ void TgeompointFunctions::Edisjoint_tgeo_geo(DataChunk &args, ExpressionState &s
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Edisjoint_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1655,9 +1549,6 @@ void TgeompointFunctions::Edisjoint_tgeo_tgeo(DataChunk &args, ExpressionState &
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Adisjoint_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1695,9 +1586,6 @@ void TgeompointFunctions::Adisjoint_geo_tgeo(DataChunk &args, ExpressionState &s
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Adisjoint_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1734,9 +1622,6 @@ void TgeompointFunctions::Adisjoint_tgeo_geo(DataChunk &args, ExpressionState &s
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Adisjoint_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1775,9 +1660,6 @@ void TgeompointFunctions::Adisjoint_tgeo_tgeo(DataChunk &args, ExpressionState &
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Eintersects_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1815,9 +1697,6 @@ void TgeompointFunctions::Eintersects_tgeo_tgeo(DataChunk &args, ExpressionState
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Eintersects_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1851,9 +1730,6 @@ void TgeompointFunctions::Eintersects_geo_tgeo(DataChunk &args, ExpressionState 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Eintersects_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1887,9 +1763,6 @@ void TgeompointFunctions::Eintersects_tgeo_geo(DataChunk &args, ExpressionState 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Aintersects_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1922,9 +1795,6 @@ void TgeompointFunctions::Aintersects_geo_tgeo(DataChunk &args, ExpressionState 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Aintersects_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1958,9 +1828,6 @@ void TgeompointFunctions::Aintersects_tgeo_geo(DataChunk &args, ExpressionState 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Aintersects_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1998,9 +1865,6 @@ void TgeompointFunctions::Aintersects_tgeo_tgeo(DataChunk &args, ExpressionState
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Etouches_geo_tpoint(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2036,9 +1900,6 @@ void TgeompointFunctions::Etouches_geo_tpoint(DataChunk &args, ExpressionState &
 		    }
 		    return ret;
 	    });
-	if (args.size() == 1) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	}
 }
 
 void TgeompointFunctions::Atouches_geo_tpoint(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2074,9 +1935,6 @@ void TgeompointFunctions::Atouches_geo_tpoint(DataChunk &args, ExpressionState &
 		    }
 		    return ret;
 	    });
-	if (args.size() == 1) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	}
 }
 
 void TgeompointFunctions::Etouches_tpoint_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2110,9 +1968,6 @@ void TgeompointFunctions::Etouches_tpoint_geo(DataChunk &args, ExpressionState &
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Atouches_tpoint_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2146,9 +2001,6 @@ void TgeompointFunctions::Atouches_tpoint_geo(DataChunk &args, ExpressionState &
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Edwithin_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2186,9 +2038,6 @@ void TgeompointFunctions::Edwithin_tgeo_tgeo(DataChunk &args, ExpressionState &s
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Edwithin_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2222,9 +2071,6 @@ void TgeompointFunctions::Edwithin_tgeo_geo(DataChunk &args, ExpressionState &st
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Edwithin_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2261,9 +2107,6 @@ void TgeompointFunctions::Edwithin_geo_tgeo(DataChunk &args, ExpressionState &st
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Adwithin_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2300,9 +2143,6 @@ void TgeompointFunctions::Adwithin_tgeo_geo(DataChunk &args, ExpressionState &st
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Adwithin_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2339,9 +2179,6 @@ void TgeompointFunctions::Adwithin_geo_tgeo(DataChunk &args, ExpressionState &st
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Adwithin_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2379,9 +2216,6 @@ void TgeompointFunctions::Adwithin_tgeo_tgeo(DataChunk &args, ExpressionState &s
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -2422,9 +2256,6 @@ void TgeompointFunctions::Tcontains_geo_tgeo(DataChunk &args, ExpressionState &s
             free(ret);
             return stored_data;
         });
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tdisjoint_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2461,9 +2292,6 @@ void TgeompointFunctions::Tdisjoint_geo_tgeo(DataChunk &args, ExpressionState &s
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tdisjoint_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2500,9 +2328,6 @@ void TgeompointFunctions::Tdisjoint_tgeo_geo(DataChunk &args, ExpressionState &s
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tdisjoint_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2543,9 +2368,6 @@ void TgeompointFunctions::Tdisjoint_tgeo_tgeo(DataChunk &args, ExpressionState &
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tintersects_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2582,9 +2404,6 @@ void TgeompointFunctions::Tintersects_geo_tgeo(DataChunk &args, ExpressionState 
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tintersects_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2621,9 +2440,6 @@ void TgeompointFunctions::Tintersects_tgeo_geo(DataChunk &args, ExpressionState 
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tintersects_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2664,9 +2480,6 @@ void TgeompointFunctions::Tintersects_tgeo_tgeo(DataChunk &args, ExpressionState
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Ttouches_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2703,9 +2516,6 @@ void TgeompointFunctions::Ttouches_geo_tgeo(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Ttouches_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2742,9 +2552,6 @@ void TgeompointFunctions::Ttouches_tgeo_geo(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tdwithin_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2786,9 +2593,6 @@ void TgeompointFunctions::Tdwithin_tgeo_tgeo(DataChunk &args, ExpressionState &s
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tdwithin_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2825,9 +2629,6 @@ void TgeompointFunctions::Tdwithin_tgeo_geo(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tdwithin_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2864,9 +2665,6 @@ void TgeompointFunctions::Tdwithin_geo_tgeo(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::ShortestLine_tgeo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2908,9 +2706,6 @@ void TgeompointFunctions::ShortestLine_tgeo_tgeo(DataChunk &args, ExpressionStat
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -2947,9 +2742,6 @@ void TgeompointFunctions::Temporal_overlaps_tgeompoint_stbox(DataChunk &args, Ex
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Temporal_overlaps_tgeompoint_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2982,9 +2774,6 @@ void TgeompointFunctions::Temporal_overlaps_tgeompoint_tstzspan(DataChunk &args,
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Temporal_contains_tgeompoint_stbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3017,9 +2806,6 @@ void TgeompointFunctions::Temporal_contains_tgeompoint_stbox(DataChunk &args, Ex
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -3070,9 +2856,6 @@ void TgeompointFunctions::Tdistance_tgeo_tgeo(DataChunk &args, ExpressionState &
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 // void TgeompointFunctions::gs_as_text(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3171,9 +2954,6 @@ void TgeompointFunctions::collect_gs(DataChunk &args, ExpressionState &state, Ve
             return stored_result;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::distance_geo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3207,9 +2987,6 @@ void TgeompointFunctions::distance_geo_geo(DataChunk &args, ExpressionState &sta
             return distance;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -3406,9 +3183,6 @@ void TgeompointFunctions::Tgeo_rotate_geom(DataChunk &args, ExpressionState &sta
 
         out_data[row] = ApplyAffineToTgeoStraggler(result, in_data[row], m);
     }
-    if (row_count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TgeompointFunctions::Tgeo_scale_xy(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3434,9 +3208,6 @@ void TgeompointFunctions::Tgeo_scale_xy(DataChunk &args, ExpressionState &state,
         m.afac = sx_data[row];
         m.efac = sy_data[row];
         out_data[row] = ApplyAffineToTgeoStraggler(result, in_data[row], m);
-    }
-    if (row_count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
     }
 }
 
@@ -3468,9 +3239,6 @@ void TgeompointFunctions::Tgeo_scale_xyz(DataChunk &args, ExpressionState &state
         m.efac = sy_data[row];
         m.ifac = sz_data[row];
         out_data[row] = ApplyAffineToTgeoStraggler(result, in_data[row], m);
-    }
-    if (row_count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
     }
 }
 
@@ -3525,7 +3293,6 @@ void TgeompointFunctions::Nai_tgeo_geo(DataChunk &args, ExpressionState &state, 
         if (!inst) { outv.SetInvalid(i); continue; }
         out[i] = NaiToHex(result, inst);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeompointFunctions::Nai_geo_tgeo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3551,7 +3318,6 @@ void TgeompointFunctions::Nai_geo_tgeo(DataChunk &args, ExpressionState &state, 
         if (!inst) { outv.SetInvalid(i); continue; }
         out[i] = NaiToHex(result, inst);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeompointFunctions::Nad_tgeo_geo(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3668,7 +3434,6 @@ void TgeompointFunctions::Tgeo_affine_12(DataChunk &args, ExpressionState &state
         m.xoff = xoff[i]; m.yoff = yoff[i]; m.zoff = zoff[i];
         out[i] = ApplyAffineToTgeo(result, in[i], m);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeompointFunctions::Tgeo_affine_6(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3693,7 +3458,6 @@ void TgeompointFunctions::Tgeo_affine_6(DataChunk &args, ExpressionState &state,
         m.xoff = xoff[i]; m.yoff = yoff[i];
         out[i] = ApplyAffineToTgeo(result, in[i], m);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeompointFunctions::Tgeo_translate_3d(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3713,7 +3477,6 @@ void TgeompointFunctions::Tgeo_translate_3d(DataChunk &args, ExpressionState &st
         m.xoff = dx[i]; m.yoff = dy[i]; m.zoff = dz[i];
         out[i] = ApplyAffineToTgeo(result, in[i], m);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeompointFunctions::Tgeo_translate_2d(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3732,7 +3495,6 @@ void TgeompointFunctions::Tgeo_translate_2d(DataChunk &args, ExpressionState &st
         m.xoff = dx[i]; m.yoff = dy[i];
         out[i] = ApplyAffineToTgeo(result, in[i], m);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeompointFunctions::Tgeo_rotate_angle(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3752,7 +3514,6 @@ void TgeompointFunctions::Tgeo_rotate_angle(DataChunk &args, ExpressionState &st
         m.dfac = s; m.efac =  c;
         out[i] = ApplyAffineToTgeo(result, in[i], m);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeompointFunctions::Tgeo_rotate_angle_cx_cy(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3777,7 +3538,6 @@ void TgeompointFunctions::Tgeo_rotate_angle_cx_cy(DataChunk &args, ExpressionSta
         m.yoff = cy - s * cx - c * cy;
         out[i] = ApplyAffineToTgeo(result, in[i], m);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeompointFunctions::Tgeo_rotateX(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3798,7 +3558,6 @@ void TgeompointFunctions::Tgeo_rotateX(DataChunk &args, ExpressionState &state, 
         m.hfac = s; m.ifac =  c;
         out[i] = ApplyAffineToTgeo(result, in[i], m);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeompointFunctions::Tgeo_rotateY(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3819,7 +3578,6 @@ void TgeompointFunctions::Tgeo_rotateY(DataChunk &args, ExpressionState &state, 
         m.gfac = -s; m.ifac = c;
         out[i] = ApplyAffineToTgeo(result, in[i], m);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeompointFunctions::Tgeo_transscale(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3841,7 +3599,6 @@ void TgeompointFunctions::Tgeo_transscale(DataChunk &args, ExpressionState &stat
         m.xoff = dx[i] * sx[i]; m.yoff = dy[i] * sy[i];
         out[i] = ApplyAffineToTgeo(result, in[i], m);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeompointFunctions::Tgeo_scale_geom(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3871,7 +3628,6 @@ void TgeompointFunctions::Tgeo_scale_geom(DataChunk &args, ExpressionState &stat
         out[i] = StringVector::AddStringOrBlob(result, string_t(reinterpret_cast<const char *>(rbuf), rsz));
         free(rbuf); free(ret);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TgeompointFunctions::Tgeo_scale_geom_origin(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3904,7 +3660,6 @@ void TgeompointFunctions::Tgeo_scale_geom_origin(DataChunk &args, ExpressionStat
         out[i] = StringVector::AddStringOrBlob(result, string_t(reinterpret_cast<const char *>(rbuf), rsz));
         free(rbuf); free(ret);
     }
-    if (n == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 } // namespace duckdb

--- a/src/include/temporal/temporal_blob.hpp
+++ b/src/include/temporal/temporal_blob.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+// Canonical round-trip between a DuckDB blob (string_t) and a MEOS Temporal
+// value. Every type binding shares this single definition, so the
+// function-pointer registrations across the bindings all resolve to one body.
+
+#include "meos_wrapper_simple.hpp"
+#include "common.hpp"
+
+namespace duckdb {
+
+// Copy t into result's string heap and free t; returns the stored blob.
+string_t TemporalToBlob(Vector &result, Temporal *t);
+
+// Copy the blob bytes into a freshly malloc'd Temporal* owned by the caller.
+Temporal *BlobToTemporal(string_t blob);
+
+} // namespace duckdb

--- a/src/mobilityduck_extension.cpp
+++ b/src/mobilityduck_extension.cpp
@@ -67,7 +67,7 @@ namespace duckdb {
 // 2. Utility: version scalar functions
 // =====================================================================
 
-inline void MobilityduckOpenSSLVersionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+static void MobilityduckOpenSSLVersionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &name_vector = args.data[0];
 	UnaryExecutor::Execute<string_t, string_t>(name_vector, result, args.size(), [&](string_t name) {
 		return StringVector::AddString(
@@ -111,12 +111,12 @@ inline std::string MobilityduckFullVersion() {
 	return out;
 }
 
-inline void MobilityduckVersionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+static void MobilityduckVersionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
 	const std::string s = MobilityduckShortVersion();
 	result.Reference(Value(s));
 }
 
-inline void MobilityduckFullVersionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+static void MobilityduckFullVersionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
 	const std::string s = MobilityduckFullVersion();
 	result.Reference(Value(s));
 }

--- a/src/single_tile_getters.cpp
+++ b/src/single_tile_getters.cpp
@@ -85,7 +85,6 @@ void GetValueTileExec(DataChunk &args, ExpressionState &, Vector &result) {
             result, reinterpret_cast<const char *>(tbox), sizeof(TBox));
         free(tbox);
     }
-    if (count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 // =====================================================================
@@ -130,7 +129,6 @@ void GetTBoxTimeTileExec(DataChunk &args, ExpressionState &, Vector &result) {
             result, reinterpret_cast<const char *>(tbox), sizeof(TBox));
         free(tbox);
     }
-    if (count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 // =====================================================================
@@ -184,7 +182,6 @@ void GetValueTimeTileExec(DataChunk &args, ExpressionState &, Vector &result) {
             result, reinterpret_cast<const char *>(tbox), sizeof(TBox));
         free(tbox);
     }
-    if (count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 // =====================================================================
@@ -244,7 +241,6 @@ void GetSpaceTileExec(DataChunk &args, ExpressionState &, Vector &result) {
             result, reinterpret_cast<const char *>(stbox), sizeof(STBox));
         free(stbox);
     }
-    if (count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 // getStboxTimeTile(timestamptz, interval [, timestamptz='2000-01-03']) -> stbox
@@ -281,7 +277,6 @@ void GetStboxTimeTileExec(DataChunk &args, ExpressionState &, Vector &result) {
             result, reinterpret_cast<const char *>(stbox), sizeof(STBox));
         free(stbox);
     }
-    if (count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 // getSpaceTimeTile(geom, t, xsize, ysize, zsize, interval
@@ -338,7 +333,6 @@ void GetSpaceTimeTileExec(DataChunk &args, ExpressionState &, Vector &result) {
             result, reinterpret_cast<const char *>(stbox), sizeof(STBox));
         free(stbox);
     }
-    if (count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 // Convenience overload: getSpaceTile(geom, xsize) — uniform xyz, default origin.

--- a/src/temporal/span_functions.cpp
+++ b/src/temporal/span_functions.cpp
@@ -1139,9 +1139,6 @@ void SpanFunctions::Numspan_expand(DataChunk &args, ExpressionState &state, Vect
         default:
             throw NotImplementedException("expand(<span>): unsupported span type");
     }
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpanFunctions::Tstzspan_expand(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1153,9 +1150,6 @@ void SpanFunctions::Tstzspan_expand(DataChunk &args, ExpressionState &state, Vec
         [&](string_t blob, interval_t value) -> string_t {
             return Tstzspan_expand_common(blob, value, result);
         });        
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 static inline string_t Numspan_shift_common(const string_t &blob, Datum shift_datum,
@@ -1256,9 +1250,6 @@ void SpanFunctions::Tstzspan_shift(DataChunk &args, ExpressionState &state, Vect
         [&](string_t blob, interval_t shift_interval) -> string_t {
             return Tstzspan_shift_common(blob, shift_interval, result);
         });
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 static inline string_t Numspan_scale_common(const string_t &blob, Datum scale_datum,
@@ -1358,9 +1349,6 @@ void SpanFunctions::Tstzspan_scale(DataChunk &args, ExpressionState &state, Vect
         [&](string_t blob, interval_t scale_interval) -> string_t {
             return Tstzspan_scale_common(blob, scale_interval, result);
         });
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 static inline string_t Tstzspan_shift_scale_common(const string_t &blob, interval_t shift_iv, interval_t scale_iv,
@@ -1463,9 +1451,6 @@ void SpanFunctions::Numspan_shift_scale(DataChunk &args, ExpressionState &state,
         default:
             throw NotImplementedException("shiftScale(<span>): unsupported span type for this overload");
     }
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpanFunctions::Tstzspan_shift_scale(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1475,9 +1460,6 @@ void SpanFunctions::Tstzspan_shift_scale(DataChunk &args, ExpressionState &state
         [&](string_t blob, interval_t shift, interval_t scale) -> string_t {
             return Tstzspan_shift_scale_common(blob, shift, scale, result);
         });
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpanFunctions::Floatspan_floor(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1538,9 +1520,6 @@ void SpanFunctions::Float_round(DataChunk &args, ExpressionState &state, Vector 
             [&](double_t float_value) -> double_t {
                 return float_round(float_value, 0);
             });
-    }
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
     }
 }
 
@@ -1677,9 +1656,6 @@ void SpanFunctions::Span_eq(DataChunk &args, ExpressionState &state, Vector &res
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: span <> span ---
 void SpanFunctions::Span_ne(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1707,9 +1683,6 @@ void SpanFunctions::Span_ne(DataChunk &args, ExpressionState &state, Vector &res
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: span < span ---
 void SpanFunctions::Span_lt(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1737,9 +1710,6 @@ void SpanFunctions::Span_lt(DataChunk &args, ExpressionState &state, Vector &res
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: span <= span ---
 void SpanFunctions::Span_le(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1767,9 +1737,6 @@ void SpanFunctions::Span_le(DataChunk &args, ExpressionState &state, Vector &res
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpanFunctions::Span_gt(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1797,9 +1764,6 @@ void SpanFunctions::Span_gt(DataChunk &args, ExpressionState &state, Vector &res
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: span >= span ---
 void SpanFunctions::Span_ge(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1827,9 +1791,6 @@ void SpanFunctions::Span_ge(DataChunk &args, ExpressionState &state, Vector &res
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpanFunctions::Span_cmp(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1857,9 +1818,6 @@ void SpanFunctions::Span_cmp(DataChunk &args, ExpressionState &state, Vector &re
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: span @> value ---
 void SpanFunctions::Contains_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2001,9 +1959,6 @@ void SpanFunctions::Contains_span_span(DataChunk &args, ExpressionState &state, 
             return ret;
     }
 );
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -2114,9 +2069,6 @@ void SpanFunctions::Contained_value_span(DataChunk &args, ExpressionState &state
         default:
             throw NotImplementedException("value <@ SPAN: unsupported span type");
     }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 // --- OPERATOR: span <@ span ---
@@ -2151,9 +2103,6 @@ void SpanFunctions::Contained_span_span(DataChunk &args, ExpressionState &state,
             return ret;
     }
 );
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 // --- OPERATOR: span && span ---
@@ -2187,9 +2136,6 @@ void SpanFunctions::Overlaps_span_span(DataChunk &args, ExpressionState &state, 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 // --- OPERATOR: value -|- span---
@@ -2298,9 +2244,6 @@ void SpanFunctions::Adjacent_value_span(DataChunk &args, ExpressionState &state,
         }
         default:
             throw NotImplementedException("value -|- SPAN: unsupported span type");
-    }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
     }
 }
 
@@ -2411,9 +2354,6 @@ void SpanFunctions::Adjacent_span_value(DataChunk &args, ExpressionState &state,
         default:
             throw NotImplementedException("SPAN -|- value: unsupported span type");
     }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 // --- OPERATOR: span -|- span ---
@@ -2445,9 +2385,6 @@ void SpanFunctions::Adjacent_span_span(DataChunk &args, ExpressionState &state, 
             return ret;
         }
     );
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 // --- POSITION OPERATORS ---
@@ -2559,9 +2496,6 @@ void SpanFunctions::Left_value_span(DataChunk &args, ExpressionState &state, Vec
         default:
             throw NotImplementedException("value << SPAN: unsupported span type");
     }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: span << value ---
 void SpanFunctions::Left_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2670,9 +2604,6 @@ void SpanFunctions::Left_span_value(DataChunk &args, ExpressionState &state, Vec
         default:
             throw NotImplementedException("SPAN << value: unsupported span type");
     }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: span << span ---
 void SpanFunctions::Left_span_span(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2703,9 +2634,6 @@ void SpanFunctions::Left_span_span(DataChunk &args, ExpressionState &state, Vect
             return ret;
         }
     );
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: value >> span ---
 void SpanFunctions::Right_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2814,9 +2742,6 @@ void SpanFunctions::Right_value_span(DataChunk &args, ExpressionState &state, Ve
         default:
             throw NotImplementedException("value >> SPAN: unsupported span type");
     }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: span >> value ---
 void SpanFunctions::Right_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2924,9 +2849,6 @@ void SpanFunctions::Right_span_value(DataChunk &args, ExpressionState &state, Ve
         default:
             throw NotImplementedException("SPAN >> value: unsupported span type");
     }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: span >> span ---
 void SpanFunctions::Right_span_span(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2957,9 +2879,6 @@ void SpanFunctions::Right_span_span(DataChunk &args, ExpressionState &state, Vec
             return ret;
         }
     );
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 // ---OPERATOR: value &< span ---
@@ -3069,9 +2988,6 @@ void SpanFunctions::Overleft_value_span(DataChunk &args, ExpressionState &state,
         default:
             throw NotImplementedException("value &< SPAN: unsupported span type");
     }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // ---OPERATOR: span &< value ---
 void SpanFunctions::Overleft_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3179,9 +3095,6 @@ void SpanFunctions::Overleft_span_value(DataChunk &args, ExpressionState &state,
         default:
             throw NotImplementedException("SPAN &< value: unsupported span type");
     }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }   
 
 // ---OPERATOR: span &< span ---
@@ -3213,9 +3126,6 @@ void SpanFunctions::Overleft_span_span(DataChunk &args, ExpressionState &state, 
             return ret;
         }
     );
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 // --- OPERATOR: value &> span ---
@@ -3323,9 +3233,6 @@ void SpanFunctions::Overright_value_span(DataChunk &args, ExpressionState &state
         }
         default:
             throw NotImplementedException("value &> SPAN: unsupported span type");
-    }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
     }
 }   
 
@@ -3435,9 +3342,6 @@ void SpanFunctions::Overright_span_value(DataChunk &args, ExpressionState &state
         default:
             throw NotImplementedException("SPAN &> value: unsupported span type");
     }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }   
 
 // --- OPERATOR: span &> span ---
@@ -3469,9 +3373,6 @@ void SpanFunctions::Overright_span_span(DataChunk &args, ExpressionState &state,
             return ret;
         }
     );
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 // --- SET OPERATOR ---
@@ -3613,9 +3514,6 @@ void SpanFunctions::Union_value_span(DataChunk &args, ExpressionState &state, Ve
         }
         default:
             throw NotImplementedException("value + SPAN: unsupported span type");
-    }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
     }
 }
 }
@@ -3759,9 +3657,6 @@ void SpanFunctions::Union_span_value(DataChunk &args, ExpressionState &state, Ve
         default:
             throw NotImplementedException("SPAN + value: unsupported span type");
     }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 }
 
@@ -3796,9 +3691,6 @@ void SpanFunctions::Union_span_span(DataChunk &args, ExpressionState &state, Vec
             return stored_data;
         }
     );
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: INTERSECTION ---
 void SpanFunctions::Intersection_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3960,9 +3852,6 @@ void SpanFunctions::Intersection_value_span(DataChunk &args, ExpressionState &st
         }
         default:
             throw NotImplementedException("value * SPAN: unsupported span type");
-    }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
     }
 }
 
@@ -4126,9 +4015,6 @@ void SpanFunctions::Intersection_span_value(DataChunk &args, ExpressionState &st
         default:
             throw NotImplementedException("SPAN * value: unsupported span type");
     }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpanFunctions::Intersection_span_span(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4175,9 +4061,6 @@ void SpanFunctions::Intersection_span_span(DataChunk &args, ExpressionState &sta
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 // --- OPERATOR: MINUS ---
@@ -4341,9 +4224,6 @@ void SpanFunctions::Minus_value_span(DataChunk &args, ExpressionState &state, Ve
         default:
             throw NotImplementedException("value - SPAN: unsupported span type");
     }
-     if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpanFunctions::Minus_span_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4505,9 +4385,6 @@ void SpanFunctions::Minus_span_value(DataChunk &args, ExpressionState &state, Ve
         default:
             throw NotImplementedException("SPAN - value: unsupported span type");   
         }
-        if (args.size() == 1) {
-            result.SetVectorType(VectorType::CONSTANT_VECTOR);
-        }
     }
 }
 
@@ -4555,9 +4432,6 @@ void SpanFunctions::Minus_span_span(DataChunk &args, ExpressionState &state, Vec
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 //--- DISTANCE FUNCTIONS ---
@@ -4667,9 +4541,6 @@ void SpanFunctions::Distance_span_value(DataChunk &args, ExpressionState &state,
             throw NotImplementedException("distance between SPAN and value: unsupported span type");    
 
     }
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpanFunctions::Distance_value_span(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4777,9 +4648,6 @@ void SpanFunctions::Distance_value_span(DataChunk &args, ExpressionState &state,
         default:
             throw NotImplementedException("distance between value and SPAN: unsupported span type");
     }
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpanFunctions::Distance_span_span(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4830,9 +4698,6 @@ void SpanFunctions::Distance_span_span(DataChunk &args, ExpressionState &state, 
                 return distance;
             }
         );
-    }
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
     }
 }
 

--- a/src/temporal/spanset_functions.cpp
+++ b/src/temporal/spanset_functions.cpp
@@ -1256,9 +1256,6 @@ void SpansetFunctions::Tstzspanset_shift(DataChunk &args, ExpressionState &state
         [&](string_t blob, interval_t shift_interval) -> string_t {
             return Tstzspanset_shift_common(blob, shift_interval, result);
         });
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 static inline string_t Numspanset_scale_common(const string_t &blob, Datum scale_datum,
@@ -1357,9 +1354,6 @@ void SpansetFunctions::Tstzspanset_scale(DataChunk &args, ExpressionState &state
         [&](string_t blob, interval_t scale_interval) -> string_t {
             return Tstzspanset_scale_common(blob, scale_interval, result);
         });
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 static inline string_t Tstzspanset_shift_scale_common(const string_t &blob, interval_t shift_iv, interval_t scale_iv,
@@ -1462,9 +1456,6 @@ void SpansetFunctions::Numspanset_shift_scale(DataChunk &args, ExpressionState &
         default:
             throw NotImplementedException("shiftScale(<spanset>): unsupported spanset type for this overload");
     }
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpansetFunctions::Tstzspanset_shift_scale(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1474,9 +1465,6 @@ void SpansetFunctions::Tstzspanset_shift_scale(DataChunk &args, ExpressionState 
         [&](string_t blob, interval_t shift, interval_t scale) -> string_t {
             return Tstzspanset_shift_scale_common(blob, shift, scale, result);
         });
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpansetFunctions::Floatspanset_floor(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1806,9 +1794,6 @@ void SpansetFunctions::Spanset_eq(DataChunk &args, ExpressionState &state, Vecto
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: spanset <> spanset ---
 void SpansetFunctions::Spanset_ne(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1836,9 +1821,6 @@ void SpansetFunctions::Spanset_ne(DataChunk &args, ExpressionState &state, Vecto
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: spanset < spanset ---
 void SpansetFunctions::Spanset_lt(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1866,9 +1848,6 @@ void SpansetFunctions::Spanset_lt(DataChunk &args, ExpressionState &state, Vecto
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: spanset <= spanset---
 void SpansetFunctions::Spanset_le(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1896,9 +1875,6 @@ void SpansetFunctions::Spanset_le(DataChunk &args, ExpressionState &state, Vecto
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpansetFunctions::Spanset_gt(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1926,9 +1902,6 @@ void SpansetFunctions::Spanset_gt(DataChunk &args, ExpressionState &state, Vecto
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 // --- OPERATOR: span >= span ---
 void SpansetFunctions::Spanset_ge(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1956,9 +1929,6 @@ void SpansetFunctions::Spanset_ge(DataChunk &args, ExpressionState &state, Vecto
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void SpansetFunctions::Spanset_cmp(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1986,9 +1956,6 @@ void SpansetFunctions::Spanset_cmp(DataChunk &args, ExpressionState &state, Vect
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 } // namespace duckdb   

--- a/src/temporal/tbox_functions.cpp
+++ b/src/temporal/tbox_functions.cpp
@@ -105,9 +105,6 @@ void TboxFunctions::NumberTimestamptzToTboxExecutor(Vector &value, Vector &t, Me
             return MallocBlobToResult(result, tbox_data, tbox_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Number_timestamptz_to_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -144,9 +141,6 @@ void TboxFunctions::Numspan_timestamptz_to_tbox(DataChunk &args, ExpressionState
             return MallocBlobToResult(result, tbox_data, tbox_size);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 template <typename TA>
@@ -179,9 +173,6 @@ void TboxFunctions::NumberTstzspanToTboxExecutor(Vector &value, Vector &span_str
             return MallocBlobToResult(result, tbox_data, tbox_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Number_tstzspan_to_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -228,9 +219,6 @@ void TboxFunctions::Numspan_tstzspan_to_tbox(DataChunk &args, ExpressionState &s
             return MallocBlobToResult(result, tbox_data, tbox_size);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 template <typename TA>
@@ -254,9 +242,6 @@ void TboxFunctions::NumberToTboxExecutor(Vector &value, MeosType basetype, Vecto
             return MallocBlobToResult(result, tbox_data, tbox_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Number_to_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -297,9 +282,6 @@ void TboxFunctions::TimestamptzToTboxExecutor(Vector &value, Vector &result, idx
             return MallocBlobToResult(result, tbox_data, tbox_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Timestamptz_to_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -332,9 +314,6 @@ void TboxFunctions::SetToTboxExecutor(Vector &value, Vector &result, idx_t count
             return MallocBlobToResult(result, tbox_data, tbox_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Set_to_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -367,9 +346,6 @@ void TboxFunctions::SpanToTboxExecutor(Vector &value, Vector &result, idx_t coun
             return MallocBlobToResult(result, tbox_data, tbox_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Span_to_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -402,9 +378,6 @@ void TboxFunctions::TboxToIntspanExecutor(Vector &value, Vector &result, idx_t c
             return MallocBlobToResult(result, span_data, span_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_to_intspan(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -437,9 +410,6 @@ void TboxFunctions::TboxToFloatspanExecutor(Vector &value, Vector &result, idx_t
             return MallocBlobToResult(result, span_data, span_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_to_floatspan(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -472,9 +442,6 @@ void TboxFunctions::TboxToTstzspanExecutor(Vector &value, Vector &result, idx_t 
             return MallocBlobToResult(result, span_data, span_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_to_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -507,9 +474,6 @@ void TboxFunctions::SpansetToTboxExecutor(Vector &value, Vector &result, idx_t c
             return MallocBlobToResult(result, tbox_data, tbox_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Spanset_to_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -538,9 +502,6 @@ void TboxFunctions::Tbox_hasx(DataChunk &args, ExpressionState &state, Vector &r
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_hast(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -560,9 +521,6 @@ void TboxFunctions::Tbox_hast(DataChunk &args, ExpressionState &state, Vector &r
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_xmin(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -587,9 +545,6 @@ void TboxFunctions::Tbox_xmin(DataChunk &args, ExpressionState &state, Vector &r
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_xmin_inc(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -614,9 +569,6 @@ void TboxFunctions::Tbox_xmin_inc(DataChunk &args, ExpressionState &state, Vecto
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_xmax(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -641,9 +593,6 @@ void TboxFunctions::Tbox_xmax(DataChunk &args, ExpressionState &state, Vector &r
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_xmax_inc(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -668,9 +617,6 @@ void TboxFunctions::Tbox_xmax_inc(DataChunk &args, ExpressionState &state, Vecto
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_tmin(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -696,9 +642,6 @@ void TboxFunctions::Tbox_tmin(DataChunk &args, ExpressionState &state, Vector &r
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_tmin_inc(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -723,9 +666,6 @@ void TboxFunctions::Tbox_tmin_inc(DataChunk &args, ExpressionState &state, Vecto
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_tmax(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -751,9 +691,6 @@ void TboxFunctions::Tbox_tmax(DataChunk &args, ExpressionState &state, Vector &r
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_tmax_inc(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -778,9 +715,6 @@ void TboxFunctions::Tbox_tmax_inc(DataChunk &args, ExpressionState &state, Vecto
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 template <typename TB>
@@ -813,9 +747,6 @@ void TboxFunctions::TboxShiftValueExecutor(Vector &tbox, Vector &shift, LogicalT
             return MallocBlobToResult(result, shifted_tbox_data, shifted_tbox_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_shift_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -851,9 +782,6 @@ void TboxFunctions::Tbox_shift_time(DataChunk &args, ExpressionState &state, Vec
             return MallocBlobToResult(result, shifted_tbox_data, shifted_tbox_size);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 template <typename TB>
@@ -886,9 +814,6 @@ void TboxFunctions::TboxScaleValueExecutor(Vector &tbox, Vector &width, LogicalT
             return MallocBlobToResult(result, scaled_tbox_data, scaled_tbox_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_scale_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -924,9 +849,6 @@ void TboxFunctions::Tbox_scale_time(DataChunk &args, ExpressionState &state, Vec
             return MallocBlobToResult(result, scaled_tbox_data, scaled_tbox_size);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 template <typename TB>
@@ -962,9 +884,6 @@ void TboxFunctions::TboxShiftScaleValueExecutor(Vector &tbox, Vector &shift, Vec
             return MallocBlobToResult(result, shifted_scaled_tbox_data, shifted_scaled_tbox_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_shift_scale_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1001,9 +920,6 @@ void TboxFunctions::Tbox_shift_scale_time(DataChunk &args, ExpressionState &stat
             return MallocBlobToResult(result, shifted_scaled_tbox_data, shifted_scaled_tbox_size);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 template <typename TB>
@@ -1041,9 +957,6 @@ void TboxFunctions::TboxExpandValueExecutor(Vector &tbox, Vector &value, MeosTyp
             return MallocBlobToResult(result, ret_data, ret_size);
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_expand_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1084,9 +997,6 @@ void TboxFunctions::Tbox_expand_time(DataChunk &args, ExpressionState &state, Ve
             return MallocBlobToResult(result, ret_data, ret_size);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_round(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1133,9 +1043,6 @@ void TboxFunctions::Tbox_round(DataChunk &args, ExpressionState &state, Vector &
             }
         );
     }
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Contains_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1165,9 +1072,6 @@ void TboxFunctions::Contains_tbox_tbox(DataChunk &args, ExpressionState &state, 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Contained_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1197,9 +1101,6 @@ void TboxFunctions::Contained_tbox_tbox(DataChunk &args, ExpressionState &state,
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Overlaps_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1229,9 +1130,6 @@ void TboxFunctions::Overlaps_tbox_tbox(DataChunk &args, ExpressionState &state, 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Adjacent_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1261,9 +1159,6 @@ void TboxFunctions::Adjacent_tbox_tbox(DataChunk &args, ExpressionState &state, 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Same_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1293,9 +1188,6 @@ void TboxFunctions::Same_tbox_tbox(DataChunk &args, ExpressionState &state, Vect
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Left_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1325,9 +1217,6 @@ void TboxFunctions::Left_tbox_tbox(DataChunk &args, ExpressionState &state, Vect
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Overleft_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1357,9 +1246,6 @@ void TboxFunctions::Overleft_tbox_tbox(DataChunk &args, ExpressionState &state, 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Right_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1389,9 +1275,6 @@ void TboxFunctions::Right_tbox_tbox(DataChunk &args, ExpressionState &state, Vec
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Overright_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {  
@@ -1421,9 +1304,6 @@ void TboxFunctions::Overright_tbox_tbox(DataChunk &args, ExpressionState &state,
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Before_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1453,9 +1333,6 @@ void TboxFunctions::Before_tbox_tbox(DataChunk &args, ExpressionState &state, Ve
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Overbefore_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1485,9 +1362,6 @@ void TboxFunctions::Overbefore_tbox_tbox(DataChunk &args, ExpressionState &state
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::After_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1517,9 +1391,6 @@ void TboxFunctions::After_tbox_tbox(DataChunk &args, ExpressionState &state, Vec
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Overafter_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1549,9 +1420,6 @@ void TboxFunctions::Overafter_tbox_tbox(DataChunk &args, ExpressionState &state,
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Union_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1590,9 +1458,6 @@ void TboxFunctions::Union_tbox_tbox(DataChunk &args, ExpressionState &state, Vec
             return MallocBlobToResult(result, ret_data, ret_size);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Intersection_tbox_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1631,9 +1496,6 @@ void TboxFunctions::Intersection_tbox_tbox(DataChunk &args, ExpressionState &sta
             return MallocBlobToResult(result, ret_data, ret_size);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 // Comparison operators
@@ -1664,9 +1526,6 @@ void TboxFunctions::Tbox_eq(DataChunk &args, ExpressionState &state, Vector &res
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_ne(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1696,9 +1555,6 @@ void TboxFunctions::Tbox_ne(DataChunk &args, ExpressionState &state, Vector &res
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_lt(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1728,9 +1584,6 @@ void TboxFunctions::Tbox_lt(DataChunk &args, ExpressionState &state, Vector &res
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_le(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1760,9 +1613,6 @@ void TboxFunctions::Tbox_le(DataChunk &args, ExpressionState &state, Vector &res
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_gt(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1792,9 +1642,6 @@ void TboxFunctions::Tbox_gt(DataChunk &args, ExpressionState &state, Vector &res
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_ge(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1824,9 +1671,6 @@ void TboxFunctions::Tbox_ge(DataChunk &args, ExpressionState &state, Vector &res
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_cmp(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1856,9 +1700,6 @@ void TboxFunctions::Tbox_cmp(DataChunk &args, ExpressionState &state, Vector &re
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -1888,9 +1729,6 @@ void TboxFunctions::Tbox_as_wkb(DataChunk &args, ExpressionState &state, Vector 
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_as_hexwkb(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1915,9 +1753,6 @@ void TboxFunctions::Tbox_as_hexwkb(DataChunk &args, ExpressionState &state, Vect
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_from_wkb(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1944,9 +1779,6 @@ void TboxFunctions::Tbox_from_wkb(DataChunk &args, ExpressionState &state, Vecto
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_from_hexwkb(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1968,9 +1800,6 @@ void TboxFunctions::Tbox_from_hexwkb(DataChunk &args, ExpressionState &state, Ve
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_hash(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1988,9 +1817,6 @@ void TboxFunctions::Tbox_hash(DataChunk &args, ExpressionState &state, Vector &r
             return static_cast<int32_t>(h);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TboxFunctions::Tbox_hash_extended(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2008,9 +1834,6 @@ void TboxFunctions::Tbox_hash_extended(DataChunk &args, ExpressionState &state, 
             return static_cast<int64_t>(h);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 } // namespace duckdb

--- a/src/temporal/temporal.cpp
+++ b/src/temporal/temporal.cpp
@@ -2241,7 +2241,7 @@ void GetBinDateExec(DataChunk &args, ExpressionState &, Vector &result) {
 
 // ----- tbox tile emitters: LIST(TBOX) outputs -----
 
-inline void EmitTboxList(Vector &result, idx_t row_idx, TBox *tiles, int count,
+static void EmitTboxList(Vector &result, idx_t row_idx, TBox *tiles, int count,
                          idx_t &total_offset, list_entry_t *list_entries,
                          Vector &child_vector, ValidityMask &result_validity) {
     if (!tiles || count <= 0) {

--- a/src/temporal/temporal_aggregates.cpp
+++ b/src/temporal/temporal_aggregates.cpp
@@ -664,7 +664,7 @@ struct SpanSetState {
 };
 
 template <class STATE>
-inline void SpanSetCombine(STATE &source, STATE &target) {
+static void SpanSetCombine(STATE &source, STATE &target) {
     if (!source.value) return;
     if (!target.value) {
         target.value = source.value;
@@ -681,7 +681,7 @@ inline void SpanSetCombine(STATE &source, STATE &target) {
 }
 
 template <class T, class STATE>
-inline void SpanSetFinalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+static void SpanSetFinalize(STATE &state, T &target, AggregateFinalizeData &fd) {
     if (!state.value) { fd.ReturnNull(); return; }
     // spanset_union_finalfn frees the state internally on the success
     // path, so clear the pointer first to prevent Destroy from
@@ -695,7 +695,7 @@ inline void SpanSetFinalize(STATE &state, T &target, AggregateFinalizeData &fd) 
 }
 
 template <class STATE>
-inline void SpanSetDestroy(STATE &state) {
+static void SpanSetDestroy(STATE &state) {
     if (state.value) {
         free(state.value);
         state.value = nullptr;
@@ -773,7 +773,7 @@ struct SetAggState {
 };
 
 template <class STATE>
-inline void SetCombine(STATE &source, STATE &target) {
+static void SetCombine(STATE &source, STATE &target) {
     if (!source.value) return;
     if (!target.value) {
         target.value = source.value;
@@ -788,7 +788,7 @@ inline void SetCombine(STATE &source, STATE &target) {
 }
 
 template <class T, class STATE>
-inline void SetFinalize(STATE &state, T &target, AggregateFinalizeData &fd) {
+static void SetFinalize(STATE &state, T &target, AggregateFinalizeData &fd) {
     if (!state.value) { fd.ReturnNull(); return; }
     // set_union_finalfn frees the state internally on the success path.
     Set *result = set_union_finalfn(state.value);
@@ -800,7 +800,7 @@ inline void SetFinalize(STATE &state, T &target, AggregateFinalizeData &fd) {
 }
 
 template <class STATE>
-inline void SetDestroy(STATE &state) {
+static void SetDestroy(STATE &state) {
     if (state.value) {
         free(state.value);
         state.value = nullptr;

--- a/src/temporal/temporal_blob.cpp
+++ b/src/temporal/temporal_blob.cpp
@@ -1,0 +1,26 @@
+// Single definition of the canonical DuckDB-blob <-> MEOS Temporal round-trip
+// shared by every type binding.
+
+#include "temporal/temporal_blob.hpp"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace duckdb {
+
+string_t TemporalToBlob(Vector &result, Temporal *t) {
+    size_t sz = temporal_mem_size(t);
+    string_t out = StringVector::AddStringOrBlob(
+        result, reinterpret_cast<const char *>(t), sz);
+    free(t);
+    return out;
+}
+
+Temporal *BlobToTemporal(string_t blob) {
+    size_t sz = blob.GetSize();
+    uint8_t *copy = static_cast<uint8_t *>(malloc(sz));
+    memcpy(copy, blob.GetData(), sz);
+    return reinterpret_cast<Temporal *>(copy);
+}
+
+} // namespace duckdb

--- a/src/temporal/temporal_functions.cpp
+++ b/src/temporal/temporal_functions.cpp
@@ -1,6 +1,7 @@
 #include "meos_wrapper_simple.hpp"
 #include "common.hpp"
 #include "temporal/temporal_functions.hpp"
+#include "temporal/temporal_blob.hpp"
 #include "temporal/spanset.hpp"
 #include "geo_util.hpp"
 
@@ -186,9 +187,6 @@ void TemporalFunctions::Tinstant_constructor_common(Vector &value, Vector &ts, V
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tinstant_constructor_text(Vector &value, Vector &ts, Vector &result, idx_t count) {
@@ -214,9 +212,6 @@ void TemporalFunctions::Tinstant_constructor_text(Vector &value, Vector &ts, Vec
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tinstant_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -339,9 +334,6 @@ void TemporalFunctions::Tsequence_constructor(DataChunk &args, ExpressionState &
             return stored_data;
         }
     );
-    if (row_count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tsequenceset_constructor(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -405,9 +397,6 @@ void TemporalFunctions::Tsequenceset_constructor(DataChunk &args, ExpressionStat
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 static string_t Tsequence_from_base_tstzset_impl(Datum datum, string_t set_blob, MeosType temptype, Vector &result) {
@@ -480,9 +469,6 @@ void TemporalFunctions::Tsequence_from_base_tstzset(DataChunk &args, ExpressionS
         throw InvalidInputException("Invalid argument type for Tsequence_from_base_tstzset: " + arg_type.ToString());
     }
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }   
 
 static string_t Tsequence_from_base_tstzspan_impl(Datum datum, string_t span_blob, MeosType temptype, interpType interp, Vector &result) {
@@ -563,9 +549,6 @@ void TemporalFunctions::Tsequence_from_base_tstzspan(DataChunk &args, Expression
         throw InvalidInputException("Invalid argument type for Tsequence_from_base_tstzspan: " + arg_type.ToString());
     }
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 static string_t Tsequenceset_from_base_tstzspanset_impl(Datum datum, string_t spanset_blob, MeosType temptype, interpType interp, Vector &result) {
@@ -646,9 +629,6 @@ void TemporalFunctions::Tsequenceset_from_base_tstzspanset(DataChunk &args, Expr
         throw InvalidInputException("Invalid argument type for Tsequenceset_from_base_tstzspanset: " + arg_type.ToString());
     }
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 /* ***************************************************
  * Conversion functions: [TYPE] -> Temporal
@@ -684,9 +664,6 @@ void TemporalFunctions::Temporal_to_tstzspan(DataChunk &args, ExpressionState &s
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_to_span(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -718,9 +695,6 @@ void TemporalFunctions::Tnumber_to_span(DataChunk &args, ExpressionState &state,
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 static string_t Tbool_to_tint_common(string_t input, Vector &result) {
@@ -927,9 +901,6 @@ void TemporalFunctions::Tnumber_to_tbox(DataChunk &args, ExpressionState &state,
     } else {
         throw InvalidInputException("Invalid argument type for Tnumber_to_tbox: " + arg_type.ToString());
     }
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 bool TemporalFunctions::Tnumber_to_tbox_cast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
@@ -973,9 +944,6 @@ void TemporalFunctions::Temporal_enforce_typmod(DataChunk &args, ExpressionState
             return StringVector::AddStringOrBlob(result, input);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 bool TemporalFunctions::Temporal_enforce_typmod_cast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
@@ -1020,9 +988,6 @@ void TemporalFunctions::Temporal_subtype(DataChunk &args, ExpressionState &state
             return string_t(str);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_interp(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1046,9 +1011,6 @@ void TemporalFunctions::Temporal_interp(DataChunk &args, ExpressionState &state,
             return string_t(str);
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_mem_size(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1072,9 +1034,6 @@ void TemporalFunctions::Temporal_mem_size(DataChunk &args, ExpressionState &stat
             return (int32_t)mem_size;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tinstant_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1098,9 +1057,6 @@ void TemporalFunctions::Tinstant_value(DataChunk &args, ExpressionState &state, 
             return (int64_t)ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_valueset(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1132,9 +1088,6 @@ void TemporalFunctions::Temporal_valueset(DataChunk &args, ExpressionState &stat
             return blob;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_start_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1158,9 +1111,6 @@ void TemporalFunctions::Temporal_start_value(DataChunk &args, ExpressionState &s
             return (int64_t)ret;
     }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_end_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1184,9 +1134,6 @@ void TemporalFunctions::Temporal_end_value(DataChunk &args, ExpressionState &sta
             return (int64_t)ret;
     }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_min_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1210,9 +1157,6 @@ void TemporalFunctions::Temporal_min_value(DataChunk &args, ExpressionState &sta
             return (int64_t)ret;
     }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_max_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1236,9 +1180,6 @@ void TemporalFunctions::Temporal_max_value(DataChunk &args, ExpressionState &sta
             return (int64_t)ret;
     }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_value_n(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1363,9 +1304,6 @@ void TemporalFunctions::Temporal_value_n(DataChunk &args, ExpressionState &state
         );
     }
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_num_instants(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1389,9 +1327,6 @@ void TemporalFunctions::Temporal_num_instants(DataChunk &args, ExpressionState &
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_min_instant(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1423,9 +1358,6 @@ void TemporalFunctions::Temporal_min_instant(DataChunk &args, ExpressionState &s
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_max_instant(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1457,9 +1389,6 @@ void TemporalFunctions::Temporal_max_instant(DataChunk &args, ExpressionState &s
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tinstant_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1484,9 +1413,6 @@ void TemporalFunctions::Tinstant_timestamptz(DataChunk &args, ExpressionState &s
             return duckdb_ts;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_time(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1518,9 +1444,6 @@ void TemporalFunctions::Temporal_time(DataChunk &args, ExpressionState &state, V
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_duration(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1554,9 +1477,6 @@ void TemporalFunctions::Temporal_duration(DataChunk &args, ExpressionState &stat
             return duckdb_interval;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_sequences(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1628,9 +1548,6 @@ void TemporalFunctions::Temporal_start_timestamptz(DataChunk &args, ExpressionSt
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_end_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1655,9 +1572,6 @@ void TemporalFunctions::Temporal_end_timestamptz(DataChunk &args, ExpressionStat
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_timestamps(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1770,9 +1684,6 @@ void TemporalFunctions::Temporal_num_sequences(DataChunk &args, ExpressionState 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_lower_inc(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1796,9 +1707,6 @@ void TemporalFunctions::Temporal_lower_inc(DataChunk &args, ExpressionState &sta
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_upper_inc(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1822,9 +1730,6 @@ void TemporalFunctions::Temporal_upper_inc(DataChunk &args, ExpressionState &sta
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_start_instant(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1855,9 +1760,6 @@ void TemporalFunctions::Temporal_start_instant(DataChunk &args, ExpressionState 
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_end_instant(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1888,9 +1790,6 @@ void TemporalFunctions::Temporal_end_instant(DataChunk &args, ExpressionState &s
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_instant_n(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1921,9 +1820,6 @@ void TemporalFunctions::Temporal_instant_n(DataChunk &args, ExpressionState &sta
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_num_timestamps(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -1947,9 +1843,6 @@ void TemporalFunctions::Temporal_num_timestamps(DataChunk &args, ExpressionState
             return ret;
         }    
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -1980,9 +1873,6 @@ void TemporalFunctions::Temporal_timestamptz_n(DataChunk &args, ExpressionState 
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_start_sequence(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2013,9 +1903,6 @@ void TemporalFunctions::Temporal_start_sequence(DataChunk &args, ExpressionState
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -2047,9 +1934,6 @@ void TemporalFunctions::Temporal_end_sequence(DataChunk &args, ExpressionState &
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_sequence_n(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2080,9 +1964,6 @@ void TemporalFunctions::Temporal_sequence_n(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_segments(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2168,9 +2049,6 @@ void TemporalFunctions::Temporal_shift_time(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_scale_time(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2204,9 +2082,6 @@ void TemporalFunctions::Temporal_scale_time(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_shift_scale_time(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2240,9 +2115,6 @@ void TemporalFunctions::Temporal_shift_scale_time(DataChunk &args, ExpressionSta
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -2282,9 +2154,6 @@ void TemporalFunctions::Temporal_to_tinstant(DataChunk &args, ExpressionState &s
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_to_tsequence(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2324,9 +2193,6 @@ void TemporalFunctions::Temporal_to_tsequence(DataChunk &args, ExpressionState &
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_to_tsequenceset(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2366,9 +2232,6 @@ void TemporalFunctions::Temporal_to_tsequenceset(DataChunk &args, ExpressionStat
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_set_interp(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2409,9 +2272,6 @@ void TemporalFunctions::Temporal_set_interp(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_append_tinstant(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2464,9 +2324,6 @@ void TemporalFunctions::Temporal_append_tinstant(DataChunk &args, ExpressionStat
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_append_tsequence(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2510,9 +2367,6 @@ void TemporalFunctions::Temporal_append_tsequence(DataChunk &args, ExpressionSta
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_merge(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2553,9 +2407,6 @@ void TemporalFunctions::Temporal_merge(DataChunk &args, ExpressionState &state, 
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_merge_array(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2609,9 +2460,6 @@ void TemporalFunctions::Temporal_merge_array(DataChunk &args, ExpressionState &s
             return stored_data;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_shift_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2643,9 +2491,6 @@ void TemporalFunctions::Tnumber_shift_value(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_scale_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2677,9 +2522,6 @@ void TemporalFunctions::Tnumber_scale_value(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_shift_scale_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2711,9 +2553,6 @@ void TemporalFunctions::Tnumber_shift_scale_value(DataChunk &args, ExpressionSta
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -2820,9 +2659,6 @@ static void temporal_at_minus_values_dispatch(DataChunk &args, ExpressionState &
         throw InvalidInputException("Invalid argument type for atValues/minusValues: " + val_type.ToString());
     }
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_at_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2873,9 +2709,6 @@ void TemporalFunctions::Temporal_at_timestamptz(DataChunk &args, ExpressionState
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_at_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2925,9 +2758,6 @@ void TemporalFunctions::Temporal_at_tstzspan(DataChunk &args, ExpressionState &s
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_at_tstzspanset(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -2977,9 +2807,6 @@ void TemporalFunctions::Temporal_at_tstzspanset(DataChunk &args, ExpressionState
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_at_span(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3029,9 +2856,6 @@ void TemporalFunctions::Tnumber_at_span(DataChunk &args, ExpressionState &state,
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_at_min(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3069,9 +2893,6 @@ void TemporalFunctions::Temporal_at_min(DataChunk &args, ExpressionState &state,
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_minus_min(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3100,9 +2921,6 @@ void TemporalFunctions::Temporal_minus_min(DataChunk &args, ExpressionState &sta
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_at_max(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3131,9 +2949,6 @@ void TemporalFunctions::Temporal_at_max(DataChunk &args, ExpressionState &state,
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_minus_max(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3162,9 +2977,6 @@ void TemporalFunctions::Temporal_minus_max(DataChunk &args, ExpressionState &sta
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_minus_span(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3205,9 +3017,6 @@ void TemporalFunctions::Tnumber_minus_span(DataChunk &args, ExpressionState &sta
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_at_spanset(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3248,9 +3057,6 @@ void TemporalFunctions::Tnumber_at_spanset(DataChunk &args, ExpressionState &sta
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_minus_spanset(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3291,9 +3097,6 @@ void TemporalFunctions::Tnumber_minus_spanset(DataChunk &args, ExpressionState &
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_at_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3331,9 +3134,6 @@ void TemporalFunctions::Tnumber_at_tbox(DataChunk &args, ExpressionState &state,
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_minus_tbox(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3371,9 +3171,6 @@ void TemporalFunctions::Tnumber_minus_tbox(DataChunk &args, ExpressionState &sta
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_minus_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3403,9 +3200,6 @@ void TemporalFunctions::Temporal_minus_timestamptz(DataChunk &args, ExpressionSt
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_value_at_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3531,9 +3325,6 @@ void TemporalFunctions::Temporal_value_at_timestamptz(DataChunk &args, Expressio
         throw InvalidInputException("Unsupported result type for valueAtTimestamp");
     }
 
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_at_tstzset(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3573,9 +3364,6 @@ void TemporalFunctions::Temporal_at_tstzset(DataChunk &args, ExpressionState &st
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_minus_tstzset(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3615,9 +3403,6 @@ void TemporalFunctions::Temporal_minus_tstzset(DataChunk &args, ExpressionState 
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_minus_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3658,9 +3443,6 @@ void TemporalFunctions::Temporal_minus_tstzspan(DataChunk &args, ExpressionState
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_minus_tstzspanset(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3701,9 +3483,6 @@ void TemporalFunctions::Temporal_minus_tstzspanset(DataChunk &args, ExpressionSt
             return stored;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_before_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3741,9 +3520,6 @@ void TemporalFunctions::Temporal_before_timestamptz(DataChunk &args, ExpressionS
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_after_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3781,9 +3557,6 @@ void TemporalFunctions::Temporal_after_timestamptz(DataChunk &args, ExpressionSt
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_valuespans(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3818,9 +3591,6 @@ void TemporalFunctions::Tnumber_valuespans(DataChunk &args, ExpressionState &sta
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_avg_value(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3844,9 +3614,6 @@ void TemporalFunctions::Tnumber_avg_value(DataChunk &args, ExpressionState &stat
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 /* ***************************************************
  * Modification Functions
@@ -3900,9 +3667,6 @@ void TemporalFunctions::Temporal_insert(DataChunk &args, ExpressionState &state,
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_update(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3953,9 +3717,6 @@ void TemporalFunctions::Temporal_update(DataChunk &args, ExpressionState &state,
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_delete_timestamptz(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -3993,9 +3754,6 @@ void TemporalFunctions::Temporal_delete_timestamptz(DataChunk &args, ExpressionS
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_delete_tstzset(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4047,9 +3805,6 @@ void TemporalFunctions::Temporal_delete_tstzset(DataChunk &args, ExpressionState
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_delete_tstzspan(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4100,9 +3855,6 @@ void TemporalFunctions::Temporal_delete_tstzspan(DataChunk &args, ExpressionStat
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_delete_tstzspanset(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4154,9 +3906,6 @@ void TemporalFunctions::Temporal_delete_tstzspanset(DataChunk &args, ExpressionS
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 
@@ -4198,9 +3947,6 @@ void TemporalFunctions::Temporal_segm_min_duration(DataChunk &args, ExpressionSt
             return stored;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_segm_max_duration(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4238,9 +3984,6 @@ void TemporalFunctions::Temporal_segm_max_duration(DataChunk &args, ExpressionSt
             return stored;
         }
     );
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -4266,9 +4009,6 @@ void TemporalFunctions::Tnumber_integral(DataChunk &args, ExpressionState &state
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Tnumber_twavg(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4291,9 +4031,6 @@ void TemporalFunctions::Tnumber_twavg(DataChunk &args, ExpressionState &state, V
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 /* ***************************************************
  * Comparison operators
@@ -4332,9 +4069,6 @@ void TemporalFunctions::Temporal_eq(DataChunk &args, ExpressionState &state, Vec
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_ne(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4371,9 +4105,6 @@ void TemporalFunctions::Temporal_ne(DataChunk &args, ExpressionState &state, Vec
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_le(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4410,9 +4141,6 @@ void TemporalFunctions::Temporal_le(DataChunk &args, ExpressionState &state, Vec
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_lt(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4449,9 +4177,6 @@ void TemporalFunctions::Temporal_lt(DataChunk &args, ExpressionState &state, Vec
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_ge(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4488,9 +4213,6 @@ void TemporalFunctions::Temporal_ge(DataChunk &args, ExpressionState &state, Vec
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 void TemporalFunctions::Temporal_gt(DataChunk &args, ExpressionState &state, Vector &result) {
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, bool>(
@@ -4526,9 +4248,6 @@ void TemporalFunctions::Temporal_gt(DataChunk &args, ExpressionState &state, Vec
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_cmp(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -4565,9 +4284,6 @@ void TemporalFunctions::Temporal_cmp(DataChunk &args, ExpressionState &state, Ve
             return ret;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -4608,9 +4324,6 @@ void TemporalFunctions::Tbool_when_true(DataChunk &args, ExpressionState &state,
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -4618,22 +4331,6 @@ void TemporalFunctions::Tbool_when_true(DataChunk &args, ExpressionState &state,
  ****************************************************/
 
 namespace {
-
-// Helper: Temporal* -> string_t result blob
-inline string_t TemporalToBlob(Vector &result, Temporal *t) {
-    size_t sz = temporal_mem_size(t);
-    string_t out = StringVector::AddStringOrBlob(result, (const char *)t, sz);
-    free(t);
-    return out;
-}
-
-// Helper: copy string_t blob into a malloc'd Temporal*
-inline Temporal *BlobToTemporal(string_t blob) {
-    size_t sz = blob.GetSize();
-    uint8_t *copy = (uint8_t *)malloc(sz);
-    memcpy(copy, blob.GetData(), sz);
-    return reinterpret_cast<Temporal *>(copy);
-}
 
 template <typename Fn>
 void TemporalUnary(DataChunk &args, Vector &result, Fn fn) {
@@ -4866,9 +4563,6 @@ void RunTboxesEmit(DataChunk &args, Vector &result, Producer produce, bool has_n
         }
         total += count;
         free(boxes);
-    }
-    if (row_count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
     }
 }
 
@@ -5302,9 +4996,6 @@ void RunSimilarityPath(DataChunk &args, Vector &result,
         total += count;
         free(matches);
     }
-    if (row_count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
     (void) fn_name;
 }
 
@@ -5635,7 +5326,6 @@ void TemporalFunctions::Temporal_tprecision(DataChunk &args, ExpressionState &st
         out_data[row] = StringVector::AddStringOrBlob(result, blob);
         free(r);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 void TemporalFunctions::Temporal_tsample(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -5684,7 +5374,6 @@ void TemporalFunctions::Temporal_tsample(DataChunk &args, ExpressionState &state
         out_data[row] = StringVector::AddStringOrBlob(result, blob);
         free(r);
     }
-    if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
 /* ***************************************************
@@ -5902,9 +5591,6 @@ void TemporalFunctions::Temporal_dump_common(DataChunk &args, Vector &result, Me
         free(extracted_values);
         free(temp);
     }
-    if (count == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_dump(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -5978,9 +5664,6 @@ void TemporalFunctions::Temporal_round(DataChunk &args, ExpressionState &state, 
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_derivative(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -6013,9 +5696,6 @@ void TemporalFunctions::Temporal_derivative(DataChunk &args, ExpressionState &st
             return stored_data;
         }
     );
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 /* ***************************************************
@@ -6072,9 +5752,6 @@ void TemporalFunctions::Temporal_as_wkb(DataChunk &args, ExpressionState &state,
             free(temp);
             return stored;
         });
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 void TemporalFunctions::Temporal_as_hexwkb(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -6112,9 +5789,6 @@ void TemporalFunctions::Temporal_as_hexwkb(DataChunk &args, ExpressionState &sta
             free(temp);
             return stored;
         });
-    if (args.size() == 1) {
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-    }
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Scalar and cast bodies run MEOS on DuckDB TaskScheduler worker threads, which need a per-thread meos_initialize(); a thread-local guard in the scalar exec wrapper and a cast trampoline (RegisterMeosCastFunction) cover every entry point, so timestamp formatting no longer dereferences a NULL session_timezone. Per-type DuckDB callbacks and blob helpers have internal linkage and a single canonical blob round-trip (TemporalToBlob / BlobToTemporal) declared once in temporal/temporal_blob.hpp, so each function-pointer registration binds to its own body.