### PR TITLE
Generate the value-type extended hashes (span / spanset / set)

### DIFF
--- a/src/generated/generated_temporal_udfs.cpp
+++ b/src/generated/generated_temporal_udfs.cpp
@@ -5530,6 +5530,17 @@ static void Gen_set_hash(DataChunk &args, ExpressionState &, Vector &result) {
         });
 }
 
+static void Gen_set_hash_extended(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, uint64_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Set *s = BlobToSet(in);
+            uint64_t r = set_hash_extended(s, a2);
+            free(s);
+            return r;
+        });
+}
+
 static void Gen_set_num_values(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     UnaryExecutor::Execute<string_t, int32_t>(args.data[0], result, args.size(),
@@ -5914,6 +5925,17 @@ static void Gen_span_hash(DataChunk &args, ExpressionState &, Vector &result) {
         });
 }
 
+static void Gen_span_hash_extended(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, uint64_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Span *s = BlobToSpan(in);
+            uint64_t r = span_hash_extended(s, a2);
+            free(s);
+            return r;
+        });
+}
+
 static void Gen_span_lower_inc(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     UnaryExecutor::Execute<string_t, bool>(args.data[0], result, args.size(),
@@ -6107,6 +6129,17 @@ static void Gen_spanset_hash(DataChunk &args, ExpressionState &, Vector &result)
         [&](string_t in) {
             SpanSet *s = BlobToSpanSet(in);
             uint32_t r = spanset_hash(s);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_spanset_hash_extended(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, uint64_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            SpanSet *s = BlobToSpanSet(in);
+            uint64_t r = spanset_hash_extended(s, a2);
             free(s);
             return r;
         });
@@ -16570,6 +16603,7 @@ static void RegisterGenerated_meos_quadbin_conversion(ExtensionLoader &loader) {
 static void RegisterGenerated_meos_setspan_accessor(ExtensionLoader &loader) {
     for (auto &type : SetTypes::AllTypes()) {
         RegisterSerializedScalarFunction(loader, ScalarFunction("hash", {type}, LogicalType::UINTEGER, Gen_set_hash));
+        RegisterSerializedScalarFunction(loader, ScalarFunction("hash_extended", {type, LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_set_hash_extended));
         RegisterSerializedScalarFunction(loader, ScalarFunction("numValues", {type}, LogicalType::INTEGER, Gen_set_num_values));
     }
     RegisterSerializedScalarFunction(loader, ScalarFunction("endValue", {SetTypes::bigintset()}, LogicalType::BIGINT, Gen_bigintset_end_value));
@@ -16592,6 +16626,7 @@ static void RegisterGenerated_meos_setspan_accessor(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("getValues", {SetTypes::tstzset()}, LogicalType::LIST(LogicalType::TIMESTAMP_TZ), Gen_tstzset_values));
     for (auto &type : SpanTypes::AllTypes()) {
         RegisterSerializedScalarFunction(loader, ScalarFunction("span_hash", {type}, LogicalType::UINTEGER, Gen_span_hash));
+        RegisterSerializedScalarFunction(loader, ScalarFunction("hash_extended", {type, LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_span_hash_extended));
         RegisterSerializedScalarFunction(loader, ScalarFunction("lower_inc", {type}, LogicalType::BOOLEAN, Gen_span_lower_inc));
         RegisterSerializedScalarFunction(loader, ScalarFunction("lower_inc", {type}, LogicalType::BOOLEAN, Gen_span_upper_inc));
     }
@@ -16630,6 +16665,7 @@ static void RegisterGenerated_meos_setspan_accessor(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("upper", {SpansetTypes::tstzspanset()}, LogicalType::TIMESTAMP_TZ, Gen_tstzspanset_upper));
     for (auto &type : SpansetTypes::AllTypes()) {
         RegisterSerializedScalarFunction(loader, ScalarFunction("spanset_hash", {type}, LogicalType::UINTEGER, Gen_spanset_hash));
+        RegisterSerializedScalarFunction(loader, ScalarFunction("spanset_hash_extended", {type, LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_spanset_hash_extended));
         RegisterSerializedScalarFunction(loader, ScalarFunction("lower_inc", {type}, LogicalType::BOOLEAN, Gen_spanset_lower_inc));
         RegisterSerializedScalarFunction(loader, ScalarFunction("numSpans", {type}, LogicalType::INTEGER, Gen_spanset_num_spans));
         RegisterSerializedScalarFunction(loader, ScalarFunction("lower_inc", {type}, LogicalType::BOOLEAN, Gen_spanset_upper_inc));

--- a/src/generated/generated_temporal_udfs.cpp
+++ b/src/generated/generated_temporal_udfs.cpp
@@ -4747,6 +4747,94 @@ static void Gen_ever_eq_h3indexset_th3index(DataChunk &args, ExpressionState &, 
 
 
 // ===== @ingroup meos_h3_comp_ever =====
+static void Gen_ever_eq_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<uint64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = ever_eq_h3index_th3index(a1, t);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_ever_eq_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = ever_eq_th3index_h3index(t, a2);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_ever_ne_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<uint64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = ever_ne_h3index_th3index(a1, t);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_ever_ne_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = ever_ne_th3index_h3index(t, a2);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_always_eq_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<uint64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = always_eq_h3index_th3index(a1, t);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_always_eq_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = always_eq_th3index_h3index(t, a2);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_always_ne_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<uint64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = always_ne_h3index_th3index(a1, t);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_always_ne_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = always_ne_th3index_h3index(t, a2);
+            free(t);
+            return (r != 0);
+        });
+}
+
 static void Gen_ever_eq_th3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
@@ -4797,6 +4885,28 @@ static void Gen_always_ne_th3index_th3index(DataChunk &args, ExpressionState &, 
 
 
 // ===== @ingroup meos_h3_comp_temp =====
+static void Gen_teq_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<uint64_t, string_t, string_t>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(in);
+            Temporal *r = teq_h3index_th3index(a1, t);
+            free(t);
+            return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
+static void Gen_teq_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<string_t, uint64_t, string_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(in);
+            Temporal *r = teq_th3index_h3index(t, a2);
+            free(t);
+            return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
 static void Gen_teq_th3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(args.data[0], args.data[1], result, args.size(),
@@ -4805,6 +4915,28 @@ static void Gen_teq_th3index_th3index(DataChunk &args, ExpressionState &, Vector
             Temporal *t2 = BlobToTemporal(in2);
             Temporal *r = teq_th3index_th3index(t1, t2);
             free(t1); free(t2);
+            return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
+static void Gen_tne_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<uint64_t, string_t, string_t>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(in);
+            Temporal *r = tne_h3index_th3index(a1, t);
+            free(t);
+            return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
+static void Gen_tne_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<string_t, uint64_t, string_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(in);
+            Temporal *r = tne_th3index_h3index(t, a2);
+            free(t);
             return TemporalToBlobN(result, r, mask, idx);
         });
 }
@@ -9654,6 +9786,17 @@ static void Gen_temporal_hash(DataChunk &args, ExpressionState &, Vector &result
         [&](string_t in) {
             Temporal *t = BlobToTemporal(in);
             uint32_t r = temporal_hash(t);
+            free(t);
+            return r;
+        });
+}
+
+static void Gen_temporal_hash_extended(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, uint64_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            uint64_t r = temporal_hash_extended(t, a2);
             free(t);
             return r;
         });
@@ -16310,6 +16453,22 @@ static void RegisterGenerated_meos_h3_comp(ExtensionLoader &loader) {
 }
 
 static void RegisterGenerated_meos_h3_comp_ever(ExtensionLoader &loader) {
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eEq", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?=", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eEq", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?=", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eNe", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?<>", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eNe", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_ever_ne_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?<>", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_ever_ne_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aEq", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%=", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aEq", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_always_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%=", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_always_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aNe", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%<>", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aNe", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_always_ne_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%<>", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_always_ne_th3index_h3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eEq", {H3indexTypes::th3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_th3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("?=", {H3indexTypes::th3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_th3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eNe", {H3indexTypes::th3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_ne_th3index_th3index));
@@ -16321,7 +16480,11 @@ static void RegisterGenerated_meos_h3_comp_ever(ExtensionLoader &loader) {
 }
 
 static void RegisterGenerated_meos_h3_comp_temp(ExtensionLoader &loader) {
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tEq", {LogicalType::UBIGINT, H3indexTypes::th3index()}, TemporalTypes::tbool(), Gen_teq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tEq", {H3indexTypes::th3index(), LogicalType::UBIGINT}, TemporalTypes::tbool(), Gen_teq_th3index_h3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tEq", {H3indexTypes::th3index(), H3indexTypes::th3index()}, TemporalTypes::tbool(), Gen_teq_th3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tNe", {LogicalType::UBIGINT, H3indexTypes::th3index()}, TemporalTypes::tbool(), Gen_tne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tNe", {H3indexTypes::th3index(), LogicalType::UBIGINT}, TemporalTypes::tbool(), Gen_tne_th3index_h3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tNe", {H3indexTypes::th3index(), H3indexTypes::th3index()}, TemporalTypes::tbool(), Gen_tne_th3index_th3index));
 }
 
@@ -17234,6 +17397,18 @@ static void RegisterGenerated_meos_temporal_accessor(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {CbufferTypes::tcbuffer()}, LogicalType::UINTEGER, Gen_temporal_hash));
     RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {H3indexTypes::th3index()}, LogicalType::UINTEGER, Gen_temporal_hash));
     RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {QuadbinTypes::tquadbin()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::tint(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::tbigint(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::tbool(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::tfloat(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::ttext(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TgeompointType::tgeompoint(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TgeogpointType::tgeogpoint(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TGeometryTypes::tgeometry(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TGeographyTypes::tgeography(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {CbufferTypes::tcbuffer(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {QuadbinTypes::tquadbin(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tint(), LogicalType::INTEGER}, TemporalTypes::tint(), Gen_temporal_instant_n));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tbigint(), LogicalType::INTEGER}, TemporalTypes::tbigint(), Gen_temporal_instant_n));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tbool(), LogicalType::INTEGER}, TemporalTypes::tbool(), Gen_temporal_instant_n));

--- a/src/generated/generated_temporal_udfs.cpp
+++ b/src/generated/generated_temporal_udfs.cpp
@@ -4037,6 +4037,18 @@ static void Gen_adisjoint_tgeoarr_tgeoarr(DataChunk &args, ExpressionState &, Ve
     if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
+static void Gen_acontains_tcbuffer_tcbuffer(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in1, string_t in2) {
+            Temporal *t1 = BlobToTemporal(in1);
+            Temporal *t2 = BlobToTemporal(in2);
+            int32_t r = acontains_tcbuffer_tcbuffer(t1, t2);
+            free(t1); free(t2);
+            return (r != 0);
+        });
+}
+
 static void Gen_acovers_tcbuffer_tcbuffer(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
@@ -4044,6 +4056,18 @@ static void Gen_acovers_tcbuffer_tcbuffer(DataChunk &args, ExpressionState &, Ve
             Temporal *t1 = BlobToTemporal(in1);
             Temporal *t2 = BlobToTemporal(in2);
             int32_t r = acovers_tcbuffer_tcbuffer(t1, t2);
+            free(t1); free(t2);
+            return (r != 0);
+        });
+}
+
+static void Gen_econtains_tcbuffer_tcbuffer(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in1, string_t in2) {
+            Temporal *t1 = BlobToTemporal(in1);
+            Temporal *t2 = BlobToTemporal(in2);
+            int32_t r = econtains_tcbuffer_tcbuffer(t1, t2);
             free(t1); free(t2);
             return (r != 0);
         });
@@ -16068,6 +16092,7 @@ static void RegisterGenerated_meos_geo_rel_ever(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, LogicalType::BOOLEAN, Gen_acontains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_acontains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_acontains_tgeo_geo));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, LogicalType::BOOLEAN, Gen_acovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_acovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_acovers_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_acovers_tgeo_tgeo));
@@ -16111,6 +16136,7 @@ static void RegisterGenerated_meos_geo_rel_ever(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_econtains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_econtains_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_econtains_tgeo_tgeo));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, LogicalType::BOOLEAN, Gen_ecovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_ecovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_ecovers_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_ecovers_tgeo_tgeo));
@@ -16180,7 +16206,9 @@ static void RegisterGenerated_meos_geo_rel_ever(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("aDisjointPairs", {LogicalType::LIST(TgeogpointType::tgeogpoint()), LogicalType::LIST(TgeogpointType::tgeogpoint())}, LogicalType::LIST(LogicalType::STRUCT({{"i", LogicalType::INTEGER}, {"j", LogicalType::INTEGER}})), Gen_adisjoint_tgeoarr_tgeoarr));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aDisjointPairs", {LogicalType::LIST(TGeometryTypes::tgeometry()), LogicalType::LIST(TGeometryTypes::tgeometry())}, LogicalType::LIST(LogicalType::STRUCT({{"i", LogicalType::INTEGER}, {"j", LogicalType::INTEGER}})), Gen_adisjoint_tgeoarr_tgeoarr));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aDisjointPairs", {LogicalType::LIST(TGeographyTypes::tgeography()), LogicalType::LIST(TGeographyTypes::tgeography())}, LogicalType::LIST(LogicalType::STRUCT({{"i", LogicalType::INTEGER}, {"j", LogicalType::INTEGER}})), Gen_adisjoint_tgeoarr_tgeoarr));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_acontains_tcbuffer_tcbuffer));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_acovers_tcbuffer_tcbuffer));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_econtains_tcbuffer_tcbuffer));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_ecovers_tcbuffer_tcbuffer));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eTouches", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_etouches_tcbuffer_tcbuffer));
 }
@@ -16190,6 +16218,7 @@ static void RegisterGenerated_meos_geo_rel_temp(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("tContains", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcontains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tContains", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, TemporalTypes::tbool(), Gen_tcontains_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tContains", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcontains_tgeo_tgeo));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, TemporalTypes::tbool(), Gen_tcovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, TemporalTypes::tbool(), Gen_tcovers_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcovers_tgeo_tgeo));
@@ -17130,12 +17159,6 @@ static void RegisterGenerated_meos_setspan_transf(ExtensionLoader &loader) {
 }
 
 static void RegisterGenerated_meos_temporal_accessor(ExtensionLoader &loader) {
-    for (auto &type : TemporalTypes::AllTypes()) {
-        RegisterSerializedScalarFunction(loader, ScalarFunction("tint_hash", {type}, LogicalType::UINTEGER, Gen_temporal_hash));
-    }
-    for (auto &type : std::vector<LogicalType>{TgeompointType::tgeompoint(), TgeogpointType::tgeogpoint(), TGeometryTypes::tgeometry(), TGeographyTypes::tgeography(), CbufferTypes::tcbuffer(), H3indexTypes::th3index(), QuadbinTypes::tquadbin()}) {
-        RegisterSerializedScalarFunction(loader, ScalarFunction("tint_hash", {type}, LogicalType::UINTEGER, Gen_temporal_hash));
-    }
     RegisterSerializedScalarFunction(loader, ScalarFunction("endValue", {TemporalTypes::tbool()}, LogicalType::BOOLEAN, Gen_tbool_end_value));
     RegisterSerializedScalarFunction(loader, ScalarFunction("startValue", {TemporalTypes::tbool()}, LogicalType::BOOLEAN, Gen_tbool_start_value));
     RegisterSerializedScalarFunction(loader, ScalarFunction("valueN", {TemporalTypes::tbool(), LogicalType::INTEGER}, LogicalType::BOOLEAN, Gen_tbool_value_n));
@@ -17199,6 +17222,18 @@ static void RegisterGenerated_meos_temporal_accessor(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("endTimestamp", {CbufferTypes::tcbuffer()}, LogicalType::TIMESTAMP_TZ, Gen_temporal_end_timestamptz));
     RegisterSerializedScalarFunction(loader, ScalarFunction("endTimestamp", {H3indexTypes::th3index()}, LogicalType::TIMESTAMP_TZ, Gen_temporal_end_timestamptz));
     RegisterSerializedScalarFunction(loader, ScalarFunction("endTimestamp", {QuadbinTypes::tquadbin()}, LogicalType::TIMESTAMP_TZ, Gen_temporal_end_timestamptz));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::tint()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::tbigint()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::tbool()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::tfloat()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::ttext()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TgeompointType::tgeompoint()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TgeogpointType::tgeogpoint()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TGeometryTypes::tgeometry()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TGeographyTypes::tgeography()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {CbufferTypes::tcbuffer()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {H3indexTypes::th3index()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {QuadbinTypes::tquadbin()}, LogicalType::UINTEGER, Gen_temporal_hash));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tint(), LogicalType::INTEGER}, TemporalTypes::tint(), Gen_temporal_instant_n));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tbigint(), LogicalType::INTEGER}, TemporalTypes::tbigint(), Gen_temporal_instant_n));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tbool(), LogicalType::INTEGER}, TemporalTypes::tbool(), Gen_temporal_instant_n));

--- a/test/sql/temporal_hash.test
+++ b/test/sql/temporal_hash.test
@@ -1,0 +1,43 @@
+# name: test/sql/temporal_hash.test
+# description: Generated hash surface for the temporal types — temporal_hash (uint32)
+#             and temporal_hash_extended (uint64 + seed). Both use DuckDB's native
+#             unsigned types (UINTEGER / UBIGINT): a MEOS hash fills the full unsigned
+#             range, so a signed INTEGER/BIGINT would be out of range (DuckDB range-
+#             checks the cast, unlike PostgreSQL/C which bit-reinterpret).
+
+require mobilityduck
+
+# temporal_hash returns the uint32 hash as the native UINTEGER
+query I
+SELECT temporal_hash(tint '1@2000-01-01');
+----
+157457912
+
+query I
+SELECT typeof(temporal_hash(tint '1@2000-01-01'));
+----
+UINTEGER
+
+# temporal_hash_extended returns the uint64 hash as the native UBIGINT. This value
+# (> 2**63) does NOT fit in a signed BIGINT — proof that UBIGINT is required.
+query I
+SELECT temporal_hash_extended(tint '1@2000-01-01', 0);
+----
+11445401048662056440
+
+query I
+SELECT typeof(temporal_hash_extended(tint '1@2000-01-01', 0));
+----
+UBIGINT
+
+# the seed changes the hash (0 vs 42)
+query I
+SELECT temporal_hash_extended(tint '1@2000-01-01', 42);
+----
+10824501823241357556
+
+# inherited over every temporal family via Temporal<T>
+query I
+SELECT temporal_hash_extended(tfloat '1.5@2000-01-01', 42);
+----
+17681145013286498633

--- a/test/sql/temporal_hash.test
+++ b/test/sql/temporal_hash.test
@@ -1,9 +1,10 @@
 # name: test/sql/temporal_hash.test
-# description: Generated hash surface for the temporal types — temporal_hash (uint32)
-#             and temporal_hash_extended (uint64 + seed). Both use DuckDB's native
-#             unsigned types (UINTEGER / UBIGINT): a MEOS hash fills the full unsigned
-#             range, so a signed INTEGER/BIGINT would be out of range (DuckDB range-
-#             checks the cast, unlike PostgreSQL/C which bit-reinterpret).
+# description: Generated hash surface — temporal_hash (uint32) / temporal_hash_extended
+#             (uint64 + seed) for the temporal types, plus the value-type extended hashes
+#             (span / spanset / set). All use DuckDB's native unsigned types (UINTEGER /
+#             UBIGINT): a MEOS hash fills the full unsigned range, so a signed INTEGER/BIGINT
+#             would be out of range (DuckDB range-checks the cast, unlike PostgreSQL/C which
+#             bit-reinterpret).
 
 require mobilityduck
 
@@ -41,3 +42,33 @@ query I
 SELECT temporal_hash_extended(tfloat '1.5@2000-01-01', 42);
 ----
 17681145013286498633
+
+# ---------------------------------------------------------------------------
+# Value-type extended hashes — span / spanset / set (span & set share the bare
+# `hash_extended` SQL name; spanset uses `spanset_hash_extended`). All UBIGINT.
+# ---------------------------------------------------------------------------
+
+query I
+SELECT hash_extended(intspan '[1,5)', 42);
+----
+17081792371660567560
+
+query I
+SELECT typeof(hash_extended(intspan '[1,5)', 42));
+----
+UBIGINT
+
+query I
+SELECT hash_extended(intset '{1,2,3}', 42);
+----
+8820475475926064787
+
+query I
+SELECT hash_extended(floatset '{1.5,2.5}', 0);
+----
+8197047930258302178
+
+query I
+SELECT spanset_hash_extended(intspanset '{[1,5)}', 42);
+----
+17081792371660567591

--- a/tools/codegen_duck_udfs.py
+++ b/tools/codegen_duck_udfs.py
@@ -84,8 +84,11 @@ SCALAR = {
     "int":          ("LogicalType::INTEGER",  "int32_t"),
     "int32":        ("LogicalType::INTEGER",  "int32_t"),
     "int32_t":      ("LogicalType::INTEGER",  "int32_t"),
-    # uint32 (the PG hash width) registers as the unsigned UINTEGER — see the
-    # SCALAR_RET_CPP note below. The uint64 cell ids keep the CELL_UINT path.
+    # Unsigned ints use DuckDB's NATIVE unsigned types (UINTEGER/UBIGINT) — the
+    # faithful representation, see the SCALAR_RET_CPP note below. The 14l catalog
+    # renders the uint32 canonical as "unsigned int"; uint64 stays "uint64_t".
+    # (uint64 cell ids keep the CELL_UINT path, checked before scalar in ret_type.)
+    "unsigned int": ("LogicalType::UINTEGER", "uint32_t"),
     "uint32":       ("LogicalType::UINTEGER", "uint32_t"),
     "uint32_t":     ("LogicalType::UINTEGER", "uint32_t"),
     "int64":        ("LogicalType::BIGINT",   "int64_t"),
@@ -255,13 +258,17 @@ def family(f):
 SCALAR_RET_CPP = {"int": ("int32_t", "LogicalType::INTEGER"),
                   "int32_t": ("int32_t", "LogicalType::INTEGER"),
                   "int64_t": ("int64_t", "LogicalType::BIGINT"),
-                  # The MEOS *_hash functions return uint32 (PG hash width) and
-                  # must register as UINTEGER, not a signed INTEGER that flips
-                  # the sign of hashes >= 2**31. (uint64 returns — hash seeds and
-                  # the H3Index/Quadbin cell ids — are handled elsewhere: cell
-                  # ids via the CELL_UINT path; the *_hash_extended seed width is
-                  # left to a follow-up so it does not surface here yet.)
-                  "uint32_t": ("uint32_t", "LogicalType::UINTEGER"),
+                  # The MEOS *_hash functions return uint32. DuckDB has a NATIVE unsigned
+                  # type (UINTEGER) that holds the full uint32 range, so the faithful
+                  # representation is UINTEGER — NOT a signed INTEGER (a hash >= 2**31 is out
+                  # of range for INT32 and DuckDB RANGE-CHECKS the cast, it does NOT
+                  # bit-reinterpret the way PG/C does). PG only *declares* integer because it
+                  # lacks unsigned SQL types; DuckDB does not have that limit. The 14l catalog
+                  # renders the uint32 canonical as "unsigned int" (was "uint32_t" before the
+                  # meos-api update — both keyed here). (uint64 *_hash_extended returns UBIGINT
+                  # analogously but needs a (Temporal, seed)->scalar shape — a follow-up.)
+                  "unsigned int": ("uint32_t", "LogicalType::UINTEGER"),
+                  "uint32_t":     ("uint32_t", "LogicalType::UINTEGER"),
                   "double": ("double", "LogicalType::DOUBLE"),
                   "bool": ("bool", "LogicalType::BOOLEAN")}
 # By-value scalar returns the TEMPORAL detectors accept: the identity-marshalled ones

--- a/tools/codegen_duck_udfs.py
+++ b/tools/codegen_duck_udfs.py
@@ -91,6 +91,7 @@ SCALAR = {
     "unsigned int": ("LogicalType::UINTEGER", "uint32_t"),
     "uint32":       ("LogicalType::UINTEGER", "uint32_t"),
     "uint32_t":     ("LogicalType::UINTEGER", "uint32_t"),
+    "uint64_t":     ("LogicalType::UBIGINT",  "uint64_t"),
     "int64":        ("LogicalType::BIGINT",   "int64_t"),
     "int64_t":      ("LogicalType::BIGINT",   "int64_t"),
     "double":       ("LogicalType::DOUBLE",   "double"),
@@ -149,11 +150,12 @@ def ret_type(f, out_canon):
         return None
     rc = f["returnType"]["canonical"]; nc = norm(rc); b = base(rc)
     if b in PTR_RET and nc.endswith("*"):  return (PTR_RET[b][0], "ptr")
+    if b in CELL_UINT and "*" not in nc:   # Tcell<T> cell-id base value (startValue/endValue);
+        sc = reg_scope(f["name"])          # checked BEFORE the generic scalar path so a uint64 cell
+        if sc and sc[0] == "types" and len(sc[1]) == 1 and sc[1][0] in CELL_BASEVAL:  # id keeps its
+            return (CELL_BASEVAL[sc[1][0]], "scalar")   # cell type; a non-cell uint64 (hash_extended)
+        # falls through to the scalar path below (UBIGINT).
     if b in SCALAR and "*" not in nc:      return (SCALAR[b][0], "scalar")
-    if b in CELL_UINT and "*" not in nc:   # Tcell<T> cell-id base value (startValue/endValue)
-        sc = reg_scope(f["name"])
-        if sc and sc[0] == "types" and len(sc[1]) == 1 and sc[1][0] in CELL_BASEVAL:
-            return (CELL_BASEVAL[sc[1][0]], "scalar")
     if b == "GSERIALIZED" and nc.endswith("*"):  # owned geometry -> DuckDB GEOMETRY (geo marshaller)
         return ("GeoTypes::GEOMETRY()", "geo")
     if b == "Interval" and nc.endswith("*"):  # owned ptr -> by-value interval_t (TakeInterval)
@@ -265,10 +267,12 @@ SCALAR_RET_CPP = {"int": ("int32_t", "LogicalType::INTEGER"),
                   # bit-reinterpret the way PG/C does). PG only *declares* integer because it
                   # lacks unsigned SQL types; DuckDB does not have that limit. The 14l catalog
                   # renders the uint32 canonical as "unsigned int" (was "uint32_t" before the
-                  # meos-api update — both keyed here). (uint64 *_hash_extended returns UBIGINT
-                  # analogously but needs a (Temporal, seed)->scalar shape — a follow-up.)
+                  # meos-api update — both keyed here). uint64 *_hash_extended returns UBIGINT
+                  # analogously (native unsigned, holds the full uint64 hash; the seed arg is
+                  # UBIGINT too — see SCALAR_ARG).
                   "unsigned int": ("uint32_t", "LogicalType::UINTEGER"),
                   "uint32_t":     ("uint32_t", "LogicalType::UINTEGER"),
+                  "uint64_t":     ("uint64_t", "LogicalType::UBIGINT"),
                   "double": ("double", "LogicalType::DOUBLE"),
                   "bool": ("bool", "LogicalType::BOOLEAN")}
 # By-value scalar returns the TEMPORAL detectors accept: the identity-marshalled ones
@@ -800,14 +804,16 @@ def shape_emittable(f):
     # Take only the owned (non-const) return so the body's free(t)+TemporalToBlob stays correct.
     if rb in TEMPORAL_PTR_RET and rn.endswith("*") and "const" not in f["returnType"]["canonical"]:
         return ("temporal", "MD_TEMPORAL")   # ret type resolved per-accessor via ret_temporal_type
-    if rb in BYVAL_RET and "*" not in rn:
-        return ("scalar:" + rb, scalar_ret_duck(f))
     # Tcell<T> cell-id base value: a per-type cell accessor (reg_scope keys the single cell
-    # temporal type) returns the collapsed uint64 cell id -> the family's BIGINT-backed cell
-    # DuckDB type (startValue/endValue on th3index -> h3index()). See CELL_BASEVAL.
+    # temporal type) returns the collapsed uint64 cell id -> the family's cell DuckDB type
+    # (startValue/endValue on th3index -> h3index()). Checked BEFORE the generic by-value
+    # scalar branch so a uint64 cell id keeps its cell type (BYVAL_RET now includes uint64
+    # for *_hash_extended). See CELL_BASEVAL.
     if rb in CELL_UINT and "*" not in rn and sc[0] == "types" and len(sc[1]) == 1 \
             and sc[1][0] in CELL_BASEVAL:
         return ("cellscalar", CELL_BASEVAL[sc[1][0]])
+    if rb in BYVAL_RET and "*" not in rn:
+        return ("scalar:" + rb, scalar_ret_duck(f))
     if rb in ("Interval", "text", "char") and rn.endswith("*"):   # owned-pointer scalar return (duration / text / cstring)
         return ("scalar:" + rb, scalar_ret_duck(f))
     # base-value pointer return (Temporal<T> accessor: startValue/endValue -> the family base value,
@@ -898,6 +904,7 @@ SCALAR_ARG = {
     "int":         ("LogicalType::INTEGER", "int32_t", "a2"),
     "int32_t":     ("LogicalType::INTEGER", "int32_t", "a2"),
     "int64_t":     ("LogicalType::BIGINT",  "int64_t", "a2"),
+    "uint64_t":    ("LogicalType::UBIGINT", "uint64_t", "a2"),  # *_hash_extended seed (native unsigned)
     "double":      ("LogicalType::DOUBLE",  "double",  "a2"),
     "bool":        ("LogicalType::BOOLEAN", "bool",    "a2"),
     "TimestampTz": ("LogicalType::TIMESTAMP_TZ", "timestamp_tz_t", "DuckDBToMeosTimestamp(a2).value"),

--- a/tools/codegen_duck_udfs.py
+++ b/tools/codegen_duck_udfs.py
@@ -667,6 +667,11 @@ def shape_set(f):
             and "*" not in norm(ins[1]["canonical"]) and set_reg_scope(f["name"])):
         return ("setcsc:" + base(ins[1]["canonical"]), "LogicalType::BLOB")
     if set_reg_scope(f["name"]) is None: return None
+    # (Set, by-value scalar) -> by-value scalar : the seeded extended hash
+    # set_hash_extended(set, uint64 seed) -> uint64. Mirrors the unary u_scalar.
+    if (len(ins) == 2 and setp(ins[0]) and base(ins[1]["canonical"]) in SCALAR_ARG
+            and "*" not in norm(ins[1]["canonical"]) and rb in BYVAL_RET and "*" not in rn):
+        return ("bsc:" + base(ins[1]["canonical"]) + ":" + rb, byval_ret_duck(rb))
     if len(ins) == 1 and setp(ins[0]):
         if rb == "Set" and rn.endswith("*"):       return ("u_set", "LogicalType::BLOB")
         if rb in BYVAL_RET and "*" not in rn: return ("u_scalar:" + rb, byval_ret_duck(rb))
@@ -749,6 +754,16 @@ def emit_set(f, kind):
                 f"    UnaryExecutor::Execute<string_t, {rett}>(args.data[0], result, args.size(),\n"
                 f"        [&](string_t in) {{\n"
                 f"            Set *s = BlobToSet(in);\n            {cct} r = {name}(s);\n            free(s);\n"
+                f"            return {rexpr};\n        }});\n}}\n")
+    if kind.startswith("bsc:"):     # (Set, by-value scalar) -> by-value scalar (seeded extended hash)
+        _bsc, ab, rb2 = kind.split(':')
+        _dt, cpp2, marsh = SCALAR_ARG[ab]
+        cct, rett, rexpr = byval_ret3(rb2)
+        return (f"static void Gen_{name}(DataChunk &args, ExpressionState &, Vector &result) {{\n"
+                f"    EnsureMeosThreadInitialized();\n"
+                f"    BinaryExecutor::Execute<string_t, {cpp2}, {rett}>(args.data[0], args.data[1], result, args.size(),\n"
+                f"        [&](string_t in, {cpp2} a2) {{\n"
+                f"            Set *s = BlobToSet(in);\n            {cct} r = {name}(s, {marsh});\n            free(s);\n"
                 f"            return {rexpr};\n        }});\n}}\n")
     if kind == "b_set":             # (Set,Set) -> Set (pointer return; MEOS NULL -> SQL NULL)
         return (f"static void Gen_{name}(DataChunk &args, ExpressionState &, Vector &result) {{\n"
@@ -1944,6 +1959,13 @@ def shape_span(f, C=SPAN_C):
             and "*" not in norm(ins[1]["canonical"]) and rb == cb and rn.endswith("*")
             and C["scope"] is not None and C["scope"](f["name"]) is not None):
         return ("csc:" + base(ins[1]["canonical"]), "type")
+    # (X, by-value scalar) -> by-value scalar : the seeded extended hash,
+    # <cbase>_hash_extended(x, uint64 seed) -> uint64. Mirrors the unary u_scalar
+    # return with a SCALAR_ARG 2nd operand; name-scoped like the other span scalars.
+    if (contp(ins[0]) and base(ins[1]["canonical"]) in SCALAR_ARG
+            and "*" not in norm(ins[1]["canonical"]) and rb in BYVAL_RET and "*" not in rn
+            and C["scope"] is not None and C["scope"](f["name"]) is not None):
+        return ("bsc:" + base(ins[1]["canonical"]) + ":" + rb, byval_ret_duck(rb))
     # mixed container (Span, SpanSet) / (SpanSet, Span) -> bool : the span<->spanset
     # positional operators (left/right/overleft/overright span_spanset|spanset_span).
     # A 1-D span and its spanset order on the same axis, but the two operands are
@@ -2005,6 +2027,16 @@ def emit_span(f, kind, C=SPAN_C):
                 f"    UnaryExecutor::Execute<string_t, {rett}>(args.data[0], result, args.size(),\n"
                 f"        [&](string_t in) {{\n"
                 f"            {cb} *s = {bt}(in);\n            {cct} r = {name}(s);\n            free(s);\n"
+                f"            return {rexpr};\n        }});\n}}\n")
+    if kind.startswith("bsc:"):     # (X, by-value scalar) -> by-value scalar (seeded extended hash)
+        _bsc, ab, rb2 = kind.split(':')
+        _dt, cpp2, marsh = SCALAR_ARG[ab]
+        cct, rett, rexpr = byval_ret3(rb2)
+        return (f"static void Gen_{name}(DataChunk &args, ExpressionState &, Vector &result) {{\n"
+                f"    EnsureMeosThreadInitialized();\n"
+                f"    BinaryExecutor::Execute<string_t, {cpp2}, {rett}>(args.data[0], args.data[1], result, args.size(),\n"
+                f"        [&](string_t in, {cpp2} a2) {{\n"
+                f"            {cb} *s = {bt}(in);\n            {cct} r = {name}(s, {marsh});\n            free(s);\n"
                 f"            return {rexpr};\n        }});\n}}\n")
     if kind.startswith("u2iv:"):    # (X, by-value scalar) -> owned Interval (duration(spanset,bool))
         _dt, cpp2, marsh = SCALAR_ARG[kind.split(':')[1]]
@@ -2765,6 +2797,16 @@ def gen_cpp(fns, out_path, declared=None, aliases=None):
                 set_specific_regs.append(f'    RegisterSerializedScalarFunction(loader, ScalarFunction('
                                          f'"{reg_name(nm, f)}", {sig}, LogicalType::BOOLEAN, Gen_{fn}));')
             continue
+        if kind.startswith("bsc:"):   # (Set, by-value scalar)->scalar (seeded extended hash): {set, seed}
+            scd = SCALAR_ARG[kind.split(':')[1]][0]
+            scope, accs = set_reg_scope(fn)
+            acc_list = ["type"] if scope == "all" else accs
+            sink = set_generic_regs if scope == "all" else set_specific_regs
+            for a in acc_list:
+                for nm in names:
+                    sink.append(f'        RegisterSerializedScalarFunction(loader, ScalarFunction('
+                                f'"{reg_name(nm, f)}", {{{a}, {scd}}}, {dret}, Gen_{fn}));')
+            continue
         sc = set_reg_scope(fn)
         scope, accs = sc if sc else ("all", None)   # b_set/b_bool (<op>_set_set) -> over AllTypes
         nargs = len(classify(f)[0])
@@ -2869,6 +2911,17 @@ def gen_cpp(fns, out_path, declared=None, aliases=None):
                         if dflt is not None:
                             sink.append(f'        RegisterSerializedScalarFunction(loader, ScalarFunction('
                                         f'"{reg_name(nm, f)}", {{{a}}}, {a}, Gen_{fn}_d));')
+                continue
+            # (X, by-value scalar)->scalar (seeded extended hash): name-scoped 2-arg {X, seed}.
+            if kind.startswith("bsc:"):
+                argdt = SCALAR_ARG[kind.split(':')[1]][0]
+                scope, accs = C["scope"](fn)
+                acc_list = ["type"] if scope == "all" else accs
+                sink = gen if scope == "all" else span_specific_regs
+                for a in acc_list:
+                    for nm in names:
+                        sink.append(f'        RegisterSerializedScalarFunction(loader, ScalarFunction('
+                                    f'"{reg_name(nm, f)}", {{{a}, {argdt}}}, {dret}, Gen_{fn}));')
                 continue
             # generic (X,X)->bool|X.
             if C.get("single"):   # box: single type, concrete accessor (no AllTypes loop)


### PR DESCRIPTION
Extends the seeded 64-bit hash to the value containers whose plain hash already generates: `span_hash_extended` / `spanset_hash_extended` / `set_hash_extended` — as `hash_extended(<span|set>, UBIGINT)` and `spanset_hash_extended(spanset, UBIGINT)`, all returning UBIGINT (the native unsigned type, matching the temporal case).

- Generator: adds a `(container, by-value scalar) -> by-value scalar` shape (`bsc`) to `shape_span` and `shape_set`, mirroring the existing unary `u_scalar` hash, plus the matching registration arms so the seed registers as its scalar type (`UBIGINT`) rather than a second container operand.
- `test/sql/temporal_hash.test`: adds span/spanset/set extended-hash coverage (UBIGINT values across the full unsigned range).

The box hashes (`tbox`/`stbox`) and `cbuffer` are a separate gap — their *plain* hash does not generate yet either, so their extended form is out of scope here.