### PR TITLE
Generate the box (TBox/STBox) scalar accessors

### DIFF
--- a/src/generated/generated_temporal_udfs.cpp
+++ b/src/generated/generated_temporal_udfs.cpp
@@ -5530,6 +5530,17 @@ static void Gen_set_hash(DataChunk &args, ExpressionState &, Vector &result) {
         });
 }
 
+static void Gen_set_hash_extended(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, uint64_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Set *s = BlobToSet(in);
+            uint64_t r = set_hash_extended(s, a2);
+            free(s);
+            return r;
+        });
+}
+
 static void Gen_set_num_values(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     UnaryExecutor::Execute<string_t, int32_t>(args.data[0], result, args.size(),
@@ -5914,6 +5925,17 @@ static void Gen_span_hash(DataChunk &args, ExpressionState &, Vector &result) {
         });
 }
 
+static void Gen_span_hash_extended(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, uint64_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Span *s = BlobToSpan(in);
+            uint64_t r = span_hash_extended(s, a2);
+            free(s);
+            return r;
+        });
+}
+
 static void Gen_span_lower_inc(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     UnaryExecutor::Execute<string_t, bool>(args.data[0], result, args.size(),
@@ -6107,6 +6129,17 @@ static void Gen_spanset_hash(DataChunk &args, ExpressionState &, Vector &result)
         [&](string_t in) {
             SpanSet *s = BlobToSpanSet(in);
             uint32_t r = spanset_hash(s);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_spanset_hash_extended(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, uint64_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            SpanSet *s = BlobToSpanSet(in);
+            uint64_t r = spanset_hash_extended(s, a2);
             free(s);
             return r;
         });
@@ -16570,6 +16603,7 @@ static void RegisterGenerated_meos_quadbin_conversion(ExtensionLoader &loader) {
 static void RegisterGenerated_meos_setspan_accessor(ExtensionLoader &loader) {
     for (auto &type : SetTypes::AllTypes()) {
         RegisterSerializedScalarFunction(loader, ScalarFunction("hash", {type}, LogicalType::UINTEGER, Gen_set_hash));
+        RegisterSerializedScalarFunction(loader, ScalarFunction("hash_extended", {type, LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_set_hash_extended));
         RegisterSerializedScalarFunction(loader, ScalarFunction("numValues", {type}, LogicalType::INTEGER, Gen_set_num_values));
     }
     RegisterSerializedScalarFunction(loader, ScalarFunction("endValue", {SetTypes::bigintset()}, LogicalType::BIGINT, Gen_bigintset_end_value));
@@ -16592,6 +16626,7 @@ static void RegisterGenerated_meos_setspan_accessor(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("getValues", {SetTypes::tstzset()}, LogicalType::LIST(LogicalType::TIMESTAMP_TZ), Gen_tstzset_values));
     for (auto &type : SpanTypes::AllTypes()) {
         RegisterSerializedScalarFunction(loader, ScalarFunction("span_hash", {type}, LogicalType::UINTEGER, Gen_span_hash));
+        RegisterSerializedScalarFunction(loader, ScalarFunction("hash_extended", {type, LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_span_hash_extended));
         RegisterSerializedScalarFunction(loader, ScalarFunction("lower_inc", {type}, LogicalType::BOOLEAN, Gen_span_lower_inc));
         RegisterSerializedScalarFunction(loader, ScalarFunction("lower_inc", {type}, LogicalType::BOOLEAN, Gen_span_upper_inc));
     }
@@ -16630,6 +16665,7 @@ static void RegisterGenerated_meos_setspan_accessor(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("upper", {SpansetTypes::tstzspanset()}, LogicalType::TIMESTAMP_TZ, Gen_tstzspanset_upper));
     for (auto &type : SpansetTypes::AllTypes()) {
         RegisterSerializedScalarFunction(loader, ScalarFunction("spanset_hash", {type}, LogicalType::UINTEGER, Gen_spanset_hash));
+        RegisterSerializedScalarFunction(loader, ScalarFunction("spanset_hash_extended", {type, LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_spanset_hash_extended));
         RegisterSerializedScalarFunction(loader, ScalarFunction("lower_inc", {type}, LogicalType::BOOLEAN, Gen_spanset_lower_inc));
         RegisterSerializedScalarFunction(loader, ScalarFunction("numSpans", {type}, LogicalType::INTEGER, Gen_spanset_num_spans));
         RegisterSerializedScalarFunction(loader, ScalarFunction("lower_inc", {type}, LogicalType::BOOLEAN, Gen_spanset_upper_inc));

--- a/src/generated/generated_temporal_udfs.cpp
+++ b/src/generated/generated_temporal_udfs.cpp
@@ -176,6 +176,52 @@ inline string_t TakeCString(Vector &result, char *s) {
 }
 
 
+// ===== @ingroup meos_box_accessor =====
+static void Gen_tbox_hash(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    UnaryExecutor::Execute<string_t, uint32_t>(args.data[0], result, args.size(),
+        [&](string_t in) {
+            TBox *s = BlobToTbox(in);
+            uint32_t r = tbox_hash(s);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_tbox_hash_extended(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, uint64_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            TBox *s = BlobToTbox(in);
+            uint64_t r = tbox_hash_extended(s, a2);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_tbox_hast(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    UnaryExecutor::Execute<string_t, bool>(args.data[0], result, args.size(),
+        [&](string_t in) {
+            TBox *s = BlobToTbox(in);
+            bool r = tbox_hast(s);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_tbox_hasx(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    UnaryExecutor::Execute<string_t, bool>(args.data[0], result, args.size(),
+        [&](string_t in) {
+            TBox *s = BlobToTbox(in);
+            bool r = tbox_hasx(s);
+            free(s);
+            return r;
+        });
+}
+
+
 // ===== @ingroup meos_box_bbox_pos =====
 static void Gen_after_tbox_tbox(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
@@ -337,6 +383,18 @@ static void Gen_same_tbox_tbox(DataChunk &args, ExpressionState &, Vector &resul
 
 
 // ===== @ingroup meos_box_comp =====
+static void Gen_tbox_cmp(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, string_t, int32_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t a, string_t b) {
+            TBox *s1 = BlobToTbox(a);
+            TBox *s2 = BlobToTbox(b);
+            int32_t r = tbox_cmp(s1, s2);
+            free(s1); free(s2);
+            return r;
+        });
+}
+
 static void Gen_tbox_eq(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
@@ -2328,7 +2386,120 @@ static void Gen_same_tspatial_stbox(DataChunk &args, ExpressionState &, Vector &
 }
 
 
+// ===== @ingroup meos_geo_box_accessor =====
+static void Gen_stbox_area(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, bool, double>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, bool a2) {
+            STBox *s = BlobToStbox(in);
+            double r = stbox_area(s, a2);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_stbox_hash(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    UnaryExecutor::Execute<string_t, uint32_t>(args.data[0], result, args.size(),
+        [&](string_t in) {
+            STBox *s = BlobToStbox(in);
+            uint32_t r = stbox_hash(s);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_stbox_hash_extended(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, uint64_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            STBox *s = BlobToStbox(in);
+            uint64_t r = stbox_hash_extended(s, a2);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_stbox_hast(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    UnaryExecutor::Execute<string_t, bool>(args.data[0], result, args.size(),
+        [&](string_t in) {
+            STBox *s = BlobToStbox(in);
+            bool r = stbox_hast(s);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_stbox_hasx(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    UnaryExecutor::Execute<string_t, bool>(args.data[0], result, args.size(),
+        [&](string_t in) {
+            STBox *s = BlobToStbox(in);
+            bool r = stbox_hasx(s);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_stbox_hasz(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    UnaryExecutor::Execute<string_t, bool>(args.data[0], result, args.size(),
+        [&](string_t in) {
+            STBox *s = BlobToStbox(in);
+            bool r = stbox_hasz(s);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_stbox_isgeodetic(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    UnaryExecutor::Execute<string_t, bool>(args.data[0], result, args.size(),
+        [&](string_t in) {
+            STBox *s = BlobToStbox(in);
+            bool r = stbox_isgeodetic(s);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_stbox_perimeter(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, bool, double>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, bool a2) {
+            STBox *s = BlobToStbox(in);
+            double r = stbox_perimeter(s, a2);
+            free(s);
+            return r;
+        });
+}
+
+static void Gen_stbox_volume(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    UnaryExecutor::Execute<string_t, double>(args.data[0], result, args.size(),
+        [&](string_t in) {
+            STBox *s = BlobToStbox(in);
+            double r = stbox_volume(s);
+            free(s);
+            return r;
+        });
+}
+
+
 // ===== @ingroup meos_geo_box_comp =====
+static void Gen_stbox_cmp(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, string_t, int32_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t a, string_t b) {
+            STBox *s1 = BlobToStbox(a);
+            STBox *s2 = BlobToStbox(b);
+            int32_t r = stbox_cmp(s1, s2);
+            free(s1); free(s2);
+            return r;
+        });
+}
+
 static void Gen_stbox_eq(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
@@ -2611,6 +2782,19 @@ static void Gen_intersection_stbox_stbox(DataChunk &args, ExpressionState &, Vec
 }
 
 
+// ===== @ingroup meos_geo_box_srid =====
+static void Gen_stbox_srid(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    UnaryExecutor::Execute<string_t, int32_t>(args.data[0], result, args.size(),
+        [&](string_t in) {
+            STBox *s = BlobToStbox(in);
+            int32_t r = stbox_srid(s);
+            free(s);
+            return r;
+        });
+}
+
+
 // ===== @ingroup meos_geo_box_topo =====
 static void Gen_adjacent_stbox_stbox(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
@@ -2669,6 +2853,20 @@ static void Gen_same_stbox_stbox(DataChunk &args, ExpressionState &, Vector &res
             bool r = same_stbox_stbox(s1, s2);
             free(s1); free(s2);
             return r;
+        });
+}
+
+
+// ===== @ingroup meos_geo_box_transf =====
+static void Gen_stbox_get_space(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    UnaryExecutor::ExecuteWithNulls<string_t, string_t>(args.data[0], result, args.size(),
+        [&](string_t in, ValidityMask &mask, idx_t idx) -> string_t {
+            STBox *s = BlobToStbox(in);
+            STBox *r = stbox_get_space(s);
+            free(s);
+            if (!r) { mask.SetInvalid(idx); return string_t(); }
+            return StboxToBlob(result, r);
         });
 }
 
@@ -3047,6 +3245,18 @@ static void Gen_mindistance_tgeoarr_tgeoarr(DataChunk &args, ExpressionState &, 
             const Temporal **a2 = ListToTemporalArr(child2, le2, &n2);
             double r = mindistance_tgeoarr_tgeoarr(a1, n1, a2, n2);
             FreeTemporalArr(a1, n1); FreeTemporalArr(a2, n2);
+            return r;
+        });
+}
+
+static void Gen_nad_stbox_stbox(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, string_t, double>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t a, string_t b) {
+            STBox *s1 = BlobToStbox(a);
+            STBox *s2 = BlobToStbox(b);
+            double r = nad_stbox_stbox(s1, s2);
+            free(s1); free(s2);
             return r;
         });
 }
@@ -15019,6 +15229,13 @@ static void Gen_tbigint_shift_value(DataChunk &args, ExpressionState &, Vector &
 
 } // anonymous
 
+static void RegisterGenerated_meos_box_accessor(ExtensionLoader &loader) {
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tbox_hash", {TboxType::tbox()}, LogicalType::UINTEGER, Gen_tbox_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tbox_hash_extended", {TboxType::tbox(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_tbox_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("hasT", {TboxType::tbox()}, LogicalType::BOOLEAN, Gen_tbox_hast));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("hasX", {TboxType::tbox()}, LogicalType::BOOLEAN, Gen_tbox_hasx));
+}
+
 static void RegisterGenerated_meos_box_bbox_pos(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("after", {TboxType::tbox(), TboxType::tbox()}, LogicalType::BOOLEAN, Gen_after_tbox_tbox));
     RegisterSerializedScalarFunction(loader, ScalarFunction("before", {TboxType::tbox(), TboxType::tbox()}, LogicalType::BOOLEAN, Gen_before_tbox_tbox));
@@ -15048,6 +15265,7 @@ static void RegisterGenerated_meos_box_bbox_topo(ExtensionLoader &loader) {
 }
 
 static void RegisterGenerated_meos_box_comp(ExtensionLoader &loader) {
+    RegisterSerializedScalarFunction(loader, ScalarFunction("cmp", {TboxType::tbox(), TboxType::tbox()}, LogicalType::INTEGER, Gen_tbox_cmp));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eq", {TboxType::tbox(), TboxType::tbox()}, LogicalType::BOOLEAN, Gen_tbox_eq));
     RegisterSerializedScalarFunction(loader, ScalarFunction("=", {TboxType::tbox(), TboxType::tbox()}, LogicalType::BOOLEAN, Gen_tbox_eq));
     RegisterSerializedScalarFunction(loader, ScalarFunction("ge", {TboxType::tbox(), TboxType::tbox()}, LogicalType::BOOLEAN, Gen_tbox_ge));
@@ -16005,7 +16223,20 @@ static void RegisterGenerated_meos_geo_bbox_topo(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("~=", {QuadbinTypes::tquadbin(), StboxType::stbox()}, LogicalType::BOOLEAN, Gen_same_tspatial_stbox));
 }
 
+static void RegisterGenerated_meos_geo_box_accessor(ExtensionLoader &loader) {
+    RegisterSerializedScalarFunction(loader, ScalarFunction("area", {StboxType::stbox(), LogicalType::BOOLEAN}, LogicalType::DOUBLE, Gen_stbox_area));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("stbox_hash", {StboxType::stbox()}, LogicalType::UINTEGER, Gen_stbox_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("stbox_hash_extended", {StboxType::stbox(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_stbox_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("hasT", {StboxType::stbox()}, LogicalType::BOOLEAN, Gen_stbox_hast));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("hasX", {StboxType::stbox()}, LogicalType::BOOLEAN, Gen_stbox_hasx));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("hasZ", {StboxType::stbox()}, LogicalType::BOOLEAN, Gen_stbox_hasz));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("isGeodetic", {StboxType::stbox()}, LogicalType::BOOLEAN, Gen_stbox_isgeodetic));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("perimeter", {StboxType::stbox(), LogicalType::BOOLEAN}, LogicalType::DOUBLE, Gen_stbox_perimeter));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("volume", {StboxType::stbox()}, LogicalType::DOUBLE, Gen_stbox_volume));
+}
+
 static void RegisterGenerated_meos_geo_box_comp(ExtensionLoader &loader) {
+    RegisterSerializedScalarFunction(loader, ScalarFunction("cmp", {StboxType::stbox(), StboxType::stbox()}, LogicalType::INTEGER, Gen_stbox_cmp));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eq", {StboxType::stbox(), StboxType::stbox()}, LogicalType::BOOLEAN, Gen_stbox_eq));
     RegisterSerializedScalarFunction(loader, ScalarFunction("=", {StboxType::stbox(), StboxType::stbox()}, LogicalType::BOOLEAN, Gen_stbox_eq));
     RegisterSerializedScalarFunction(loader, ScalarFunction("ge", {StboxType::stbox(), StboxType::stbox()}, LogicalType::BOOLEAN, Gen_stbox_ge));
@@ -16056,6 +16287,10 @@ static void RegisterGenerated_meos_geo_box_set(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("*", {StboxType::stbox(), StboxType::stbox()}, StboxType::stbox(), Gen_intersection_stbox_stbox));
 }
 
+static void RegisterGenerated_meos_geo_box_srid(ExtensionLoader &loader) {
+    RegisterSerializedScalarFunction(loader, ScalarFunction("SRID", {StboxType::stbox()}, LogicalType::INTEGER, Gen_stbox_srid));
+}
+
 static void RegisterGenerated_meos_geo_box_topo(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("adjacent", {StboxType::stbox(), StboxType::stbox()}, LogicalType::BOOLEAN, Gen_adjacent_stbox_stbox));
     RegisterSerializedScalarFunction(loader, ScalarFunction("-|-", {StboxType::stbox(), StboxType::stbox()}, LogicalType::BOOLEAN, Gen_adjacent_stbox_stbox));
@@ -16067,6 +16302,10 @@ static void RegisterGenerated_meos_geo_box_topo(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("&&", {StboxType::stbox(), StboxType::stbox()}, LogicalType::BOOLEAN, Gen_overlaps_stbox_stbox));
     RegisterSerializedScalarFunction(loader, ScalarFunction("same", {StboxType::stbox(), StboxType::stbox()}, LogicalType::BOOLEAN, Gen_same_stbox_stbox));
     RegisterSerializedScalarFunction(loader, ScalarFunction("~=", {StboxType::stbox(), StboxType::stbox()}, LogicalType::BOOLEAN, Gen_same_stbox_stbox));
+}
+
+static void RegisterGenerated_meos_geo_box_transf(ExtensionLoader &loader) {
+    RegisterSerializedScalarFunction(loader, ScalarFunction("getSpace", {StboxType::stbox()}, StboxType::stbox(), Gen_stbox_get_space));
 }
 
 static void RegisterGenerated_meos_geo_comp_ever(ExtensionLoader &loader) {
@@ -16231,6 +16470,8 @@ static void RegisterGenerated_meos_geo_distance(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("minDistance", {LogicalType::LIST(TgeogpointType::tgeogpoint()), LogicalType::LIST(TgeogpointType::tgeogpoint())}, LogicalType::DOUBLE, Gen_mindistance_tgeoarr_tgeoarr));
     RegisterSerializedScalarFunction(loader, ScalarFunction("minDistance", {LogicalType::LIST(TGeometryTypes::tgeometry()), LogicalType::LIST(TGeometryTypes::tgeometry())}, LogicalType::DOUBLE, Gen_mindistance_tgeoarr_tgeoarr));
     RegisterSerializedScalarFunction(loader, ScalarFunction("minDistance", {LogicalType::LIST(TGeographyTypes::tgeography()), LogicalType::LIST(TGeographyTypes::tgeography())}, LogicalType::DOUBLE, Gen_mindistance_tgeoarr_tgeoarr));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("nearestApproachDistance", {StboxType::stbox(), StboxType::stbox()}, LogicalType::DOUBLE, Gen_nad_stbox_stbox));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("|=|", {StboxType::stbox(), StboxType::stbox()}, LogicalType::DOUBLE, Gen_nad_stbox_stbox));
 }
 
 static void RegisterGenerated_meos_geo_inout(ExtensionLoader &loader) {
@@ -19370,6 +19611,7 @@ static void RegisterGenerated_meos_temporal_transf(ExtensionLoader &loader) {
 }
 
 void RegisterGeneratedTemporalUdfs(ExtensionLoader &loader) {
+    RegisterGenerated_meos_box_accessor(loader);
     RegisterGenerated_meos_box_bbox_pos(loader);
     RegisterGenerated_meos_box_bbox_topo(loader);
     RegisterGenerated_meos_box_comp(loader);
@@ -19387,10 +19629,13 @@ void RegisterGeneratedTemporalUdfs(ExtensionLoader &loader) {
     RegisterGenerated_meos_geo_accessor(loader);
     RegisterGenerated_meos_geo_bbox_pos(loader);
     RegisterGenerated_meos_geo_bbox_topo(loader);
+    RegisterGenerated_meos_geo_box_accessor(loader);
     RegisterGenerated_meos_geo_box_comp(loader);
     RegisterGenerated_meos_geo_box_pos(loader);
     RegisterGenerated_meos_geo_box_set(loader);
+    RegisterGenerated_meos_geo_box_srid(loader);
     RegisterGenerated_meos_geo_box_topo(loader);
+    RegisterGenerated_meos_geo_box_transf(loader);
     RegisterGenerated_meos_geo_comp_ever(loader);
     RegisterGenerated_meos_geo_comp_temp(loader);
     RegisterGenerated_meos_geo_conversion(loader);

--- a/src/generated/generated_temporal_udfs.cpp
+++ b/src/generated/generated_temporal_udfs.cpp
@@ -4747,6 +4747,94 @@ static void Gen_ever_eq_h3indexset_th3index(DataChunk &args, ExpressionState &, 
 
 
 // ===== @ingroup meos_h3_comp_ever =====
+static void Gen_ever_eq_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<uint64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = ever_eq_h3index_th3index(a1, t);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_ever_eq_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = ever_eq_th3index_h3index(t, a2);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_ever_ne_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<uint64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = ever_ne_h3index_th3index(a1, t);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_ever_ne_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = ever_ne_th3index_h3index(t, a2);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_always_eq_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<uint64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = always_eq_h3index_th3index(a1, t);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_always_eq_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = always_eq_th3index_h3index(t, a2);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_always_ne_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<uint64_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = always_ne_h3index_th3index(a1, t);
+            free(t);
+            return (r != 0);
+        });
+}
+
+static void Gen_always_ne_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            int32_t r = always_ne_th3index_h3index(t, a2);
+            free(t);
+            return (r != 0);
+        });
+}
+
 static void Gen_ever_eq_th3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
@@ -4797,6 +4885,28 @@ static void Gen_always_ne_th3index_th3index(DataChunk &args, ExpressionState &, 
 
 
 // ===== @ingroup meos_h3_comp_temp =====
+static void Gen_teq_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<uint64_t, string_t, string_t>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(in);
+            Temporal *r = teq_h3index_th3index(a1, t);
+            free(t);
+            return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
+static void Gen_teq_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<string_t, uint64_t, string_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(in);
+            Temporal *r = teq_th3index_h3index(t, a2);
+            free(t);
+            return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
 static void Gen_teq_th3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(args.data[0], args.data[1], result, args.size(),
@@ -4805,6 +4915,28 @@ static void Gen_teq_th3index_th3index(DataChunk &args, ExpressionState &, Vector
             Temporal *t2 = BlobToTemporal(in2);
             Temporal *r = teq_th3index_th3index(t1, t2);
             free(t1); free(t2);
+            return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
+static void Gen_tne_h3index_th3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<uint64_t, string_t, string_t>(args.data[0], args.data[1], result, args.size(),
+        [&](uint64_t a1, string_t in, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(in);
+            Temporal *r = tne_h3index_th3index(a1, t);
+            free(t);
+            return TemporalToBlobN(result, r, mask, idx);
+        });
+}
+
+static void Gen_tne_th3index_h3index(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::ExecuteWithNulls<string_t, uint64_t, string_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2, ValidityMask &mask, idx_t idx) -> string_t {
+            Temporal *t = BlobToTemporal(in);
+            Temporal *r = tne_th3index_h3index(t, a2);
+            free(t);
             return TemporalToBlobN(result, r, mask, idx);
         });
 }
@@ -9654,6 +9786,17 @@ static void Gen_temporal_hash(DataChunk &args, ExpressionState &, Vector &result
         [&](string_t in) {
             Temporal *t = BlobToTemporal(in);
             uint32_t r = temporal_hash(t);
+            free(t);
+            return r;
+        });
+}
+
+static void Gen_temporal_hash_extended(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, uint64_t, uint64_t>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in, uint64_t a2) {
+            Temporal *t = BlobToTemporal(in);
+            uint64_t r = temporal_hash_extended(t, a2);
             free(t);
             return r;
         });
@@ -16310,6 +16453,22 @@ static void RegisterGenerated_meos_h3_comp(ExtensionLoader &loader) {
 }
 
 static void RegisterGenerated_meos_h3_comp_ever(ExtensionLoader &loader) {
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eEq", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?=", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eEq", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?=", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eNe", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?<>", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eNe", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_ever_ne_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("?<>", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_ever_ne_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aEq", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%=", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_eq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aEq", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_always_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%=", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_always_eq_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aNe", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%<>", {LogicalType::UBIGINT, H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_always_ne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aNe", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_always_ne_th3index_h3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("%<>", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::BOOLEAN, Gen_always_ne_th3index_h3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eEq", {H3indexTypes::th3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_th3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("?=", {H3indexTypes::th3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_eq_th3index_th3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eNe", {H3indexTypes::th3index(), H3indexTypes::th3index()}, LogicalType::BOOLEAN, Gen_ever_ne_th3index_th3index));
@@ -16321,7 +16480,11 @@ static void RegisterGenerated_meos_h3_comp_ever(ExtensionLoader &loader) {
 }
 
 static void RegisterGenerated_meos_h3_comp_temp(ExtensionLoader &loader) {
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tEq", {LogicalType::UBIGINT, H3indexTypes::th3index()}, TemporalTypes::tbool(), Gen_teq_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tEq", {H3indexTypes::th3index(), LogicalType::UBIGINT}, TemporalTypes::tbool(), Gen_teq_th3index_h3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tEq", {H3indexTypes::th3index(), H3indexTypes::th3index()}, TemporalTypes::tbool(), Gen_teq_th3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tNe", {LogicalType::UBIGINT, H3indexTypes::th3index()}, TemporalTypes::tbool(), Gen_tne_h3index_th3index));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tNe", {H3indexTypes::th3index(), LogicalType::UBIGINT}, TemporalTypes::tbool(), Gen_tne_th3index_h3index));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tNe", {H3indexTypes::th3index(), H3indexTypes::th3index()}, TemporalTypes::tbool(), Gen_tne_th3index_th3index));
 }
 
@@ -17234,6 +17397,18 @@ static void RegisterGenerated_meos_temporal_accessor(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {CbufferTypes::tcbuffer()}, LogicalType::UINTEGER, Gen_temporal_hash));
     RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {H3indexTypes::th3index()}, LogicalType::UINTEGER, Gen_temporal_hash));
     RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {QuadbinTypes::tquadbin()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::tint(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::tbigint(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::tbool(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::tfloat(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TemporalTypes::ttext(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TgeompointType::tgeompoint(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TgeogpointType::tgeogpoint(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TGeometryTypes::tgeometry(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {TGeographyTypes::tgeography(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {CbufferTypes::tcbuffer(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {H3indexTypes::th3index(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash_extended", {QuadbinTypes::tquadbin(), LogicalType::UBIGINT}, LogicalType::UBIGINT, Gen_temporal_hash_extended));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tint(), LogicalType::INTEGER}, TemporalTypes::tint(), Gen_temporal_instant_n));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tbigint(), LogicalType::INTEGER}, TemporalTypes::tbigint(), Gen_temporal_instant_n));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tbool(), LogicalType::INTEGER}, TemporalTypes::tbool(), Gen_temporal_instant_n));

--- a/src/generated/generated_temporal_udfs.cpp
+++ b/src/generated/generated_temporal_udfs.cpp
@@ -4037,6 +4037,18 @@ static void Gen_adisjoint_tgeoarr_tgeoarr(DataChunk &args, ExpressionState &, Ve
     if (row_count == 1) result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
+static void Gen_acontains_tcbuffer_tcbuffer(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in1, string_t in2) {
+            Temporal *t1 = BlobToTemporal(in1);
+            Temporal *t2 = BlobToTemporal(in2);
+            int32_t r = acontains_tcbuffer_tcbuffer(t1, t2);
+            free(t1); free(t2);
+            return (r != 0);
+        });
+}
+
 static void Gen_acovers_tcbuffer_tcbuffer(DataChunk &args, ExpressionState &, Vector &result) {
     EnsureMeosThreadInitialized();
     BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
@@ -4044,6 +4056,18 @@ static void Gen_acovers_tcbuffer_tcbuffer(DataChunk &args, ExpressionState &, Ve
             Temporal *t1 = BlobToTemporal(in1);
             Temporal *t2 = BlobToTemporal(in2);
             int32_t r = acovers_tcbuffer_tcbuffer(t1, t2);
+            free(t1); free(t2);
+            return (r != 0);
+        });
+}
+
+static void Gen_econtains_tcbuffer_tcbuffer(DataChunk &args, ExpressionState &, Vector &result) {
+    EnsureMeosThreadInitialized();
+    BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(),
+        [&](string_t in1, string_t in2) {
+            Temporal *t1 = BlobToTemporal(in1);
+            Temporal *t2 = BlobToTemporal(in2);
+            int32_t r = econtains_tcbuffer_tcbuffer(t1, t2);
             free(t1); free(t2);
             return (r != 0);
         });
@@ -16068,6 +16092,7 @@ static void RegisterGenerated_meos_geo_rel_ever(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, LogicalType::BOOLEAN, Gen_acontains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_acontains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_acontains_tgeo_geo));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, LogicalType::BOOLEAN, Gen_acovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_acovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_acovers_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_acovers_tgeo_tgeo));
@@ -16111,6 +16136,7 @@ static void RegisterGenerated_meos_geo_rel_ever(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_econtains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_econtains_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_econtains_tgeo_tgeo));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, LogicalType::BOOLEAN, Gen_ecovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_ecovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, Gen_ecovers_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, LogicalType::BOOLEAN, Gen_ecovers_tgeo_tgeo));
@@ -16180,7 +16206,9 @@ static void RegisterGenerated_meos_geo_rel_ever(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("aDisjointPairs", {LogicalType::LIST(TgeogpointType::tgeogpoint()), LogicalType::LIST(TgeogpointType::tgeogpoint())}, LogicalType::LIST(LogicalType::STRUCT({{"i", LogicalType::INTEGER}, {"j", LogicalType::INTEGER}})), Gen_adisjoint_tgeoarr_tgeoarr));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aDisjointPairs", {LogicalType::LIST(TGeometryTypes::tgeometry()), LogicalType::LIST(TGeometryTypes::tgeometry())}, LogicalType::LIST(LogicalType::STRUCT({{"i", LogicalType::INTEGER}, {"j", LogicalType::INTEGER}})), Gen_adisjoint_tgeoarr_tgeoarr));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aDisjointPairs", {LogicalType::LIST(TGeographyTypes::tgeography()), LogicalType::LIST(TGeographyTypes::tgeography())}, LogicalType::LIST(LogicalType::STRUCT({{"i", LogicalType::INTEGER}, {"j", LogicalType::INTEGER}})), Gen_adisjoint_tgeoarr_tgeoarr));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("aContains", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_acontains_tcbuffer_tcbuffer));
     RegisterSerializedScalarFunction(loader, ScalarFunction("aCovers", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_acovers_tcbuffer_tcbuffer));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("eContains", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_econtains_tcbuffer_tcbuffer));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eCovers", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_ecovers_tcbuffer_tcbuffer));
     RegisterSerializedScalarFunction(loader, ScalarFunction("eTouches", {CbufferTypes::tcbuffer(), CbufferTypes::tcbuffer()}, LogicalType::BOOLEAN, Gen_etouches_tcbuffer_tcbuffer));
 }
@@ -16190,6 +16218,7 @@ static void RegisterGenerated_meos_geo_rel_temp(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("tContains", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcontains_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tContains", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, TemporalTypes::tbool(), Gen_tcontains_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tContains", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcontains_tgeo_tgeo));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {GeoTypes::GEOMETRY(), TgeompointType::tgeompoint()}, TemporalTypes::tbool(), Gen_tcovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {GeoTypes::GEOMETRY(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcovers_geo_tgeo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {TGeometryTypes::tgeometry(), GeoTypes::GEOMETRY()}, TemporalTypes::tbool(), Gen_tcovers_tgeo_geo));
     RegisterSerializedScalarFunction(loader, ScalarFunction("tCovers", {TGeometryTypes::tgeometry(), TGeometryTypes::tgeometry()}, TemporalTypes::tbool(), Gen_tcovers_tgeo_tgeo));
@@ -17130,12 +17159,6 @@ static void RegisterGenerated_meos_setspan_transf(ExtensionLoader &loader) {
 }
 
 static void RegisterGenerated_meos_temporal_accessor(ExtensionLoader &loader) {
-    for (auto &type : TemporalTypes::AllTypes()) {
-        RegisterSerializedScalarFunction(loader, ScalarFunction("tint_hash", {type}, LogicalType::UINTEGER, Gen_temporal_hash));
-    }
-    for (auto &type : std::vector<LogicalType>{TgeompointType::tgeompoint(), TgeogpointType::tgeogpoint(), TGeometryTypes::tgeometry(), TGeographyTypes::tgeography(), CbufferTypes::tcbuffer(), H3indexTypes::th3index(), QuadbinTypes::tquadbin()}) {
-        RegisterSerializedScalarFunction(loader, ScalarFunction("tint_hash", {type}, LogicalType::UINTEGER, Gen_temporal_hash));
-    }
     RegisterSerializedScalarFunction(loader, ScalarFunction("endValue", {TemporalTypes::tbool()}, LogicalType::BOOLEAN, Gen_tbool_end_value));
     RegisterSerializedScalarFunction(loader, ScalarFunction("startValue", {TemporalTypes::tbool()}, LogicalType::BOOLEAN, Gen_tbool_start_value));
     RegisterSerializedScalarFunction(loader, ScalarFunction("valueN", {TemporalTypes::tbool(), LogicalType::INTEGER}, LogicalType::BOOLEAN, Gen_tbool_value_n));
@@ -17199,6 +17222,18 @@ static void RegisterGenerated_meos_temporal_accessor(ExtensionLoader &loader) {
     RegisterSerializedScalarFunction(loader, ScalarFunction("endTimestamp", {CbufferTypes::tcbuffer()}, LogicalType::TIMESTAMP_TZ, Gen_temporal_end_timestamptz));
     RegisterSerializedScalarFunction(loader, ScalarFunction("endTimestamp", {H3indexTypes::th3index()}, LogicalType::TIMESTAMP_TZ, Gen_temporal_end_timestamptz));
     RegisterSerializedScalarFunction(loader, ScalarFunction("endTimestamp", {QuadbinTypes::tquadbin()}, LogicalType::TIMESTAMP_TZ, Gen_temporal_end_timestamptz));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::tint()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::tbigint()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::tbool()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::tfloat()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TemporalTypes::ttext()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TgeompointType::tgeompoint()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TgeogpointType::tgeogpoint()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TGeometryTypes::tgeometry()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {TGeographyTypes::tgeography()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {CbufferTypes::tcbuffer()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {H3indexTypes::th3index()}, LogicalType::UINTEGER, Gen_temporal_hash));
+    RegisterSerializedScalarFunction(loader, ScalarFunction("temporal_hash", {QuadbinTypes::tquadbin()}, LogicalType::UINTEGER, Gen_temporal_hash));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tint(), LogicalType::INTEGER}, TemporalTypes::tint(), Gen_temporal_instant_n));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tbigint(), LogicalType::INTEGER}, TemporalTypes::tbigint(), Gen_temporal_instant_n));
     RegisterSerializedScalarFunction(loader, ScalarFunction("instantN", {TemporalTypes::tbool(), LogicalType::INTEGER}, TemporalTypes::tbool(), Gen_temporal_instant_n));

--- a/src/geo/stbox.cpp
+++ b/src/geo/stbox.cpp
@@ -195,40 +195,10 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    duckdb::RegisterSerializedScalarFunction(loader, 
-        ScalarFunction(
-            "hasX",
-            {stbox()},
-            LogicalType::BOOLEAN,
-            StboxFunctions::Stbox_hasx
-        )
-    );
-    duckdb::RegisterSerializedScalarFunction(loader, 
-        ScalarFunction(
-            "hasZ",
-            {stbox()},
-            LogicalType::BOOLEAN,
-            StboxFunctions::Stbox_hasz
-        )
-    );
-    duckdb::RegisterSerializedScalarFunction(loader, 
-        ScalarFunction(
-            "hasT",
-            {stbox()},
-            LogicalType::BOOLEAN,
-            StboxFunctions::Stbox_hast
-        )
-    );
-    duckdb::RegisterSerializedScalarFunction(loader, 
-        ScalarFunction(
-            "isGeodetic",
-            {stbox()},
-            LogicalType::BOOLEAN,
-            StboxFunctions::Stbox_isgeodetic
-        )
-    );
+    // hasX/hasZ/hasT/isGeodetic are generated from the catalog (box unary scalar
+    // accessors) in src/generated/generated_temporal_udfs.cpp.
 
-    duckdb::RegisterSerializedScalarFunction(loader, 
+    duckdb::RegisterSerializedScalarFunction(loader,
         ScalarFunction(
             "Xmin",
             {stbox()},
@@ -325,14 +295,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    duckdb::RegisterSerializedScalarFunction(loader, 
-        ScalarFunction(
-            "volume",
-            {stbox()},
-            LogicalType::DOUBLE,
-            StboxFunctions::Stbox_volume
-        )
-    );
+    // volume is generated from the catalog (box unary scalar accessor).
 
     duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(
@@ -359,14 +322,7 @@ void StboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    duckdb::RegisterSerializedScalarFunction(loader, 
-        ScalarFunction(
-            "getSpace",
-            {stbox()},
-            stbox(),
-            StboxFunctions::Stbox_get_space
-        )
-    );
+    // getSpace is generated from the catalog (box unary accessor -> stbox).
 
     duckdb::RegisterSerializedScalarFunction(loader, 
         ScalarFunction(

--- a/src/temporal/tbox.cpp
+++ b/src/temporal/tbox.cpp
@@ -338,25 +338,9 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
         )
     );
 
-    duckdb::RegisterSerializedScalarFunction(loader, 
-        ScalarFunction(
-            "hasX",
-            {tbox()},
-            LogicalType::BOOLEAN,
-            TboxFunctions::Tbox_hasx
-        )
-    );
+    // hasX/hasT are generated from the catalog (box unary scalar accessors).
 
-    duckdb::RegisterSerializedScalarFunction(loader, 
-        ScalarFunction(
-            "hasT",
-            {tbox()},
-            LogicalType::BOOLEAN,
-            TboxFunctions::Tbox_hast
-        )
-    );
-
-    duckdb::RegisterSerializedScalarFunction(loader, 
+    duckdb::RegisterSerializedScalarFunction(loader,
         ScalarFunction(
             "Xmin",
             {tbox()},
@@ -956,12 +940,9 @@ void TboxType::RegisterScalarFunctions(ExtensionLoader &loader) {
     duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
         "tboxFromHexWKB", {LogicalType::VARCHAR}, tbox(),
         TboxFunctions::Tbox_from_hexwkb));
-    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
-        "tbox_hash", {tbox()}, LogicalType::INTEGER,
-        TboxFunctions::Tbox_hash));
-    duckdb::RegisterSerializedScalarFunction(loader, ScalarFunction(
-        "tbox_hash_extended", {tbox(), LogicalType::BIGINT}, LogicalType::BIGINT,
-        TboxFunctions::Tbox_hash_extended));
+    // tbox_hash / tbox_hash_extended are generated from the catalog (box unary
+    // scalar accessors); the generated surface uses the faithful native-unsigned
+    // UINTEGER / UBIGINT return, matching temporal/span/set hash generation.
 }
 
 } // namespace duckdb

--- a/test/sql/parity/051_stbox_scalar_accessors.test
+++ b/test/sql/parity/051_stbox_scalar_accessors.test
@@ -1,0 +1,77 @@
+# name: test/sql/parity/051_stbox_scalar_accessors.test
+# description: Generated box scalar accessors — SRID/volume/hash/cmp/nad + hex hash.
+# group: [sql]
+
+require mobilityduck
+
+# SRID reads the box spatial reference
+
+query I
+SELECT SRID(stbox 'SRID=5676;STBOX X((1.0,2.0),(3.0,4.0))');
+----
+5676
+
+# volume is the product of the X/Y/Z extents of a 3D box
+
+query I
+SELECT volume(stbox 'STBOX Z((1.0,2.0,3.0),(4.0,5.0,6.0))');
+----
+27.0
+
+# stbox_hash is deterministic; distinct boxes hash differently
+
+query I
+SELECT stbox_hash(stbox 'STBOX X((1,2),(3,4))')
+     = stbox_hash(stbox 'STBOX X((1,2),(3,4))');
+----
+true
+
+query I
+SELECT stbox_hash(stbox 'STBOX X((1,2),(3,4))')
+    <> stbox_hash(stbox 'STBOX X((5,6),(7,8))');
+----
+true
+
+# stbox_hash_extended changes with the seed
+
+query I
+SELECT stbox_hash_extended(stbox 'STBOX X((1,2),(3,4))', 1)
+    <> stbox_hash_extended(stbox 'STBOX X((1,2),(3,4))', 2);
+----
+true
+
+# cmp orders boxes: 0 when equal, non-zero otherwise (tbox + stbox)
+
+query I
+SELECT cmp(stbox 'STBOX X((1,2),(3,4))', stbox 'STBOX X((1,2),(3,4))');
+----
+0
+
+query I
+SELECT cmp(stbox 'STBOX X((1,2),(3,4))', stbox 'STBOX X((1,2),(3,4))') = 0
+   AND cmp(stbox 'STBOX X((1,2),(3,4))', stbox 'STBOX X((2,2),(3,4))') <> 0;
+----
+true
+
+query I
+SELECT cmp(tbox 'TBOXFLOAT XT([1,2],[2000-01-01,2000-01-02])',
+           tbox 'TBOXFLOAT XT([1,2],[2000-01-01,2000-01-02])');
+----
+0
+
+# nearestApproachDistance between two stboxes (spatial gap of 3 units, |=| operator too)
+
+query I
+SELECT nearestApproachDistance(stbox 'STBOX X((0,0),(1,1))', stbox 'STBOX X((4,0),(5,1))');
+----
+3.0
+
+query I
+SELECT stbox 'STBOX X((0,0),(1,1))' |=| stbox 'STBOX X((4,0),(5,1))';
+----
+3.0
+
+query I
+SELECT nearestApproachDistance(stbox 'STBOX X((0,0),(2,2))', stbox 'STBOX X((1,1),(3,3))');
+----
+0.0

--- a/test/sql/temporal_hash.test
+++ b/test/sql/temporal_hash.test
@@ -1,0 +1,43 @@
+# name: test/sql/temporal_hash.test
+# description: Generated hash surface for the temporal types — temporal_hash (uint32)
+#             and temporal_hash_extended (uint64 + seed). Both use DuckDB's native
+#             unsigned types (UINTEGER / UBIGINT): a MEOS hash fills the full unsigned
+#             range, so a signed INTEGER/BIGINT would be out of range (DuckDB range-
+#             checks the cast, unlike PostgreSQL/C which bit-reinterpret).
+
+require mobilityduck
+
+# temporal_hash returns the uint32 hash as the native UINTEGER
+query I
+SELECT temporal_hash(tint '1@2000-01-01');
+----
+157457912
+
+query I
+SELECT typeof(temporal_hash(tint '1@2000-01-01'));
+----
+UINTEGER
+
+# temporal_hash_extended returns the uint64 hash as the native UBIGINT. This value
+# (> 2**63) does NOT fit in a signed BIGINT — proof that UBIGINT is required.
+query I
+SELECT temporal_hash_extended(tint '1@2000-01-01', 0);
+----
+11445401048662056440
+
+query I
+SELECT typeof(temporal_hash_extended(tint '1@2000-01-01', 0));
+----
+UBIGINT
+
+# the seed changes the hash (0 vs 42)
+query I
+SELECT temporal_hash_extended(tint '1@2000-01-01', 42);
+----
+10824501823241357556
+
+# inherited over every temporal family via Temporal<T>
+query I
+SELECT temporal_hash_extended(tfloat '1.5@2000-01-01', 42);
+----
+17681145013286498633

--- a/test/sql/temporal_hash.test
+++ b/test/sql/temporal_hash.test
@@ -1,9 +1,10 @@
 # name: test/sql/temporal_hash.test
-# description: Generated hash surface for the temporal types — temporal_hash (uint32)
-#             and temporal_hash_extended (uint64 + seed). Both use DuckDB's native
-#             unsigned types (UINTEGER / UBIGINT): a MEOS hash fills the full unsigned
-#             range, so a signed INTEGER/BIGINT would be out of range (DuckDB range-
-#             checks the cast, unlike PostgreSQL/C which bit-reinterpret).
+# description: Generated hash surface — temporal_hash (uint32) / temporal_hash_extended
+#             (uint64 + seed) for the temporal types, plus the value-type extended hashes
+#             (span / spanset / set). All use DuckDB's native unsigned types (UINTEGER /
+#             UBIGINT): a MEOS hash fills the full unsigned range, so a signed INTEGER/BIGINT
+#             would be out of range (DuckDB range-checks the cast, unlike PostgreSQL/C which
+#             bit-reinterpret).
 
 require mobilityduck
 
@@ -41,3 +42,33 @@ query I
 SELECT temporal_hash_extended(tfloat '1.5@2000-01-01', 42);
 ----
 17681145013286498633
+
+# ---------------------------------------------------------------------------
+# Value-type extended hashes — span / spanset / set (span & set share the bare
+# `hash_extended` SQL name; spanset uses `spanset_hash_extended`). All UBIGINT.
+# ---------------------------------------------------------------------------
+
+query I
+SELECT hash_extended(intspan '[1,5)', 42);
+----
+17081792371660567560
+
+query I
+SELECT typeof(hash_extended(intspan '[1,5)', 42));
+----
+UBIGINT
+
+query I
+SELECT hash_extended(intset '{1,2,3}', 42);
+----
+8820475475926064787
+
+query I
+SELECT hash_extended(floatset '{1.5,2.5}', 0);
+----
+8197047930258302178
+
+query I
+SELECT spanset_hash_extended(intspanset '{[1,5)}', 42);
+----
+17081792371660567591

--- a/tools/codegen_duck_udfs.py
+++ b/tools/codegen_duck_udfs.py
@@ -1935,9 +1935,11 @@ def shape_span(f, C=SPAN_C):
     rb = base(f["returnType"]["canonical"]); rn = norm(f["returnType"]["canonical"])
     contp = lambda p: base(p["canonical"]) == cb and norm(p["canonical"]).endswith("*")
     sel = lambda p: base(p["canonical"]) if (base(p["canonical"]) in C["elem"] and "*" not in norm(p["canonical"])) else None
-    # unary (X)->X | scalar  (lower/upper/width, ceil/floor; name-scoped; boxes have no scope)
+    # unary (X)->X | scalar  (lower/upper/width, ceil/floor; name-scoped for spans;
+    # boxes have no scope -> the single concrete accessor emits every box unary
+    # (hasX/hasZ/hasT/isGeodetic, hash, SRID, volume, getSpace, ...)).
     if len(ins) == 1 and contp(ins[0]):
-        if C["scope"] is None or C["scope"](f["name"]) is None: return None
+        if C["scope"] is not None and C["scope"](f["name"]) is None: return None
         if rb == cb and rn.endswith("*"):           return ("u_span", "LogicalType::BLOB")
         if rb in BYVAL_RET and "*" not in rn:       return ("u_scalar:" + rb, byval_ret_duck(rb))
         if rb == "Interval" and rn.endswith("*"):   return ("u_scalar:Interval", "LogicalType::INTERVAL")
@@ -1964,7 +1966,7 @@ def shape_span(f, C=SPAN_C):
     # return with a SCALAR_ARG 2nd operand; name-scoped like the other span scalars.
     if (contp(ins[0]) and base(ins[1]["canonical"]) in SCALAR_ARG
             and "*" not in norm(ins[1]["canonical"]) and rb in BYVAL_RET and "*" not in rn
-            and C["scope"] is not None and C["scope"](f["name"]) is not None):
+            and (C["scope"] is None or C["scope"](f["name"]) is not None)):
         return ("bsc:" + base(ins[1]["canonical"]) + ":" + rb, byval_ret_duck(rb))
     # mixed container (Span, SpanSet) / (SpanSet, Span) -> bool : the span<->spanset
     # positional operators (left/right/overleft/overright span_spanset|spanset_span).
@@ -1981,6 +1983,19 @@ def shape_span(f, C=SPAN_C):
     if not (contp(ins[0]) and contp(ins[1])): return None
     if rb == cb and rn.endswith("*"):  return ("b_span", "type")
     if rb == "bool" and "*" not in rn:     return ("b_bool", "LogicalType::BOOLEAN")
+    # (Box,Box) -> by-value scalar : box comparison / metric accessors
+    # (tbox_cmp/stbox_cmp -> int, nad_stbox_stbox -> float). Boxes only (single
+    # concrete accessor, no AllTypes loop); spans/sets keep their scoped scalar
+    # paths above so span_cmp/set_cmp remain a separate follow-up.
+    if C.get("single") and rb in BYVAL_RET and "*" not in rn:
+        # Skip a base-type-collapsed family: several public C functions share one SQL
+        # (sqlfn, box-pair) surface because the generic implementation is meos_internal
+        # (e.g. nad_tboxfloat_tboxfloat / nad_tboxint_tboxint both back
+        # nearestApproachDistance(tbox,tbox), each asserting its own span basetype and
+        # erroring on the other, while the faithful generic nad_tbox_tbox is internal).
+        # No single public overload is complete -> leave the surface to a MEOS export fix.
+        if f["name"] in STATE.get("box_scalar_collapsed", ()): return None
+        return ("b_scalar:" + rb, byval_ret_duck(rb))
     return None
 
 def emit_span(f, kind, C=SPAN_C):
@@ -2055,6 +2070,15 @@ def emit_span(f, kind, C=SPAN_C):
                 f"            {cb} *s = {bt}(in);\n            {cb} *r = {name}(s, {marsh});\n            free(s);\n"
                 f"            if (!r) {{ mask.SetInvalid(idx); return string_t(); }}\n"
                 f"            return {tb}(result, r);\n        }});\n}}\n")
+    if kind.startswith("b_scalar:"):  # (X,X) -> by-value scalar (box cmp -> int, nad -> double)
+        cct, rett, rexpr = byval_ret3(kind.split(':')[1])
+        return (f"static void Gen_{name}(DataChunk &args, ExpressionState &, Vector &result) {{\n"
+                f"    EnsureMeosThreadInitialized();\n"
+                f"    BinaryExecutor::Execute<string_t, string_t, {rett}>(args.data[0], args.data[1], result, args.size(),\n"
+                f"        [&](string_t a, string_t b) {{\n"
+                f"            {cb} *s1 = {bt}(a);\n            {cb} *s2 = {bt}(b);\n"
+                f"            {cct} r = {name}(s1, s2);\n            free(s1); free(s2);\n"
+                f"            return {rexpr};\n        }});\n}}\n")
     if kind == "b_span":            # (X,X) -> X (pointer return; MEOS NULL = empty -> SQL NULL)
         return (f"static void Gen_{name}(DataChunk &args, ExpressionState &, Vector &result) {{\n"
                 f"    EnsureMeosThreadInitialized();\n"
@@ -2488,6 +2512,31 @@ def gen_cpp(fns, out_path, declared=None, aliases=None):
     spanset_generic_regs = GReg(); box_regs = GReg()
     temporal_box_bodies, temporal_box_regs = GReg(), GReg()
     n_un = n_bin = n_ter = n_set = n_span = 0
+    # Detect base-type-collapsed box (Box,Box)->scalar families: >1 public C function
+    # sharing one (sqlfn, box-pair) SQL surface (the faithful generic impl is internal).
+    # Their (Box,Box)->scalar shape is skipped (see shape_span); log so the coverage gap
+    # is explicit rather than silent.
+    _box_pair_scalar = {}
+    for _f in fns:
+        if supported(_f) is not None:
+            continue
+        _ins, _out = classify(_f)
+        if _out is not None or len(_ins) != 2:
+            continue
+        _b0, _b1 = base(_ins[0]["canonical"]), base(_ins[1]["canonical"])
+        if _b0 != _b1 or _b0 not in ("TBox", "STBox"):
+            continue
+        if not (norm(_ins[0]["canonical"]).endswith("*") and norm(_ins[1]["canonical"]).endswith("*")):
+            continue
+        _rb = base(_f["returnType"]["canonical"])
+        if _rb not in BYVAL_RET or "*" in norm(_f["returnType"]["canonical"]):
+            continue
+        _box_pair_scalar.setdefault((_f.get("sqlfn"), _b0), []).append(_f["name"])
+    STATE["box_scalar_collapsed"] = {n for g in _box_pair_scalar.values() if len(g) > 1 for n in g}
+    if STATE["box_scalar_collapsed"]:
+        print("box scalar collapse: skipped %d base-type-collapsed (Box,Box)->scalar fn(s) "
+              "(internal generic backing): %s" % (len(STATE["box_scalar_collapsed"]),
+              ", ".join(sorted(STATE["box_scalar_collapsed"]))))
     for f in fns:
         if declared is not None and f["name"] not in declared:
             continue            # pin/ABI gate: skip catalog fns absent from the build headers
@@ -2866,6 +2915,12 @@ def gen_cpp(fns, out_path, declared=None, aliases=None):
                 continue
             # unary (X)->X|scalar: name-scoped (X_*→AllTypes, <elem>X_*→accessor).
             if kind == "u_span" or kind.startswith("u_scalar:"):
+                if C.get("single"):   # box: single concrete accessor, no scope loop
+                    acc = C["single"]; rett = acc if kind == "u_span" else dret
+                    for nm in names:
+                        box_regs.append(f'    RegisterSerializedScalarFunction(loader, ScalarFunction('
+                                        f'"{reg_name(nm, f)}", {{{acc}}}, {rett}, Gen_{fn}));')
+                    continue
                 scope, accs = C["scope"](fn)
                 if scope == "all":
                     rett = C["ret"](fn, "type") if kind == "u_span" else dret
@@ -2915,6 +2970,12 @@ def gen_cpp(fns, out_path, declared=None, aliases=None):
             # (X, by-value scalar)->scalar (seeded extended hash): name-scoped 2-arg {X, seed}.
             if kind.startswith("bsc:"):
                 argdt = SCALAR_ARG[kind.split(':')[1]][0]
+                if C.get("single"):   # box: single concrete accessor, 2-arg {box, seed/flag}
+                    acc = C["single"]
+                    for nm in names:
+                        box_regs.append(f'    RegisterSerializedScalarFunction(loader, ScalarFunction('
+                                        f'"{reg_name(nm, f)}", {{{acc}, {argdt}}}, {dret}, Gen_{fn}));')
+                    continue
                 scope, accs = C["scope"](fn)
                 acc_list = ["type"] if scope == "all" else accs
                 sink = gen if scope == "all" else span_specific_regs

--- a/tools/codegen_duck_udfs.py
+++ b/tools/codegen_duck_udfs.py
@@ -84,8 +84,11 @@ SCALAR = {
     "int":          ("LogicalType::INTEGER",  "int32_t"),
     "int32":        ("LogicalType::INTEGER",  "int32_t"),
     "int32_t":      ("LogicalType::INTEGER",  "int32_t"),
-    # uint32 (the PG hash width) registers as the unsigned UINTEGER — see the
-    # SCALAR_RET_CPP note below. The uint64 cell ids keep the CELL_UINT path.
+    # Unsigned ints use DuckDB's NATIVE unsigned types (UINTEGER/UBIGINT) — the
+    # faithful representation, see the SCALAR_RET_CPP note below. The 14l catalog
+    # renders the uint32 canonical as "unsigned int"; uint64 stays "uint64_t".
+    # (uint64 cell ids keep the CELL_UINT path, checked before scalar in ret_type.)
+    "unsigned int": ("LogicalType::UINTEGER", "uint32_t"),
     "uint32":       ("LogicalType::UINTEGER", "uint32_t"),
     "uint32_t":     ("LogicalType::UINTEGER", "uint32_t"),
     "int64":        ("LogicalType::BIGINT",   "int64_t"),
@@ -255,13 +258,17 @@ def family(f):
 SCALAR_RET_CPP = {"int": ("int32_t", "LogicalType::INTEGER"),
                   "int32_t": ("int32_t", "LogicalType::INTEGER"),
                   "int64_t": ("int64_t", "LogicalType::BIGINT"),
-                  # The MEOS *_hash functions return uint32 (PG hash width) and
-                  # must register as UINTEGER, not a signed INTEGER that flips
-                  # the sign of hashes >= 2**31. (uint64 returns — hash seeds and
-                  # the H3Index/Quadbin cell ids — are handled elsewhere: cell
-                  # ids via the CELL_UINT path; the *_hash_extended seed width is
-                  # left to a follow-up so it does not surface here yet.)
-                  "uint32_t": ("uint32_t", "LogicalType::UINTEGER"),
+                  # The MEOS *_hash functions return uint32. DuckDB has a NATIVE unsigned
+                  # type (UINTEGER) that holds the full uint32 range, so the faithful
+                  # representation is UINTEGER — NOT a signed INTEGER (a hash >= 2**31 is out
+                  # of range for INT32 and DuckDB RANGE-CHECKS the cast, it does NOT
+                  # bit-reinterpret the way PG/C does). PG only *declares* integer because it
+                  # lacks unsigned SQL types; DuckDB does not have that limit. The 14l catalog
+                  # renders the uint32 canonical as "unsigned int" (was "uint32_t" before the
+                  # meos-api update — both keyed here). (uint64 *_hash_extended returns UBIGINT
+                  # analogously but needs a (Temporal, seed)->scalar shape — a follow-up.)
+                  "unsigned int": ("uint32_t", "LogicalType::UINTEGER"),
+                  "uint32_t":     ("uint32_t", "LogicalType::UINTEGER"),
                   "double": ("double", "LogicalType::DOUBLE"),
                   "bool": ("bool", "LogicalType::BOOLEAN")}
 # By-value scalar returns the TEMPORAL detectors accept: the identity-marshalled ones

--- a/tools/codegen_duck_udfs.py
+++ b/tools/codegen_duck_udfs.py
@@ -91,6 +91,7 @@ SCALAR = {
     "unsigned int": ("LogicalType::UINTEGER", "uint32_t"),
     "uint32":       ("LogicalType::UINTEGER", "uint32_t"),
     "uint32_t":     ("LogicalType::UINTEGER", "uint32_t"),
+    "uint64_t":     ("LogicalType::UBIGINT",  "uint64_t"),
     "int64":        ("LogicalType::BIGINT",   "int64_t"),
     "int64_t":      ("LogicalType::BIGINT",   "int64_t"),
     "double":       ("LogicalType::DOUBLE",   "double"),
@@ -149,11 +150,12 @@ def ret_type(f, out_canon):
         return None
     rc = f["returnType"]["canonical"]; nc = norm(rc); b = base(rc)
     if b in PTR_RET and nc.endswith("*"):  return (PTR_RET[b][0], "ptr")
+    if b in CELL_UINT and "*" not in nc:   # Tcell<T> cell-id base value (startValue/endValue);
+        sc = reg_scope(f["name"])          # checked BEFORE the generic scalar path so a uint64 cell
+        if sc and sc[0] == "types" and len(sc[1]) == 1 and sc[1][0] in CELL_BASEVAL:  # id keeps its
+            return (CELL_BASEVAL[sc[1][0]], "scalar")   # cell type; a non-cell uint64 (hash_extended)
+        # falls through to the scalar path below (UBIGINT).
     if b in SCALAR and "*" not in nc:      return (SCALAR[b][0], "scalar")
-    if b in CELL_UINT and "*" not in nc:   # Tcell<T> cell-id base value (startValue/endValue)
-        sc = reg_scope(f["name"])
-        if sc and sc[0] == "types" and len(sc[1]) == 1 and sc[1][0] in CELL_BASEVAL:
-            return (CELL_BASEVAL[sc[1][0]], "scalar")
     if b == "GSERIALIZED" and nc.endswith("*"):  # owned geometry -> DuckDB GEOMETRY (geo marshaller)
         return ("GeoTypes::GEOMETRY()", "geo")
     if b == "Interval" and nc.endswith("*"):  # owned ptr -> by-value interval_t (TakeInterval)
@@ -265,10 +267,12 @@ SCALAR_RET_CPP = {"int": ("int32_t", "LogicalType::INTEGER"),
                   # bit-reinterpret the way PG/C does). PG only *declares* integer because it
                   # lacks unsigned SQL types; DuckDB does not have that limit. The 14l catalog
                   # renders the uint32 canonical as "unsigned int" (was "uint32_t" before the
-                  # meos-api update — both keyed here). (uint64 *_hash_extended returns UBIGINT
-                  # analogously but needs a (Temporal, seed)->scalar shape — a follow-up.)
+                  # meos-api update — both keyed here). uint64 *_hash_extended returns UBIGINT
+                  # analogously (native unsigned, holds the full uint64 hash; the seed arg is
+                  # UBIGINT too — see SCALAR_ARG).
                   "unsigned int": ("uint32_t", "LogicalType::UINTEGER"),
                   "uint32_t":     ("uint32_t", "LogicalType::UINTEGER"),
+                  "uint64_t":     ("uint64_t", "LogicalType::UBIGINT"),
                   "double": ("double", "LogicalType::DOUBLE"),
                   "bool": ("bool", "LogicalType::BOOLEAN")}
 # By-value scalar returns the TEMPORAL detectors accept: the identity-marshalled ones
@@ -800,14 +804,16 @@ def shape_emittable(f):
     # Take only the owned (non-const) return so the body's free(t)+TemporalToBlob stays correct.
     if rb in TEMPORAL_PTR_RET and rn.endswith("*") and "const" not in f["returnType"]["canonical"]:
         return ("temporal", "MD_TEMPORAL")   # ret type resolved per-accessor via ret_temporal_type
-    if rb in BYVAL_RET and "*" not in rn:
-        return ("scalar:" + rb, scalar_ret_duck(f))
     # Tcell<T> cell-id base value: a per-type cell accessor (reg_scope keys the single cell
-    # temporal type) returns the collapsed uint64 cell id -> the family's BIGINT-backed cell
-    # DuckDB type (startValue/endValue on th3index -> h3index()). See CELL_BASEVAL.
+    # temporal type) returns the collapsed uint64 cell id -> the family's cell DuckDB type
+    # (startValue/endValue on th3index -> h3index()). Checked BEFORE the generic by-value
+    # scalar branch so a uint64 cell id keeps its cell type (BYVAL_RET now includes uint64
+    # for *_hash_extended). See CELL_BASEVAL.
     if rb in CELL_UINT and "*" not in rn and sc[0] == "types" and len(sc[1]) == 1 \
             and sc[1][0] in CELL_BASEVAL:
         return ("cellscalar", CELL_BASEVAL[sc[1][0]])
+    if rb in BYVAL_RET and "*" not in rn:
+        return ("scalar:" + rb, scalar_ret_duck(f))
     if rb in ("Interval", "text", "char") and rn.endswith("*"):   # owned-pointer scalar return (duration / text / cstring)
         return ("scalar:" + rb, scalar_ret_duck(f))
     # base-value pointer return (Temporal<T> accessor: startValue/endValue -> the family base value,
@@ -898,6 +904,7 @@ SCALAR_ARG = {
     "int":         ("LogicalType::INTEGER", "int32_t", "a2"),
     "int32_t":     ("LogicalType::INTEGER", "int32_t", "a2"),
     "int64_t":     ("LogicalType::BIGINT",  "int64_t", "a2"),
+    "uint64_t":    ("LogicalType::UBIGINT", "uint64_t", "a2"),  # *_hash_extended seed (native unsigned)
     "double":      ("LogicalType::DOUBLE",  "double",  "a2"),
     "bool":        ("LogicalType::BOOLEAN", "bool",    "a2"),
     "TimestampTz": ("LogicalType::TIMESTAMP_TZ", "timestamp_tz_t", "DuckDBToMeosTimestamp(a2).value"),

--- a/tools/codegen_duck_udfs.py
+++ b/tools/codegen_duck_udfs.py
@@ -667,6 +667,11 @@ def shape_set(f):
             and "*" not in norm(ins[1]["canonical"]) and set_reg_scope(f["name"])):
         return ("setcsc:" + base(ins[1]["canonical"]), "LogicalType::BLOB")
     if set_reg_scope(f["name"]) is None: return None
+    # (Set, by-value scalar) -> by-value scalar : the seeded extended hash
+    # set_hash_extended(set, uint64 seed) -> uint64. Mirrors the unary u_scalar.
+    if (len(ins) == 2 and setp(ins[0]) and base(ins[1]["canonical"]) in SCALAR_ARG
+            and "*" not in norm(ins[1]["canonical"]) and rb in BYVAL_RET and "*" not in rn):
+        return ("bsc:" + base(ins[1]["canonical"]) + ":" + rb, byval_ret_duck(rb))
     if len(ins) == 1 and setp(ins[0]):
         if rb == "Set" and rn.endswith("*"):       return ("u_set", "LogicalType::BLOB")
         if rb in BYVAL_RET and "*" not in rn: return ("u_scalar:" + rb, byval_ret_duck(rb))
@@ -749,6 +754,16 @@ def emit_set(f, kind):
                 f"    UnaryExecutor::Execute<string_t, {rett}>(args.data[0], result, args.size(),\n"
                 f"        [&](string_t in) {{\n"
                 f"            Set *s = BlobToSet(in);\n            {cct} r = {name}(s);\n            free(s);\n"
+                f"            return {rexpr};\n        }});\n}}\n")
+    if kind.startswith("bsc:"):     # (Set, by-value scalar) -> by-value scalar (seeded extended hash)
+        _bsc, ab, rb2 = kind.split(':')
+        _dt, cpp2, marsh = SCALAR_ARG[ab]
+        cct, rett, rexpr = byval_ret3(rb2)
+        return (f"static void Gen_{name}(DataChunk &args, ExpressionState &, Vector &result) {{\n"
+                f"    EnsureMeosThreadInitialized();\n"
+                f"    BinaryExecutor::Execute<string_t, {cpp2}, {rett}>(args.data[0], args.data[1], result, args.size(),\n"
+                f"        [&](string_t in, {cpp2} a2) {{\n"
+                f"            Set *s = BlobToSet(in);\n            {cct} r = {name}(s, {marsh});\n            free(s);\n"
                 f"            return {rexpr};\n        }});\n}}\n")
     if kind == "b_set":             # (Set,Set) -> Set (pointer return; MEOS NULL -> SQL NULL)
         return (f"static void Gen_{name}(DataChunk &args, ExpressionState &, Vector &result) {{\n"
@@ -1944,6 +1959,13 @@ def shape_span(f, C=SPAN_C):
             and "*" not in norm(ins[1]["canonical"]) and rb == cb and rn.endswith("*")
             and C["scope"] is not None and C["scope"](f["name"]) is not None):
         return ("csc:" + base(ins[1]["canonical"]), "type")
+    # (X, by-value scalar) -> by-value scalar : the seeded extended hash,
+    # <cbase>_hash_extended(x, uint64 seed) -> uint64. Mirrors the unary u_scalar
+    # return with a SCALAR_ARG 2nd operand; name-scoped like the other span scalars.
+    if (contp(ins[0]) and base(ins[1]["canonical"]) in SCALAR_ARG
+            and "*" not in norm(ins[1]["canonical"]) and rb in BYVAL_RET and "*" not in rn
+            and C["scope"] is not None and C["scope"](f["name"]) is not None):
+        return ("bsc:" + base(ins[1]["canonical"]) + ":" + rb, byval_ret_duck(rb))
     # mixed container (Span, SpanSet) / (SpanSet, Span) -> bool : the span<->spanset
     # positional operators (left/right/overleft/overright span_spanset|spanset_span).
     # A 1-D span and its spanset order on the same axis, but the two operands are
@@ -2005,6 +2027,16 @@ def emit_span(f, kind, C=SPAN_C):
                 f"    UnaryExecutor::Execute<string_t, {rett}>(args.data[0], result, args.size(),\n"
                 f"        [&](string_t in) {{\n"
                 f"            {cb} *s = {bt}(in);\n            {cct} r = {name}(s);\n            free(s);\n"
+                f"            return {rexpr};\n        }});\n}}\n")
+    if kind.startswith("bsc:"):     # (X, by-value scalar) -> by-value scalar (seeded extended hash)
+        _bsc, ab, rb2 = kind.split(':')
+        _dt, cpp2, marsh = SCALAR_ARG[ab]
+        cct, rett, rexpr = byval_ret3(rb2)
+        return (f"static void Gen_{name}(DataChunk &args, ExpressionState &, Vector &result) {{\n"
+                f"    EnsureMeosThreadInitialized();\n"
+                f"    BinaryExecutor::Execute<string_t, {cpp2}, {rett}>(args.data[0], args.data[1], result, args.size(),\n"
+                f"        [&](string_t in, {cpp2} a2) {{\n"
+                f"            {cb} *s = {bt}(in);\n            {cct} r = {name}(s, {marsh});\n            free(s);\n"
                 f"            return {rexpr};\n        }});\n}}\n")
     if kind.startswith("u2iv:"):    # (X, by-value scalar) -> owned Interval (duration(spanset,bool))
         _dt, cpp2, marsh = SCALAR_ARG[kind.split(':')[1]]
@@ -2765,6 +2797,16 @@ def gen_cpp(fns, out_path, declared=None, aliases=None):
                 set_specific_regs.append(f'    RegisterSerializedScalarFunction(loader, ScalarFunction('
                                          f'"{reg_name(nm, f)}", {sig}, LogicalType::BOOLEAN, Gen_{fn}));')
             continue
+        if kind.startswith("bsc:"):   # (Set, by-value scalar)->scalar (seeded extended hash): {set, seed}
+            scd = SCALAR_ARG[kind.split(':')[1]][0]
+            scope, accs = set_reg_scope(fn)
+            acc_list = ["type"] if scope == "all" else accs
+            sink = set_generic_regs if scope == "all" else set_specific_regs
+            for a in acc_list:
+                for nm in names:
+                    sink.append(f'        RegisterSerializedScalarFunction(loader, ScalarFunction('
+                                f'"{reg_name(nm, f)}", {{{a}, {scd}}}, {dret}, Gen_{fn}));')
+            continue
         sc = set_reg_scope(fn)
         scope, accs = sc if sc else ("all", None)   # b_set/b_bool (<op>_set_set) -> over AllTypes
         nargs = len(classify(f)[0])
@@ -2869,6 +2911,17 @@ def gen_cpp(fns, out_path, declared=None, aliases=None):
                         if dflt is not None:
                             sink.append(f'        RegisterSerializedScalarFunction(loader, ScalarFunction('
                                         f'"{reg_name(nm, f)}", {{{a}}}, {a}, Gen_{fn}_d));')
+                continue
+            # (X, by-value scalar)->scalar (seeded extended hash): name-scoped 2-arg {X, seed}.
+            if kind.startswith("bsc:"):
+                argdt = SCALAR_ARG[kind.split(':')[1]][0]
+                scope, accs = C["scope"](fn)
+                acc_list = ["type"] if scope == "all" else accs
+                sink = gen if scope == "all" else span_specific_regs
+                for a in acc_list:
+                    for nm in names:
+                        sink.append(f'        RegisterSerializedScalarFunction(loader, ScalarFunction('
+                                    f'"{reg_name(nm, f)}", {{{a}, {argdt}}}, {dret}, Gen_{fn}));')
                 continue
             # generic (X,X)->bool|X.
             if C.get("single"):   # box: single type, concrete accessor (no AllTypes loop)


### PR DESCRIPTION
Generates the TBox/STBox scalar accessors from the MEOS catalog instead of
hand-registering them, extending the generator's box coverage from operators
and box-returning ops to the scalar-return surface.

## Generator

The single-typed box descriptors (`scope=None`, one concrete accessor) now
reach the unary and binary scalar-return paths:

- the unary and `bsc` shape gates are relaxed so a scope-less box passes;
- a new `(Box,Box)->scalar` case (gated on the box `single` marker) emits the
  box comparison and metric accessors;
- box registration arms register over the single concrete accessor instead of
  the span name-scope loop.

## Emitted surface

`hasX` / `hasZ` / `hasT` / `isGeodetic`, `SRID`, `volume`, `getSpace`,
`area` / `perimeter` (explicit spheroid form), `stbox_hash` / `tbox_hash`
(native-unsigned `UINTEGER`), `stbox_hash_extended` / `tbox_hash_extended`
(`UBIGINT`), `cmp`, and `nearestApproachDistance` / `|=|` for stbox.

## Generate-then-retire

Removes the hand registrations the generated surface now covers identically:
`hasX`/`hasZ`/`hasT`/`isGeodetic`/`volume`/`getSpace` on stbox and
`hasX`/`hasT`/`tbox_hash`/`tbox_hash_extended` on tbox. The generated tbox
hash uses the faithful native-unsigned return, matching the temporal/span/set
hashes. `area`/`perimeter` (1-arg defaulted form) and `stbox_cmp`/`tbox_cmp`
stay as-is — the generated surface adds the explicit 2-arg and the canonical
bare `cmp` alongside them, so no SQL surface is removed.

## Known gap

`nearestApproachDistance(tbox, tbox)` is intentionally not emitted: the only
public backings each assert a single span basetype and error on the other,
while the generic implementation is internal, so no single public overload is
faithful. The generator detects this base-type collapse and logs the skipped
surface rather than emitting a lossy or type-restricted binding; closing it
belongs at the source (exporting the generic).

## Tests

Adds `test/sql/parity/051_stbox_scalar_accessors.test` covering SRID, volume,
hash, hash_extended, cmp, nearestApproachDistance, and `|=|`. The committed
`src/generated` file is the generator's output for the current catalog.