### PR TITLE
Generate the geoToH3Cell + h3index scalar-cell comparison surface

### DIFF
--- a/src/generated/generated_temporal_udfs.cpp
+++ b/src/generated/generated_temporal_udfs.cpp
@@ -4771,6 +4771,102 @@ static void Gen_always_ne_th3index_th3index(DataChunk &args, ExpressionState &, 
         });
 }
 
+static void Gen_ever_eq_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<int64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](int64_t cell, string_t in_t, ValidityMask &mask, idx_t idx) {
+            Temporal *t = BlobToTemporal(in_t);
+            int r = ever_eq_h3index_th3index((uint64_t) cell, t);
+            free(t);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+static void Gen_ever_eq_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<string_t, int64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in_t, int64_t cell, ValidityMask &mask, idx_t idx) {
+            Temporal *t = BlobToTemporal(in_t);
+            int r = ever_eq_th3index_h3index(t, (uint64_t) cell);
+            free(t);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+static void Gen_ever_ne_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<int64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](int64_t cell, string_t in_t, ValidityMask &mask, idx_t idx) {
+            Temporal *t = BlobToTemporal(in_t);
+            int r = ever_ne_h3index_th3index((uint64_t) cell, t);
+            free(t);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+static void Gen_ever_ne_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<string_t, int64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in_t, int64_t cell, ValidityMask &mask, idx_t idx) {
+            Temporal *t = BlobToTemporal(in_t);
+            int r = ever_ne_th3index_h3index(t, (uint64_t) cell);
+            free(t);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+static void Gen_always_eq_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<int64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](int64_t cell, string_t in_t, ValidityMask &mask, idx_t idx) {
+            Temporal *t = BlobToTemporal(in_t);
+            int r = always_eq_h3index_th3index((uint64_t) cell, t);
+            free(t);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+static void Gen_always_eq_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<string_t, int64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in_t, int64_t cell, ValidityMask &mask, idx_t idx) {
+            Temporal *t = BlobToTemporal(in_t);
+            int r = always_eq_th3index_h3index(t, (uint64_t) cell);
+            free(t);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+static void Gen_always_ne_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<int64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](int64_t cell, string_t in_t, ValidityMask &mask, idx_t idx) {
+            Temporal *t = BlobToTemporal(in_t);
+            int r = always_ne_h3index_th3index((uint64_t) cell, t);
+            free(t);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
+static void Gen_always_ne_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<string_t, int64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in_t, int64_t cell, ValidityMask &mask, idx_t idx) {
+            Temporal *t = BlobToTemporal(in_t);
+            int r = always_ne_th3index_h3index(t, (uint64_t) cell);
+            free(t);
+            if (r < 0) { mask.SetInvalid(idx); return false; }
+            return r != 0;
+        });
+}
+
 
 // ===== @ingroup meos_h3_comp_temp =====
 static void Gen_teq_th3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
@@ -4818,6 +4914,17 @@ static void Gen_th3index_to_tbigint(DataChunk &args, ExpressionState &, Vector &
             Temporal *r = th3index_to_tbigint(t);
             free(t);
             return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
+static void Gen_h3_gs_point_to_cell(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, int32_t, int64_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in_g, int32_t res) -> int64_t {
+            GSERIALIZED *gs = GeometryToGSerialized(in_g, 4326);
+            int64_t cell = (int64_t) h3_gs_point_to_cell(gs, res);
+            free(gs);
+            return cell;
         });
 }
 
@@ -16068,6 +16175,7 @@ static void RegisterGenerated_meos_geo_rel_ever(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, LogicalType::BOOLEAN, Gen_acontains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_acontains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_acontains_tgeo_geo));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, LogicalType::BOOLEAN, Gen_acovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_acovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_acovers_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_acovers_tgeo_tgeo));
@@ -16111,6 +16219,7 @@ static void RegisterGenerated_meos_geo_rel_ever(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_econtains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_econtains_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_econtains_tgeo_tgeo));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, LogicalType::BOOLEAN, Gen_ecovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_ecovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_ecovers_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_ecovers_tgeo_tgeo));
@@ -16190,6 +16299,7 @@ static void RegisterGenerated_meos_geo_rel_temp(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("tContains", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcontains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tContains", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, TemporalTypes::tbool(), Gen_tcontains_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tContains", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcontains_tgeo_tgeo));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, TemporalTypes::tbool(), Gen_tcovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, TemporalTypes::tbool(), Gen_tcovers_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcovers_tgeo_tgeo));
@@ -16289,6 +16399,22 @@ static void RegisterGenerated_meos_h3_comp_ever(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("%=", {H3indexTypes::th3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_eq_th3index_th3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aNe", {H3indexTypes::th3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_ne_th3index_th3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("%<>", {H3indexTypes::th3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_ne_th3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eEq", {H3indexTypes::h3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?=", {H3indexTypes::h3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eEq", {H3indexTypes::th3index(), H3indexTypes::h3index()}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?=", {H3indexTypes::th3index(), H3indexTypes::h3index()}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eNe", {H3indexTypes::h3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?<>", {H3indexTypes::h3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eNe", {H3indexTypes::th3index(), H3indexTypes::h3index()}, LogicalType::BOOLEAN, Gen_ever_ne_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?<>", {H3indexTypes::th3index(), H3indexTypes::h3index()}, LogicalType::BOOLEAN, Gen_ever_ne_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aEq", {H3indexTypes::h3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%=", {H3indexTypes::h3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aEq", {H3indexTypes::th3index(), H3indexTypes::h3index()}, LogicalType::BOOLEAN, Gen_always_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%=", {H3indexTypes::th3index(), H3indexTypes::h3index()}, LogicalType::BOOLEAN, Gen_always_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aNe", {H3indexTypes::h3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%<>", {H3indexTypes::h3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aNe", {H3indexTypes::th3index(), H3indexTypes::h3index()}, LogicalType::BOOLEAN, Gen_always_ne_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%<>", {H3indexTypes::th3index(), H3indexTypes::h3index()}, LogicalType::BOOLEAN, Gen_always_ne_th3index_h3index));
 }
 
 static void RegisterGenerated_meos_h3_comp_temp(ExtensionLoader &loader) {
@@ -16301,6 +16427,7 @@ static void RegisterGenerated_meos_h3_conversion(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("::", {TemporalTypes::tbigint()}, H3indexTypes::th3index(), Gen_tbigint_to_th3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tbigint", {H3indexTypes::th3index()}, TemporalTypes::tbigint(), Gen_th3index_to_tbigint));
     RegisterSerializedScalarFunction(loader, ScalarFunction("::", {H3indexTypes::th3index()}, TemporalTypes::tbigint(), Gen_th3index_to_tbigint));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("geoToH3Cell", {GeoTypes::GEOMETRY(), LogicalType::INTEGER}, H3indexTypes::h3index(), Gen_h3_gs_point_to_cell));
     RegisterSerializedScalarFunction(loader, ScalarFunction("geoToH3IndexSet", {GeoTypes::GEOMETRY(), LogicalType::INTEGER}, H3indexTypes::h3indexset(), Gen_geo_to_h3index_set));
 }
 

--- a/test/sql/h3_prefilter.test
+++ b/test/sql/h3_prefilter.test
@@ -1,8 +1,9 @@
 # name: test/sql/h3_prefilter.test
-# description: Static H3 cell-set prefilter — geoToH3IndexSet(geometry, res) + the
-#   eEq(h3indexset, th3index) trip-in-cells membership test (the canonical BerlinMOD
-#   q02/q04/q11-q17 prefilter). geoToH3IndexSet builds the query geometry's H3 cell set;
-#   eEq answers whether the trip's th3index path ever lies in any of those cells.
+# description: Static H3 prefilter surface for the canonical BerlinMOD queries —
+#   geoToH3IndexSet(geometry, res) + eEq(h3indexset, th3index) (the cell-SET form, q02/q11-q17),
+#   and geoToH3Cell(geometry, res) + eEq(h3index, th3index) (the single-CELL form, q04).
+#   The geo functions build the query geometry's H3 cell(s); eEq answers whether the trip's
+#   th3index path ever lies in them.
 
 require mobilityduck
 
@@ -19,3 +20,26 @@ SELECT eEq(geoToH3IndexSet(ST_Point(50, 50), 5),
            th3index('SRID=4326;[Point(1 1)@2000-01-01]'::tgeompoint, 5));
 ----
 false
+
+# ---- single-cell form: geoToH3Cell + eEq(h3index, th3index) (BerlinMOD q04) ----
+
+# The query point's own H3 cell lies on the trip's th3index path -> true.
+query I
+SELECT eEq(geoToH3Cell(ST_Point(1, 1), 5),
+           th3index('SRID=4326;[Point(1 1)@2000-01-01]'::tgeompoint, 5));
+----
+true
+
+# A far query point's cell is not on the trip's path -> false.
+query I
+SELECT eEq(geoToH3Cell(ST_Point(50, 50), 5),
+           th3index('SRID=4326;[Point(1 1)@2000-01-01]'::tgeompoint, 5));
+----
+false
+
+# The commutated operand order (th3index, h3index) resolves and agrees.
+query I
+SELECT eEq(th3index('SRID=4326;[Point(1 1)@2000-01-01]'::tgeompoint, 5),
+           geoToH3Cell(ST_Point(1, 1), 5));
+----
+true

--- a/tools/codegen_duck_udfs.py
+++ b/tools/codegen_duck_udfs.py
@@ -2391,10 +2391,11 @@ def shape_h3_prefilter(f):
         return None
     if not f.get("sqlfn"):
         return None
-    # geoToH3IndexSet is rejected by supported() ONLY on its GSERIALIZED arg (marshalled here);
-    # eEq(h3indexset,th3index) passes supported(). Any OTHER unsupported reason -> skip.
+    # geoToH3IndexSet/geoToH3Cell are rejected by supported() on their GSERIALIZED arg, and the
+    # scalar h3index (uint64_t) comparison operand is likewise unmarshalled by the generic path;
+    # both are handled here. eEq(h3indexset,th3index) passes supported(). Other reasons -> skip.
     sup = supported(f)
-    if sup is not None and "GSERIALIZED" not in sup:
+    if sup is not None and not any(k in sup for k in ("GSERIALIZED", "uint64")):
         return None
     ins, out = classify(f)
     if out is not None or len(ins) != 2:
@@ -2402,12 +2403,23 @@ def shape_h3_prefilter(f):
     b0, b1 = base(ins[0]["canonical"]), base(ins[1]["canonical"])
     rb, rn = base(f["returnType"]["canonical"]), norm(f["returnType"]["canonical"])
     ptr = lambda p: norm(p["canonical"]).endswith("*")
-    if (b0 == "GSERIALIZED" and ptr(ins[0]) and b1 == "int"
-            and "*" not in norm(ins[1]["canonical"]) and rb == "Set" and rn.endswith("*")):
-        return "geo2set"
-    if (b0 == "Set" and ptr(ins[0]) and b1 == "Temporal" and ptr(ins[1])
-            and rb in ("int", "int32_t") and "*" not in rn):
+    scal = lambda p: "*" not in norm(p["canonical"])
+    ebool = rb in ("int", "int32_t") and "*" not in rn   # int tri-state -> nullable BOOLEAN
+    # geoToH3IndexSet: (GSERIALIZED*, int) -> Set*  ;  geoToH3Cell: (GSERIALIZED*, int) -> uint64_t
+    if b0 == "GSERIALIZED" and ptr(ins[0]) and b1 == "int" and scal(ins[1]):
+        if rb == "Set" and rn.endswith("*"):
+            return "geo2set"
+        if rb == "uint64_t":
+            return "geo2cell"
+    # eEq/aEq(h3indexset, th3index): (Set*, Temporal*) -> int
+    if b0 == "Set" and ptr(ins[0]) and b1 == "Temporal" and ptr(ins[1]) and ebool:
         return "settemp_ebool"
+    # eEq/aEq(h3index, th3index): (uint64_t cell, Temporal*) -> int
+    if b0 == "uint64_t" and scal(ins[0]) and b1 == "Temporal" and ptr(ins[1]) and ebool:
+        return "celltemp_ebool"
+    # eEq/aEq(th3index, h3index): (Temporal*, uint64_t cell) -> int
+    if b0 == "Temporal" and ptr(ins[0]) and b1 == "uint64_t" and scal(ins[1]) and ebool:
+        return "tempcell_ebool"
     return None
 
 def emit_h3_prefilter(f, kind):
@@ -2421,6 +2433,38 @@ def emit_h3_prefilter(f, kind):
                 f"            Set *r = {name}(gs, res);\n"
                 f"            free(gs);\n"
                 f"            return SetToBlob(result, r);\n"
+                f"        }});\n}}\n")
+    if kind == "geo2cell":  # (geometry, int) -> h3index single cell ; geometry marshalled @ 4326
+        return (f"static void Gen_{name}(DataChunk &args, ExpressionState &, Vector &result) {{\n"
+                f"    EnsureMeosThreadInitialized();\n"
+                f"    BinaryExecutor::Execute<string_t, int32_t, int64_t>(args.data[0], args.data[1], result, args.size(),\n"
+                f"        [&](string_t in_g, int32_t res) -> int64_t {{\n"
+                f"            GSERIALIZED *gs = GeometryToGSerialized(in_g, 4326);\n"
+                f"            int64_t cell = (int64_t) {name}(gs, res);\n"
+                f"            free(gs);\n"
+                f"            return cell;\n"
+                f"        }});\n}}\n")
+    if kind == "celltemp_ebool":  # (h3index cell, th3index) -> int tri-state -> nullable BOOLEAN
+        return (f"static void Gen_{name}(DataChunk &args, ExpressionState &, Vector &result) {{\n"
+                f"    EnsureMeosThreadInitialized();\n"
+                f"    BinaryExecutor::ExecuteWithNulls<int64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),\n"
+                f"        [&](int64_t cell, string_t in_t, ValidityMask &mask, idx_t idx) {{\n"
+                f"            Temporal *t = BlobToTemporal(in_t);\n"
+                f"            int r = {name}((uint64_t) cell, t);\n"
+                f"            free(t);\n"
+                f"            if (r < 0) {{ mask.SetInvalid(idx); return false; }}\n"
+                f"            return r != 0;\n"
+                f"        }});\n}}\n")
+    if kind == "tempcell_ebool":  # (th3index, h3index cell) -> int tri-state -> nullable BOOLEAN
+        return (f"static void Gen_{name}(DataChunk &args, ExpressionState &, Vector &result) {{\n"
+                f"    EnsureMeosThreadInitialized();\n"
+                f"    BinaryExecutor::ExecuteWithNulls<string_t, int64_t, bool>(args.data[0], args.data[1], result, args.size(),\n"
+                f"        [&](string_t in_t, int64_t cell, ValidityMask &mask, idx_t idx) {{\n"
+                f"            Temporal *t = BlobToTemporal(in_t);\n"
+                f"            int r = {name}(t, (uint64_t) cell);\n"
+                f"            free(t);\n"
+                f"            if (r < 0) {{ mask.SetInvalid(idx); return false; }}\n"
+                f"            return r != 0;\n"
                 f"        }});\n}}\n")
     # settemp_ebool: (h3indexset, th3index) -> int tri-state -> nullable BOOLEAN
     return (f"static void Gen_{name}(DataChunk &args, ExpressionState &, Vector &result) {{\n"
@@ -3130,6 +3174,12 @@ def gen_cpp(fns, out_path, declared=None, aliases=None):
         names = reg_names(f, f["sqlfn"], aliases)
         if hpk == "geo2set":
             sig, rett = "{GeoTypes::GEOMETRY(), LogicalType::INTEGER}", "H3indexTypes::h3indexset()"
+        elif hpk == "geo2cell":
+            sig, rett = "{GeoTypes::GEOMETRY(), LogicalType::INTEGER}", "H3indexTypes::h3index()"
+        elif hpk == "celltemp_ebool":
+            sig, rett = "{H3indexTypes::h3index(), H3indexTypes::th3index()}", "LogicalType::BOOLEAN"
+        elif hpk == "tempcell_ebool":
+            sig, rett = "{H3indexTypes::th3index(), H3indexTypes::h3index()}", "LogicalType::BOOLEAN"
         else:   # settemp_ebool
             sig, rett = "{H3indexTypes::h3indexset(), H3indexTypes::th3index()}", "LogicalType::BOOLEAN"
         for nm in names:


### PR DESCRIPTION
Adds the single-cell H3 prefilter functions the canonical BerlinMOD q04 query needs but the generic codegen paths miss:

- `geoToH3Cell(geometry, res) -> h3index` is a static geometry->single-cell function whose GSERIALIZED argument the generic arg marshaller does not handle (fixed 4326 SRID; h3 is geographic).
- `eEq`/`eNe`/`aEq`/`aNe`(h3index, th3index) and the commutated (th3index, h3index) are the scalar-cell comparisons, whose uint64_t h3index operand the generic path does not marshal.

Extends the h3 prefilter generator pass with `geo2cell` + `celltemp_ebool`/`tempcell_ebool` cases, keyed on shape and H3 family, so the full public comparison set generates from the catalog. Companion to the cell-set prefilter surface. Extends `test/sql/h3_prefilter.test` with the single-cell cases.