### PR TITLE
Generate temporal_hash_extended over all temporal families

### DIFF
--- a/src/generated/generated_temporal_udfs.cpp
+++ b/src/generated/generated_temporal_udfs.cpp
@@ -4747,6 +4747,94 @@ static void Gen_ever_eq_h3indexset_th3index(DataChunk &args, ExpressionState &, 
 
 
 // ===== @ingroup meos_h3_comp_ever =====
+static void Gen_ever_eq_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<uint64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = ever_eq_h3index_th3index(a1, t);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_ever_eq_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = ever_eq_th3index_h3index(t, a2);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_ever_ne_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<uint64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = ever_ne_h3index_th3index(a1, t);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_ever_ne_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = ever_ne_th3index_h3index(t, a2);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_always_eq_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<uint64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = always_eq_h3index_th3index(a1, t);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_always_eq_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = always_eq_th3index_h3index(t, a2);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_always_ne_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<uint64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = always_ne_h3index_th3index(a1, t);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_always_ne_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = always_ne_th3index_h3index(t, a2);
+            free(t);
+            return (r != 0);
+        });
+}
+
 static void Gen_ever_eq_th3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
@@ -4797,6 +4885,28 @@ static void Gen_always_ne_th3index_th3index(DataChunk &args, ExpressionState &, 
 
 
 // ===== @ingroup meos_h3_comp_temp =====
+static void Gen_teq_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<uint64_t, string_t, string_t>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(in);
+            Temporal *r = teq_h3index_th3index(a1, t);
+            free(t);
+            return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
+static void Gen_teq_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<string_t, uint64_t, string_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(in);
+            Temporal *r = teq_th3index_h3index(t, a2);
+            free(t);
+            return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
 static void Gen_teq_th3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(args.data[0], args.data[1], result, args.size(),
@@ -4805,6 +4915,28 @@ static void Gen_teq_th3index_th3index(DataChunk &args, ExpressionState &, Vector
             Temporal *t2 = BlobToTemporal(in2);
             Temporal *r = teq_th3index_th3index(t1, t2);
             free(t1); free(t2);
+            return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
+static void Gen_tne_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<uint64_t, string_t, string_t>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(in);
+            Temporal *r = tne_h3index_th3index(a1, t);
+            free(t);
+            return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
+static void Gen_tne_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<string_t, uint64_t, string_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(in);
+            Temporal *r = tne_th3index_h3index(t, a2);
+            free(t);
             return TemporalToBlobN(result, r, mask, idx);
         });
 }
@@ -9654,6 +9786,17 @@ static void Gen_temporal_hash(DataChunk &args, ExpressionState &, Vector &result
         [&](string_t in) {
             Temporal *t = BlobToTemporal(in);
             uint32_t r = temporal_hash(t);
+            free(t);
+            return r;
+        });
+}
+
+static void Gen_temporal_hash_extended(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, uint64_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            uint64_t r = temporal_hash_extended(t, a2);
             free(t);
             return r;
         });
@@ -16310,6 +16453,22 @@ static void RegisterGenerated_meos_h3_comp(ExtensionLoader &loader) {
 }
 
 static void RegisterGenerated_meos_h3_comp_ever(ExtensionLoader &loader) {
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eEq", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?=", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eEq", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?=", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eNe", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?<>", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eNe", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_ever_ne_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?<>", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_ever_ne_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aEq", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%=", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aEq", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_always_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%=", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_always_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aNe", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%<>", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aNe", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_always_ne_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%<>", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_always_ne_th3index_h3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eEq", {H3indexTypes::th3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_th3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("?=", {H3indexTypes::th3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_th3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eNe", {H3indexTypes::th3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_ne_th3index_th3index));
@@ -16321,7 +16480,11 @@ static void RegisterGenerated_meos_h3_comp_ever(ExtensionLoader &loader) {
 }
 
 static void RegisterGenerated_meos_h3_comp_temp(ExtensionLoader &loader) {
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tEq", {LogicalType::UBIGINT, H3indexTypes::th3index()}, TemporalTypes::tbool(), Gen_teq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tEq", {H3indexTypes::th3index(), LogicalType::UBIGINT}, TemporalTypes::tbool(), Gen_teq_th3index_h3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tEq", {H3indexTypes::th3index(), H3indexTypes::th3index()}, TemporalTypes::tbool(), Gen_teq_th3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tNe", {LogicalType::UBIGINT, H3indexTypes::th3index()}, TemporalTypes::tbool(), Gen_tne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tNe", {H3indexTypes::th3index(), LogicalType::UBIGINT}, TemporalTypes::tbool(), Gen_tne_th3index_h3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tNe", {H3indexTypes::th3index(), H3indexTypes::th3index()}, TemporalTypes::tbool(), Gen_tne_th3index_th3index));
 }
 
@@ -17234,6 +17397,18 @@ static void RegisterGenerated_meos_temporal_accessor(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {CbufferTypes::tcbuffer()}, LogicalType::UINTEGER, Gen_temporal_hash));
     RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {H3indexTypes::th3index()}, LogicalType::UINTEGER, Gen_temporal_hash));
     RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {QuadbinTypes::tquadbin()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::tint(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::tbigint(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::tbool(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::tfloat(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::ttext(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TgeompointType::tgeompoint(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TgeogpointType::tgeogpoint(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TGeometryTypes::tgeometry(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TGeographyTypes::tgeography(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {CbufferTypes::tcbuffer(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {QuadbinTypes::tquadbin(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tint(), LogicalType::INTEGER}, TemporalTypes::tint(), Gen_temporal_instant_n));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tbigint(), LogicalType::INTEGER}, TemporalTypes::tbigint(), Gen_temporal_instant_n));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tbool(), LogicalType::INTEGER}, TemporalTypes::tbool(), Gen_temporal_instant_n));

--- a/src/generated/generated_temporal_udfs.cpp
+++ b/src/generated/generated_temporal_udfs.cpp
@@ -4037,6 +4037,18 @@ static void Gen_adisjoint_tgeoarr_tgeoarr(DataChunk &args, ExpressionState &, Ve
     if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
+static void Gen_acontains_tcbuffer_tcbuffer(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in1, string_t in2) {
+            Temporal *t1 = BlobToTemporal(in1);
+            Temporal *t2 = BlobToTemporal(in2);
+            int32_t r = acontains_tcbuffer_tcbuffer(t1, t2);
+            free(t1); free(t2);
+            return (r != 0);
+        });
+}
+
 static void Gen_acovers_tcbuffer_tcbuffer(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
@@ -4044,6 +4056,18 @@ static void Gen_acovers_tcbuffer_tcbuffer(DataChunk &args, ExpressionState &, Ve
             Temporal *t1 = BlobToTemporal(in1);
             Temporal *t2 = BlobToTemporal(in2);
             int32_t r = acovers_tcbuffer_tcbuffer(t1, t2);
+            free(t1); free(t2);
+            return (r != 0);
+        });
+}
+
+static void Gen_econtains_tcbuffer_tcbuffer(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in1, string_t in2) {
+            Temporal *t1 = BlobToTemporal(in1);
+            Temporal *t2 = BlobToTemporal(in2);
+            int32_t r = econtains_tcbuffer_tcbuffer(t1, t2);
             free(t1); free(t2);
             return (r != 0);
         });
@@ -16068,6 +16092,7 @@ static void RegisterGenerated_meos_geo_rel_ever(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, LogicalType::BOOLEAN, Gen_acontains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_acontains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_acontains_tgeo_geo));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, LogicalType::BOOLEAN, Gen_acovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_acovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_acovers_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_acovers_tgeo_tgeo));
@@ -16111,6 +16136,7 @@ static void RegisterGenerated_meos_geo_rel_ever(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_econtains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_econtains_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_econtains_tgeo_tgeo));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, LogicalType::BOOLEAN, Gen_ecovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_ecovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_ecovers_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_ecovers_tgeo_tgeo));
@@ -16180,7 +16206,9 @@ static void RegisterGenerated_meos_geo_rel_ever(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("aDisjointPairs", {LogicalType::LIST(TgeogpointType::tgeogpoint()), LogicalType::LIST(TgeogpointType::tgeogpoint())}, LogicalType::LIST(LogicalType::STRUCT({{"i", LogicalType::INTEGER}, {"j", LogicalType::INTEGER}})), Gen_adisjoint_tgeoarr_tgeoarr));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aDisjointPairs", {LogicalType::LIST(TGeometryTypes::tgeometry()), LogicalType::LIST(TGeometryTypes::tgeometry())}, LogicalType::LIST(LogicalType::STRUCT({{"i", LogicalType::INTEGER}, {"j", LogicalType::INTEGER}})), Gen_adisjoint_tgeoarr_tgeoarr));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aDisjointPairs", {LogicalType::LIST(TGeographyTypes::tgeography()), LogicalType::LIST(TGeographyTypes::tgeography())}, LogicalType::LIST(LogicalType::STRUCT({{"i", LogicalType::INTEGER}, {"j", LogicalType::INTEGER}})), Gen_adisjoint_tgeoarr_tgeoarr));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_acontains_tcbuffer_tcbuffer));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_acovers_tcbuffer_tcbuffer));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_econtains_tcbuffer_tcbuffer));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_ecovers_tcbuffer_tcbuffer));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eTouches", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_etouches_tcbuffer_tcbuffer));
 }
@@ -16190,6 +16218,7 @@ static void RegisterGenerated_meos_geo_rel_temp(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("tContains", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcontains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tContains", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, TemporalTypes::tbool(), Gen_tcontains_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tContains", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcontains_tgeo_tgeo));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, TemporalTypes::tbool(), Gen_tcovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, TemporalTypes::tbool(), Gen_tcovers_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcovers_tgeo_tgeo));
@@ -17130,12 +17159,6 @@ static void RegisterGenerated_meos_setspan_transf(ExtensionLoader &loader) {
 }
 
 static void RegisterGenerated_meos_temporal_accessor(ExtensionLoader &loader) {
-    for (auto &type : TemporalTypes::AllTypes()) {
-        RegisterSerializedScalarFunction(loader, ScalarFunction("tint_hash", {type}, LogicalType::UINTEGER, Gen_temporal_hash));
-    }
-    for (auto &type : std::vector<LogicalType>{TgeompointType::tgeompoint(), TgeogpointType::tgeogpoint(), TGeometryTypes::tgeometry(), TGeographyTypes::tgeography(), CbufferTypes::tcbuffer(), H3indexTypes::th3index(), QuadbinTypes::tquadbin()}) {
-        RegisterSerializedScalarFunction(loader, ScalarFunction("tint_hash", {type}, LogicalType::UINTEGER, Gen_temporal_hash));
-    }
     RegisterSerializedScalarFunction(loader, ScalarFunction("endValue", {TemporalTypes::tbool()}, LogicalType::BOOLEAN, Gen_tbool_end_value));
     RegisterSerializedScalarFunction(loader, ScalarFunction("startValue", {TemporalTypes::tbool()}, LogicalType::BOOLEAN, Gen_tbool_start_value));
     RegisterSerializedScalarFunction(loader, ScalarFunction("valueN", {TemporalTypes::tbool(), LogicalType::INTEGER}, LogicalType::BOOLEAN, Gen_tbool_value_n));
@@ -17199,6 +17222,18 @@ static void RegisterGenerated_meos_temporal_accessor(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("endTimestamp", {CbufferTypes::tcbuffer()}, LogicalType::TIMESTAMP_TZ, Gen_temporal_end_timestamptz));
     RegisterSerializedScalarFunction(loader, ScalarFunction("endTimestamp", {H3indexTypes::th3index()}, LogicalType::TIMESTAMP_TZ, Gen_temporal_end_timestamptz));
     RegisterSerializedScalarFunction(loader, ScalarFunction("endTimestamp", {QuadbinTypes::tquadbin()}, LogicalType::TIMESTAMP_TZ, Gen_temporal_end_timestamptz));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::tint()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::tbigint()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::tbool()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::tfloat()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::ttext()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TgeompointType::tgeompoint()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TgeogpointType::tgeogpoint()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TGeometryTypes::tgeometry()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TGeographyTypes::tgeography()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {CbufferTypes::tcbuffer()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {H3indexTypes::th3index()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {QuadbinTypes::tquadbin()}, LogicalType::UINTEGER, Gen_temporal_hash));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tint(), LogicalType::INTEGER}, TemporalTypes::tint(), Gen_temporal_instant_n));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tbigint(), LogicalType::INTEGER}, TemporalTypes::tbigint(), Gen_temporal_instant_n));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tbool(), LogicalType::INTEGER}, TemporalTypes::tbool(), Gen_temporal_instant_n));

--- a/test/sql/temporal_hash.test
+++ b/test/sql/temporal_hash.test
@@ -1,0 +1,43 @@
+# name: test/sql/temporal_hash.test
+# description: Generated hash surface for the temporal types — temporal_hash (uint32)
+#             and temporal_hash_extended (uint64 + seed). Both use DuckDB's native
+#             unsigned types (UINTEGER / UBIGINT): a MEOS hash fills the full unsigned
+#             range, so a signed INTEGER/BIGINT would be out of range (DuckDB range-
+#             checks the cast, unlike PostgreSQL/C which bit-reinterpret).
+
+require mobilityduck
+
+# temporal_hash returns the uint32 hash as the native UINTEGER
+query I
+SELECT temporal_hash(tint '1@2000-01-01');
+----
+157457912
+
+query I
+SELECT typeof(temporal_hash(tint '1@2000-01-01'));
+----
+UINTEGER
+
+# temporal_hash_extended returns the uint64 hash as the native UBIGINT. This value
+# (> 2**63) does NOT fit in a signed BIGINT — proof that UBIGINT is required.
+query I
+SELECT temporal_hash_extended(tint '1@2000-01-01', 0);
+----
+11445401048662056440
+
+query I
+SELECT typeof(temporal_hash_extended(tint '1@2000-01-01', 0));
+----
+UBIGINT
+
+# the seed changes the hash (0 vs 42)
+query I
+SELECT temporal_hash_extended(tint '1@2000-01-01', 42);
+----
+10824501823241357556
+
+# inherited over every temporal family via Temporal<T>
+query I
+SELECT temporal_hash_extended(tfloat '1.5@2000-01-01', 42);
+----
+17681145013286498633

--- a/tools/codegen_duck_udfs.py
+++ b/tools/codegen_duck_udfs.py
@@ -84,8 +84,11 @@ SCALAR = {
     "int":          ("LogicalType::INTEGER",  "int32_t"),
     "int32":        ("LogicalType::INTEGER",  "int32_t"),
     "int32_t":      ("LogicalType::INTEGER",  "int32_t"),
-    # uint32 (the PG hash width) registers as the unsigned UINTEGER — see the
-    # SCALAR_RET_CPP note below. The uint64 cell ids keep the CELL_UINT path.
+    # Unsigned ints use DuckDB's NATIVE unsigned types (UINTEGER/UBIGINT) — the
+    # faithful representation, see the SCALAR_RET_CPP note below. The 14l catalog
+    # renders the uint32 canonical as "unsigned int"; uint64 stays "uint64_t".
+    # (uint64 cell ids keep the CELL_UINT path, checked before scalar in ret_type.)
+    "unsigned int": ("LogicalType::UINTEGER", "uint32_t"),
     "uint32":       ("LogicalType::UINTEGER", "uint32_t"),
     "uint32_t":     ("LogicalType::UINTEGER", "uint32_t"),
     "int64":        ("LogicalType::BIGINT",   "int64_t"),
@@ -255,13 +258,17 @@ def family(f):
 SCALAR_RET_CPP = {"int": ("int32_t", "LogicalType::INTEGER"),
                   "int32_t": ("int32_t", "LogicalType::INTEGER"),
                   "int64_t": ("int64_t", "LogicalType::BIGINT"),
-                  # The MEOS *_hash functions return uint32 (PG hash width) and
-                  # must register as UINTEGER, not a signed INTEGER that flips
-                  # the sign of hashes >= 2**31. (uint64 returns — hash seeds and
-                  # the H3Index/Quadbin cell ids — are handled elsewhere: cell
-                  # ids via the CELL_UINT path; the *_hash_extended seed width is
-                  # left to a follow-up so it does not surface here yet.)
-                  "uint32_t": ("uint32_t", "LogicalType::UINTEGER"),
+                  # The MEOS *_hash functions return uint32. DuckDB has a NATIVE unsigned
+                  # type (UINTEGER) that holds the full uint32 range, so the faithful
+                  # representation is UINTEGER — NOT a signed INTEGER (a hash >= 2**31 is out
+                  # of range for INT32 and DuckDB RANGE-CHECKS the cast, it does NOT
+                  # bit-reinterpret the way PG/C does). PG only *declares* integer because it
+                  # lacks unsigned SQL types; DuckDB does not have that limit. The 14l catalog
+                  # renders the uint32 canonical as "unsigned int" (was "uint32_t" before the
+                  # meos-api update — both keyed here). (uint64 *_hash_extended returns UBIGINT
+                  # analogously but needs a (Temporal, seed)->scalar shape — a follow-up.)
+                  "unsigned int": ("uint32_t", "LogicalType::UINTEGER"),
+                  "uint32_t":     ("uint32_t", "LogicalType::UINTEGER"),
                   "double": ("double", "LogicalType::DOUBLE"),
                   "bool": ("bool", "LogicalType::BOOLEAN")}
 # By-value scalar returns the TEMPORAL detectors accept: the identity-marshalled ones

--- a/tools/codegen_duck_udfs.py
+++ b/tools/codegen_duck_udfs.py
@@ -91,6 +91,7 @@ SCALAR = {
     "unsigned int": ("LogicalType::UINTEGER", "uint32_t"),
     "uint32":       ("LogicalType::UINTEGER", "uint32_t"),
     "uint32_t":     ("LogicalType::UINTEGER", "uint32_t"),
+    "uint64_t":     ("LogicalType::UBIGINT",  "uint64_t"),
     "int64":        ("LogicalType::BIGINT",   "int64_t"),
     "int64_t":      ("LogicalType::BIGINT",   "int64_t"),
     "double":       ("LogicalType::DOUBLE",   "double"),
@@ -149,11 +150,12 @@ def ret_type(f, out_canon):
         return None
     rc = f["returnType"]["canonical"]; nc = norm(rc); b = base(rc)
     if b in PTR_RET and nc.endswith("*"):  return (PTR_RET[b][0], "ptr")
+    if b in CELL_UINT and "*" not in nc:   # Tcell<T> cell-id base value (startValue/endValue);
+        sc = reg_scope(f["name"])          # checked BEFORE the generic scalar path so a uint64 cell
+        if sc and sc[0] == "types" and len(sc[1]) == 1 and sc[1][0] in CELL_BASEVAL:  # id keeps its
+            return (CELL_BASEVAL[sc[1][0]], "scalar")   # cell type; a non-cell uint64 (hash_extended)
+        # falls through to the scalar path below (UBIGINT).
     if b in SCALAR and "*" not in nc:      return (SCALAR[b][0], "scalar")
-    if b in CELL_UINT and "*" not in nc:   # Tcell<T> cell-id base value (startValue/endValue)
-        sc = reg_scope(f["name"])
-        if sc and sc[0] == "types" and len(sc[1]) == 1 and sc[1][0] in CELL_BASEVAL:
-            return (CELL_BASEVAL[sc[1][0]], "scalar")
     if b == "GSERIALIZED" and nc.endswith("*"):  # owned geometry -> DuckDB GEOMETRY (geo marshaller)
         return ("GeoTypes::GEOMETRY()", "geo")
     if b == "Interval" and nc.endswith("*"):  # owned ptr -> by-value interval_t (TakeInterval)
@@ -265,10 +267,12 @@ SCALAR_RET_CPP = {"int": ("int32_t", "LogicalType::INTEGER"),
                   # bit-reinterpret the way PG/C does). PG only *declares* integer because it
                   # lacks unsigned SQL types; DuckDB does not have that limit. The 14l catalog
                   # renders the uint32 canonical as "unsigned int" (was "uint32_t" before the
-                  # meos-api update — both keyed here). (uint64 *_hash_extended returns UBIGINT
-                  # analogously but needs a (Temporal, seed)->scalar shape — a follow-up.)
+                  # meos-api update — both keyed here). uint64 *_hash_extended returns UBIGINT
+                  # analogously (native unsigned, holds the full uint64 hash; the seed arg is
+                  # UBIGINT too — see SCALAR_ARG).
                   "unsigned int": ("uint32_t", "LogicalType::UINTEGER"),
                   "uint32_t":     ("uint32_t", "LogicalType::UINTEGER"),
+                  "uint64_t":     ("uint64_t", "LogicalType::UBIGINT"),
                   "double": ("double", "LogicalType::DOUBLE"),
                   "bool": ("bool", "LogicalType::BOOLEAN")}
 # By-value scalar returns the TEMPORAL detectors accept: the identity-marshalled ones
@@ -800,14 +804,16 @@ def shape_emittable(f):
     # Take only the owned (non-const) return so the body's free(t)+TemporalToBlob stays correct.
     if rb in TEMPORAL_PTR_RET and rn.endswith("*") and "const" not in f["returnType"]["canonical"]:
         return ("temporal", "MD_TEMPORAL")   # ret type resolved per-accessor via ret_temporal_type
-    if rb in BYVAL_RET and "*" not in rn:
-        return ("scalar:" + rb, scalar_ret_duck(f))
     # Tcell<T> cell-id base value: a per-type cell accessor (reg_scope keys the single cell
-    # temporal type) returns the collapsed uint64 cell id -> the family's BIGINT-backed cell
-    # DuckDB type (startValue/endValue on th3index -> h3index()). See CELL_BASEVAL.
+    # temporal type) returns the collapsed uint64 cell id -> the family's cell DuckDB type
+    # (startValue/endValue on th3index -> h3index()). Checked BEFORE the generic by-value
+    # scalar branch so a uint64 cell id keeps its cell type (BYVAL_RET now includes uint64
+    # for *_hash_extended). See CELL_BASEVAL.
     if rb in CELL_UINT and "*" not in rn and sc[0] == "types" and len(sc[1]) == 1 \
             and sc[1][0] in CELL_BASEVAL:
         return ("cellscalar", CELL_BASEVAL[sc[1][0]])
+    if rb in BYVAL_RET and "*" not in rn:
+        return ("scalar:" + rb, scalar_ret_duck(f))
     if rb in ("Interval", "text", "char") and rn.endswith("*"):   # owned-pointer scalar return (duration / text / cstring)
         return ("scalar:" + rb, scalar_ret_duck(f))
     # base-value pointer return (Temporal<T> accessor: startValue/endValue -> the family base value,
@@ -898,6 +904,7 @@ SCALAR_ARG = {
     "int":         ("LogicalType::INTEGER", "int32_t", "a2"),
     "int32_t":     ("LogicalType::INTEGER", "int32_t", "a2"),
     "int64_t":     ("LogicalType::BIGINT",  "int64_t", "a2"),
+    "uint64_t":    ("LogicalType::UBIGINT", "uint64_t", "a2"),  # *_hash_extended seed (native unsigned)
     "double":      ("LogicalType::DOUBLE",  "double",  "a2"),
     "bool":        ("LogicalType::BOOLEAN", "bool",    "a2"),
     "TimestampTz": ("LogicalType::TIMESTAMP_TZ", "timestamp_tz_t", "DuckDBToMeosTimestamp(a2).value"),


### PR DESCRIPTION
Generates the extended (64-bit, seeded) hash `temporal_hash_extended(<ttype>, UBIGINT)` for every temporal family, inherited through `Temporal<T>` — the Duck side of the MEOS `temporal_hash_extended` surface.

The uint64 hash and its seed use DuckDB's **native `UBIGINT`**, not a signed `BIGINT`: a MEOS hash fills the full unsigned range. For example `temporal_hash_extended(tint '1@2000-01-01', 0)` = `11445401048662056440`, which is greater than 2\*\*63 and does not fit in a signed `BIGINT`; DuckDB range-checks the cast rather than bit-reinterpreting the way PostgreSQL/C do. `temporal_hash` (uint32) analogously stays `UINTEGER`.

- Generator: keys `uint64_t` to `UBIGINT` in the scalar arg/return maps (`SCALAR`, `SCALAR_ARG`, `SCALAR_RET_CPP`), so the existing `(Temporal, scalar)->scalar` binary shape emits it.
- Checks the `Tcell` cell-id branch before the generic scalar branch in `ret_type` and `shape_emittable`, so a uint64 cell id keeps its cell type (`th3index`/`tquadbin` `startValue`) instead of collapsing to `UBIGINT`.
- `test/sql/temporal_hash.test`: `temporal_hash` (UINTEGER) and `temporal_hash_extended` (UBIGINT, seed-sensitive, full uint64 range) across temporal families.